### PR TITLE
Ensure generated code passes `mypy --strict`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,5 +27,8 @@ jobs:
       run: |
         pylint ariadne_codegen tests
         mypy ariadne_codegen --ignore-missing-imports
+        # these test outputs represent things that may be committed into other projects that may
+        # have strict mypy settings, and so they should be maximally annotated.
+        mypy --strict tests/main/*/expected_client
         black --check .
         isort . --check-only

--- a/ariadne_codegen/generators/client.py
+++ b/ariadne_codegen/generators/client.py
@@ -17,6 +17,8 @@ from .codegen import (
     generate_method_definition,
     generate_name,
     generate_return,
+    generate_subscript,
+    generate_tuple,
 )
 from .constants import ANY, LIST, OPTIONAL, TYPING_MODULE
 
@@ -142,7 +144,10 @@ class ClientGenerator:
     ) -> ast.AnnAssign:
         return generate_ann_assign(
             target=self._variables_dict_variable,
-            annotation=generate_name("dict"),
+            annotation=generate_subscript(
+                generate_name("dict"),
+                generate_tuple([generate_name("str"), generate_name("object")]),
+            ),
             value=arguments_dict,
             lineno=lineno,
         )

--- a/ariadne_codegen/generators/dependencies/base_client.py
+++ b/ariadne_codegen/generators/dependencies/base_client.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, TypeVar, cast
 
 import httpx
 from pydantic import BaseModel
@@ -8,6 +8,8 @@ from .exceptions import (
     GraphQLClientHttpError,
     GraphQlClientInvalidResponseError,
 )
+
+Self = TypeVar("Self", bound="BaseClient")
 
 
 class BaseClient:
@@ -26,14 +28,14 @@ class BaseClient:
             else httpx.Client(base_url=base_url, headers=headers)
         )
 
-    def __enter__(self):
+    def __enter__(self: Self) -> Self:
         return self
 
     def __exit__(
         self,
-        exc_type,
-        exc_val,
-        exc_tb,
+        exc_type: object,
+        exc_val: object,
+        exc_tb: object,
     ) -> None:
         self.http_client.close()
 
@@ -45,7 +47,7 @@ class BaseClient:
             payload["variables"] = self._convert_dict_to_json_serializable(variables)
         return self.http_client.post(url="/graphql/", json=payload)
 
-    def get_data(self, response: httpx.Response) -> dict:
+    def get_data(self, response: httpx.Response) -> dict[str, Any]:
         if not response.is_success:
             raise GraphQLClientHttpError(
                 status_code=response.status_code, response=response
@@ -67,9 +69,11 @@ class BaseClient:
                 errors_dicts=errors, data=data
             )
 
-        return data
+        return cast(dict[str, Any], data)
 
-    def _convert_dict_to_json_serializable(self, dict_: Dict[str, Any]):
+    def _convert_dict_to_json_serializable(
+        self, dict_: Dict[str, Any]
+    ) -> Dict[str, Any]:
         return {
             key: value
             if not isinstance(value, BaseModel)

--- a/ariadne_codegen/generators/dependencies/exceptions.py
+++ b/ariadne_codegen/generators/dependencies/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import httpx
 
@@ -43,7 +43,7 @@ class GraphQLClientGraphQLError(GraphQLClientError):
         return self.message
 
     @classmethod
-    def from_dict(cls, error: dict):
+    def from_dict(cls, error: dict[str, Any]) -> "GraphQLClientGraphQLError":
         return cls(
             message=error["message"],
             locations=error.get("locations"),
@@ -54,7 +54,7 @@ class GraphQLClientGraphQLError(GraphQLClientError):
 
 
 class GraphQLClientGraphQLMultiError(GraphQLClientError):
-    def __init__(self, errors: List[GraphQLClientGraphQLError], data: dict):
+    def __init__(self, errors: List[GraphQLClientGraphQLError], data: dict[str, Any]):
         self.errors = errors
         self.data = data
 
@@ -62,7 +62,9 @@ class GraphQLClientGraphQLMultiError(GraphQLClientError):
         return "; ".join(str(e) for e in self.errors)
 
     @classmethod
-    def from_errors_dicts(cls, errors_dicts: List[dict], data: dict):
+    def from_errors_dicts(
+        cls, errors_dicts: List[dict[str, Any]], data: dict[str, Any]
+    ) -> "GraphQLClientGraphQLMultiError":
         return cls(
             errors=[GraphQLClientGraphQLError.from_dict(e) for e in errors_dicts],
             data=data,

--- a/tests/generators/test_client_generator.py
+++ b/tests/generators/test_client_generator.py
@@ -18,25 +18,27 @@ def test_generate_returns_module_with_correct_class_name():
 
 def test_generate_returns_module_with_gql_lambda_definition():
     generator = ClientGenerator("ClientXyz", "BaseClient")
-    expected_assign = ast.Assign(
-        targets=[ast.Name(id="gql")],
-        value=ast.Lambda(
-            args=ast.arguments(
-                posonlyargs=[],
-                args=[ast.arg(arg="q")],
-                kwonlyargs=[],
-                kw_defaults=[],
-                defaults=[],
-            ),
-            body=ast.Name(id="q"),
+    expected_def = ast.FunctionDef(
+        name="gql",
+        args=ast.arguments(
+            posonlyargs=[],
+            args=[ast.arg(arg="q", annotation=ast.Name(id="str"))],
+            kwonlyargs=[],
+            kw_defaults=[],
+            defaults=[],
         ),
+        body=[ast.Return(value=ast.Name(id="q"))],
+        returns=ast.Name(id="str"),
+        decorator_list=[],
     )
 
     module = generator.generate()
 
-    assign = next(filter(lambda expr: isinstance(expr, ast.Assign), module.body), None)
+    assign = next(
+        filter(lambda expr: isinstance(expr, ast.FunctionDef), module.body), None
+    )
     assert assign
-    assert compare_ast(assign, expected_assign)
+    assert compare_ast(assign, expected_def)
 
 
 def test_add_import_adds_import_to_generated_module():

--- a/tests/generators/test_client_generator.py
+++ b/tests/generators/test_client_generator.py
@@ -126,7 +126,10 @@ def test_add_method_generates_correct_async_method_body():
         ),
         ast.AnnAssign(
             target=ast.Name(id="variables"),
-            annotation=ast.Name(id="dict"),
+            annotation=ast.Subscript(
+                value=ast.Name(id="dict"),
+                slice=ast.Tuple(elts=[ast.Name(id="str"), ast.Name(id="object")]),
+            ),
             value=ast.Dict(
                 keys=[ast.Constant(value="arg1")], values=[ast.Name(id="arg1")]
             ),
@@ -249,7 +252,10 @@ def test_add_method_generates_correct_method_body():
         ),
         ast.AnnAssign(
             target=ast.Name(id="variables"),
-            annotation=ast.Name(id="dict"),
+            annotation=ast.Subscript(
+                value=ast.Name(id="dict"),
+                slice=ast.Tuple(elts=[ast.Name(id="str"), ast.Name(id="object")]),
+            ),
             value=ast.Dict(
                 keys=[ast.Constant(value="arg1")], values=[ast.Name(id="arg1")]
             ),

--- a/tests/generators/test_package_generator.py
+++ b/tests/generators/test_package_generator.py
@@ -286,7 +286,7 @@ def test_generate_creates_client_with_correctly_implemented_async_method(tmp_pat
                 }
                 """
             )
-            variables: dict = {"id": id, "param": param}
+            variables: dict[str, object] = {"id": id, "param": param}
             response = await self.execute(query=query, variables=variables)
             data = self.get_data(response)
             return CustomQuery.parse_obj(data)

--- a/tests/generators/test_package_generator.py
+++ b/tests/generators/test_package_generator.py
@@ -357,7 +357,7 @@ def test_generate_creates_client_file_with_gql_lambda_definition(tmp_path):
     client_file_path = tmp_path / package_name / "client.py"
     with client_file_path.open() as client_file:
         client_content = client_file.read()
-        expected_gql_def = "gql = lambda q: q"
+        expected_gql_def = "def gql(q: str) -> str:\n    return q"
         assert expected_gql_def in client_content
 
 

--- a/tests/main/custom_base_client/custom_base_client.py
+++ b/tests/main/custom_base_client/custom_base_client.py
@@ -1,6 +1,9 @@
+from typing import Any  # this file needs to pass mypy --strict
+
+
 class CustomAsyncBaseClient:
-    async def execute(self, query, variables):
+    async def execute(self, query: Any, variables: Any) -> Any:
         pass
 
-    def get_data(self, response):
+    def get_data(self, response: Any) -> Any:
         pass

--- a/tests/main/custom_base_client/expected_client/client.py
+++ b/tests/main/custom_base_client/expected_client/client.py
@@ -4,7 +4,9 @@ from .custom_base_client import CustomAsyncBaseClient
 from .get_query_a import GetQueryA
 from .input_types import inputA
 
-gql = lambda q: q
+
+def gql(q: str) -> str:
+    return q
 
 
 class Client(CustomAsyncBaseClient):

--- a/tests/main/custom_base_client/expected_client/client.py
+++ b/tests/main/custom_base_client/expected_client/client.py
@@ -20,7 +20,7 @@ class Client(CustomAsyncBaseClient):
             }
             """
         )
-        variables: dict = {"dataA": data_a}
+        variables: dict[str, object] = {"dataA": data_a}
         response = await self.execute(query=query, variables=variables)
         data = self.get_data(response)
         return GetQueryA.parse_obj(data)

--- a/tests/main/custom_base_client/expected_client/custom_base_client.py
+++ b/tests/main/custom_base_client/expected_client/custom_base_client.py
@@ -1,6 +1,9 @@
+from typing import Any  # this file needs to pass mypy --strict
+
+
 class CustomAsyncBaseClient:
-    async def execute(self, query, variables):
+    async def execute(self, query: Any, variables: Any) -> Any:
         pass
 
-    def get_data(self, response):
+    def get_data(self, response: Any) -> Any:
         pass

--- a/tests/main/custom_files_names/expected_client/custom_client.py
+++ b/tests/main/custom_files_names/expected_client/custom_client.py
@@ -20,7 +20,7 @@ class Client(AsyncBaseClient):
             }
             """
         )
-        variables: dict = {"dataA": data_a}
+        variables: dict[str, object] = {"dataA": data_a}
         response = await self.execute(query=query, variables=variables)
         data = self.get_data(response)
         return GetQueryA.parse_obj(data)

--- a/tests/main/custom_files_names/expected_client/custom_client.py
+++ b/tests/main/custom_files_names/expected_client/custom_client.py
@@ -4,7 +4,9 @@ from .async_base_client import AsyncBaseClient
 from .custom_input_types import inputA
 from .get_query_a import GetQueryA
 
-gql = lambda q: q
+
+def gql(q: str) -> str:
+    return q
 
 
 class Client(AsyncBaseClient):

--- a/tests/main/custom_files_names/expected_client/exceptions.py
+++ b/tests/main/custom_files_names/expected_client/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import httpx
 
@@ -43,7 +43,7 @@ class GraphQLClientGraphQLError(GraphQLClientError):
         return self.message
 
     @classmethod
-    def from_dict(cls, error: dict):
+    def from_dict(cls, error: dict[str, Any]) -> "GraphQLClientGraphQLError":
         return cls(
             message=error["message"],
             locations=error.get("locations"),
@@ -54,7 +54,7 @@ class GraphQLClientGraphQLError(GraphQLClientError):
 
 
 class GraphQLClientGraphQLMultiError(GraphQLClientError):
-    def __init__(self, errors: List[GraphQLClientGraphQLError], data: dict):
+    def __init__(self, errors: List[GraphQLClientGraphQLError], data: dict[str, Any]):
         self.errors = errors
         self.data = data
 
@@ -62,7 +62,9 @@ class GraphQLClientGraphQLMultiError(GraphQLClientError):
         return "; ".join(str(e) for e in self.errors)
 
     @classmethod
-    def from_errors_dicts(cls, errors_dicts: List[dict], data: dict):
+    def from_errors_dicts(
+        cls, errors_dicts: List[dict[str, Any]], data: dict[str, Any]
+    ) -> "GraphQLClientGraphQLMultiError":
         return cls(
             errors=[GraphQLClientGraphQLError.from_dict(e) for e in errors_dicts],
             data=data,

--- a/tests/main/example/expected_client/client.py
+++ b/tests/main/example/expected_client/client.py
@@ -22,7 +22,7 @@ class Client(AsyncBaseClient):
             }
             """
         )
-        variables: dict = {"userData": user_data}
+        variables: dict[str, object] = {"userData": user_data}
         response = await self.execute(query=query, variables=variables)
         data = self.get_data(response)
         return CreateUser.parse_obj(data)
@@ -43,7 +43,7 @@ class Client(AsyncBaseClient):
             }
             """
         )
-        variables: dict = {}
+        variables: dict[str, object] = {}
         response = await self.execute(query=query, variables=variables)
         data = self.get_data(response)
         return ListAllUsers.parse_obj(data)
@@ -70,7 +70,7 @@ class Client(AsyncBaseClient):
             }
             """
         )
-        variables: dict = {"country": country}
+        variables: dict[str, object] = {"country": country}
         response = await self.execute(query=query, variables=variables)
         data = self.get_data(response)
         return ListUsersByCountry.parse_obj(data)

--- a/tests/main/example/expected_client/client.py
+++ b/tests/main/example/expected_client/client.py
@@ -6,7 +6,9 @@ from .input_types import UserCreateInput
 from .list_all_users import ListAllUsers
 from .list_users_by_country import ListUsersByCountry
 
-gql = lambda q: q
+
+def gql(q: str) -> str:
+    return q
 
 
 class Client(AsyncBaseClient):

--- a/tests/main/example/expected_client/exceptions.py
+++ b/tests/main/example/expected_client/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import httpx
 
@@ -43,7 +43,7 @@ class GraphQLClientGraphQLError(GraphQLClientError):
         return self.message
 
     @classmethod
-    def from_dict(cls, error: dict):
+    def from_dict(cls, error: dict[str, Any]) -> "GraphQLClientGraphQLError":
         return cls(
             message=error["message"],
             locations=error.get("locations"),
@@ -54,7 +54,7 @@ class GraphQLClientGraphQLError(GraphQLClientError):
 
 
 class GraphQLClientGraphQLMultiError(GraphQLClientError):
-    def __init__(self, errors: List[GraphQLClientGraphQLError], data: dict):
+    def __init__(self, errors: List[GraphQLClientGraphQLError], data: dict[str, Any]):
         self.errors = errors
         self.data = data
 
@@ -62,7 +62,9 @@ class GraphQLClientGraphQLMultiError(GraphQLClientError):
         return "; ".join(str(e) for e in self.errors)
 
     @classmethod
-    def from_errors_dicts(cls, errors_dicts: List[dict], data: dict):
+    def from_errors_dicts(
+        cls, errors_dicts: List[dict[str, Any]], data: dict[str, Any]
+    ) -> "GraphQLClientGraphQLMultiError":
         return cls(
             errors=[GraphQLClientGraphQLError.from_dict(e) for e in errors_dicts],
             data=data,

--- a/tests/main/extended_models/expected_client/client.py
+++ b/tests/main/extended_models/expected_client/client.py
@@ -4,7 +4,9 @@ from .async_base_client import AsyncBaseClient
 from .get_query_a import GetQueryA
 from .get_query_b import GetQueryB
 
-gql = lambda q: q
+
+def gql(q: str) -> str:
+    return q
 
 
 class Client(AsyncBaseClient):

--- a/tests/main/extended_models/expected_client/client.py
+++ b/tests/main/extended_models/expected_client/client.py
@@ -20,7 +20,7 @@ class Client(AsyncBaseClient):
             }
             """
         )
-        variables: dict = {}
+        variables: dict[str, object] = {}
         response = await self.execute(query=query, variables=variables)
         data = self.get_data(response)
         return GetQueryA.parse_obj(data)
@@ -35,7 +35,7 @@ class Client(AsyncBaseClient):
             }
             """
         )
-        variables: dict = {}
+        variables: dict[str, object] = {}
         response = await self.execute(query=query, variables=variables)
         data = self.get_data(response)
         return GetQueryB.parse_obj(data)

--- a/tests/main/extended_models/expected_client/exceptions.py
+++ b/tests/main/extended_models/expected_client/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import httpx
 
@@ -43,7 +43,7 @@ class GraphQLClientGraphQLError(GraphQLClientError):
         return self.message
 
     @classmethod
-    def from_dict(cls, error: dict):
+    def from_dict(cls, error: dict[str, Any]) -> "GraphQLClientGraphQLError":
         return cls(
             message=error["message"],
             locations=error.get("locations"),
@@ -54,7 +54,7 @@ class GraphQLClientGraphQLError(GraphQLClientError):
 
 
 class GraphQLClientGraphQLMultiError(GraphQLClientError):
-    def __init__(self, errors: List[GraphQLClientGraphQLError], data: dict):
+    def __init__(self, errors: List[GraphQLClientGraphQLError], data: dict[str, Any]):
         self.errors = errors
         self.data = data
 
@@ -62,7 +62,9 @@ class GraphQLClientGraphQLMultiError(GraphQLClientError):
         return "; ".join(str(e) for e in self.errors)
 
     @classmethod
-    def from_errors_dicts(cls, errors_dicts: List[dict], data: dict):
+    def from_errors_dicts(
+        cls, errors_dicts: List[dict[str, Any]], data: dict[str, Any]
+    ) -> "GraphQLClientGraphQLMultiError":
         return cls(
             errors=[GraphQLClientGraphQLError.from_dict(e) for e in errors_dicts],
             data=data,

--- a/tests/main/remote_schema/expected_client/client.py
+++ b/tests/main/remote_schema/expected_client/client.py
@@ -3,7 +3,9 @@ from typing import Any, List, Optional
 from .async_base_client import AsyncBaseClient
 from .test import Test
 
-gql = lambda q: q
+
+def gql(q: str) -> str:
+    return q
 
 
 class Client(AsyncBaseClient):

--- a/tests/main/remote_schema/expected_client/client.py
+++ b/tests/main/remote_schema/expected_client/client.py
@@ -17,7 +17,7 @@ class Client(AsyncBaseClient):
             }
             """
         )
-        variables: dict = {}
+        variables: dict[str, object] = {}
         response = await self.execute(query=query, variables=variables)
         data = self.get_data(response)
         return Test.parse_obj(data)

--- a/tests/main/remote_schema/expected_client/exceptions.py
+++ b/tests/main/remote_schema/expected_client/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import httpx
 
@@ -43,7 +43,7 @@ class GraphQLClientGraphQLError(GraphQLClientError):
         return self.message
 
     @classmethod
-    def from_dict(cls, error: dict):
+    def from_dict(cls, error: dict[str, Any]) -> "GraphQLClientGraphQLError":
         return cls(
             message=error["message"],
             locations=error.get("locations"),
@@ -54,7 +54,7 @@ class GraphQLClientGraphQLError(GraphQLClientError):
 
 
 class GraphQLClientGraphQLMultiError(GraphQLClientError):
-    def __init__(self, errors: List[GraphQLClientGraphQLError], data: dict):
+    def __init__(self, errors: List[GraphQLClientGraphQLError], data: dict[str, Any]):
         self.errors = errors
         self.data = data
 
@@ -62,7 +62,9 @@ class GraphQLClientGraphQLMultiError(GraphQLClientError):
         return "; ".join(str(e) for e in self.errors)
 
     @classmethod
-    def from_errors_dicts(cls, errors_dicts: List[dict], data: dict):
+    def from_errors_dicts(
+        cls, errors_dicts: List[dict[str, Any]], data: dict[str, Any]
+    ) -> "GraphQLClientGraphQLMultiError":
         return cls(
             errors=[GraphQLClientGraphQLError.from_dict(e) for e in errors_dicts],
             data=data,


### PR DESCRIPTION
This adjusts the code _generated_ by ariadne-codegen to pass `mypy --strict` (https://mypy.readthedocs.io/en/stable/getting_started.html?highlight=strict#strict-mode-and-configuration). 

Having the generated code pass `mypy --strict` allows easier integration into projects that mypy with stricter settings than the default. Without this change, we could not easily use ariadne-codegen, because we have stricter mypy settings, and so mypy was rejecting the generated files, and we need to adding exclusions.

The changes are mostly just adding new annotations that were missing, or adjusting them (especially `dict` -> `dict[str, Any]`). Specifically:

1. annotations in the static files in `ariadne_codegen/generators/dependencies/` 
2. annotations in dynamically generated code:
   1. the `qql` lambda is now as a full `def gql(q: str) -> str: return q` function, so that it can have annotations
   2. `variables: dict = ...` is now `variables: dict[str, object] = ...`
3. fixing the `custom_base_client` test to also pass `mypy --strict`
4. adding `mypy --strict` to run over the generated code in CI, to ensure this keeps up to date

This _is_ a bit annoying, but hopefully it's not too bad, because the generator code (i.e. the `ariadne_codegen` folder, minus the `dependencies`) can continue to be non-strict. The pay-off is much simpler integration!

(Thank you for ariadne-codegen, very cool!)