### PR TITLE
Set the full URL in base clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ from graphql_client.client import Client
 
 Client (with default base client), takes passed headers and attaches them to every sent request.
 ```py
-client = Client("https://example.com", {"Authorization": "Bearer token"})
+client = Client("https://example.com/graphql", {"Authorization": "Bearer token"})
 ```
 
 For more complex scenarios, you can pass your own http client:

--- a/ariadne_codegen/generators/dependencies/async_base_client.py
+++ b/ariadne_codegen/generators/dependencies/async_base_client.py
@@ -43,7 +43,7 @@ class AsyncBaseClient:
         payload: Dict[str, Any] = {"query": query}
         if variables:
             payload["variables"] = self._convert_dict_to_json_serializable(variables)
-        return await self.http_client.post(url="/graphql/", json=payload)
+        return await self.http_client.post(url="/graphql", json=payload)
 
     def get_data(self, response: httpx.Response) -> dict:
         if not response.is_success:

--- a/ariadne_codegen/generators/dependencies/async_base_client.py
+++ b/ariadne_codegen/generators/dependencies/async_base_client.py
@@ -16,6 +16,7 @@ class AsyncBaseClient:
         base_url: str = "",
         headers: Optional[Dict[str, str]] = None,
         http_client: Optional[httpx.AsyncClient] = None,
+        endpoint: str = "/graphql/",
     ) -> None:
         self.base_url = base_url
         self.headers = headers
@@ -25,6 +26,7 @@ class AsyncBaseClient:
             if http_client
             else httpx.AsyncClient(base_url=base_url, headers=headers)
         )
+        self.endpoint = endpoint
 
     async def __aenter__(self):
         return self
@@ -43,7 +45,7 @@ class AsyncBaseClient:
         payload: Dict[str, Any] = {"query": query}
         if variables:
             payload["variables"] = self._convert_dict_to_json_serializable(variables)
-        return await self.http_client.post(url="/graphql", json=payload)
+        return await self.http_client.post(url=self.endpoint, json=payload)
 
     def get_data(self, response: httpx.Response) -> dict:
         if not response.is_success:

--- a/ariadne_codegen/generators/dependencies/async_base_client.py
+++ b/ariadne_codegen/generators/dependencies/async_base_client.py
@@ -13,20 +13,16 @@ from .exceptions import (
 class AsyncBaseClient:
     def __init__(
         self,
-        base_url: str = "",
+        url: str = "",
         headers: Optional[Dict[str, str]] = None,
         http_client: Optional[httpx.AsyncClient] = None,
-        endpoint: str = "/graphql/",
     ) -> None:
-        self.base_url = base_url
+        self.url = url
         self.headers = headers
 
         self.http_client = (
-            http_client
-            if http_client
-            else httpx.AsyncClient(base_url=base_url, headers=headers)
+            http_client if http_client else httpx.AsyncClient(headers=headers)
         )
-        self.endpoint = endpoint
 
     async def __aenter__(self):
         return self
@@ -45,7 +41,7 @@ class AsyncBaseClient:
         payload: Dict[str, Any] = {"query": query}
         if variables:
             payload["variables"] = self._convert_dict_to_json_serializable(variables)
-        return await self.http_client.post(url=self.endpoint, json=payload)
+        return await self.http_client.post(url=self.url, json=payload)
 
     def get_data(self, response: httpx.Response) -> dict:
         if not response.is_success:

--- a/ariadne_codegen/generators/dependencies/base_client.py
+++ b/ariadne_codegen/generators/dependencies/base_client.py
@@ -16,6 +16,7 @@ class BaseClient:
         base_url: str = "",
         headers: Optional[Dict[str, str]] = None,
         http_client: Optional[httpx.Client] = None,
+        endpoint: str = "/graphql/",
     ) -> None:
         self.base_url = base_url
         self.headers = headers
@@ -25,6 +26,7 @@ class BaseClient:
             if http_client
             else httpx.Client(base_url=base_url, headers=headers)
         )
+        self.endpoint = endpoint
 
     def __enter__(self):
         return self
@@ -43,7 +45,7 @@ class BaseClient:
         payload: Dict[str, Any] = {"query": query}
         if variables:
             payload["variables"] = self._convert_dict_to_json_serializable(variables)
-        return self.http_client.post(url="/graphql", json=payload)
+        return self.http_client.post(url=self.endpoint, json=payload)
 
     def get_data(self, response: httpx.Response) -> dict:
         if not response.is_success:

--- a/ariadne_codegen/generators/dependencies/base_client.py
+++ b/ariadne_codegen/generators/dependencies/base_client.py
@@ -13,20 +13,14 @@ from .exceptions import (
 class BaseClient:
     def __init__(
         self,
-        base_url: str = "",
+        url: str = "",
         headers: Optional[Dict[str, str]] = None,
         http_client: Optional[httpx.Client] = None,
-        endpoint: str = "/graphql/",
     ) -> None:
-        self.base_url = base_url
+        self.url = url
         self.headers = headers
 
-        self.http_client = (
-            http_client
-            if http_client
-            else httpx.Client(base_url=base_url, headers=headers)
-        )
-        self.endpoint = endpoint
+        self.http_client = http_client if http_client else httpx.Client(headers=headers)
 
     def __enter__(self):
         return self
@@ -45,7 +39,7 @@ class BaseClient:
         payload: Dict[str, Any] = {"query": query}
         if variables:
             payload["variables"] = self._convert_dict_to_json_serializable(variables)
-        return self.http_client.post(url=self.endpoint, json=payload)
+        return self.http_client.post(url=self.url, json=payload)
 
     def get_data(self, response: httpx.Response) -> dict:
         if not response.is_success:

--- a/ariadne_codegen/generators/dependencies/base_client.py
+++ b/ariadne_codegen/generators/dependencies/base_client.py
@@ -43,7 +43,7 @@ class BaseClient:
         payload: Dict[str, Any] = {"query": query}
         if variables:
             payload["variables"] = self._convert_dict_to_json_serializable(variables)
-        return self.http_client.post(url="/graphql/", json=payload)
+        return self.http_client.post(url="/graphql", json=payload)
 
     def get_data(self, response: httpx.Response) -> dict:
         if not response.is_success:

--- a/tests/generators/dependencies/test_async_base_client.py
+++ b/tests/generators/dependencies/test_async_base_client.py
@@ -13,19 +13,9 @@ from ariadne_codegen.generators.dependencies.exceptions import (
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("endpoint", [None, "/some/custom/endpoint"])
-async def test_execute_sends_post_to_correct_endpoint_with_correct_payload(
-    mocker, endpoint
-):
+async def test_execute_sends_post_to_correct_url_with_correct_payload(mocker):
     fake_client = mocker.AsyncMock()
-    if endpoint is None:
-        client = AsyncBaseClient(base_url="base_url", http_client=fake_client)
-        expected_endpoint = "/graphql/"
-    else:
-        client = AsyncBaseClient(
-            base_url="base_url", http_client=fake_client, endpoint=endpoint
-        )
-        expected_endpoint = endpoint
+    client = AsyncBaseClient(url="base_url/endpoint", http_client=fake_client)
     query_str = """
     query Abc($v: String!) {
         abc(v: $v) {
@@ -39,7 +29,7 @@ async def test_execute_sends_post_to_correct_endpoint_with_correct_payload(
     assert fake_client.post.called
     assert len(fake_client.post.mock_calls) == 1
     call_kwargs = fake_client.post.mock_calls[0].kwargs
-    assert call_kwargs["url"] == expected_endpoint
+    assert call_kwargs["url"] == "base_url/endpoint"
     assert call_kwargs["json"] == {"query": query_str, "variables": {"v": "Xyz"}}
 
 
@@ -52,7 +42,7 @@ async def test_execute_parses_pydantic_variables_before_sending(mocker):
         nested: TestModel1
 
     fake_client = mocker.AsyncMock()
-    client = AsyncBaseClient(base_url="base_url", http_client=fake_client)
+    client = AsyncBaseClient(url="base_url", http_client=fake_client)
     query_str = """
     query Abc($v1: TestModel1!, $v2: TestModel2) {
         abc(v1: $v1, v2: $v2){
@@ -68,7 +58,7 @@ async def test_execute_parses_pydantic_variables_before_sending(mocker):
     assert fake_client.post.called
     assert len(fake_client.post.mock_calls) == 1
     call_kwargs = fake_client.post.mock_calls[0].kwargs
-    assert call_kwargs["url"] == "/graphql/"
+    assert call_kwargs["url"] == "base_url"
     assert call_kwargs["json"] == {
         "query": query_str,
         "variables": {"v1": {"a": 5}, "v2": {"nested": {"a": 10}}},
@@ -87,7 +77,7 @@ async def test_execute_parses_pydantic_variables_before_sending(mocker):
 def test_get_data_raises_graphql_client_http_error(
     mocker, status_code, response_content
 ):
-    client = AsyncBaseClient(base_url="base_url", http_client=mocker.MagicMock())
+    client = AsyncBaseClient(url="base_url", http_client=mocker.MagicMock())
     response = httpx.Response(
         status_code=status_code, content=json.dumps(response_content)
     )
@@ -102,7 +92,7 @@ def test_get_data_raises_graphql_client_http_error(
 def test_get_data_raises_graphql_client_invalid_response_error(
     mocker, response_content
 ):
-    client = AsyncBaseClient(base_url="base_url", http_client=mocker.MagicMock())
+    client = AsyncBaseClient(url="base_url", http_client=mocker.MagicMock())
     response = httpx.Response(status_code=200, content=json.dumps(response_content))
 
     with pytest.raises(GraphQlClientInvalidResponseError) as exc:
@@ -141,7 +131,7 @@ def test_get_data_raises_graphql_client_invalid_response_error(
     ],
 )
 def test_get_data_raises_graphql_client_graphql_multi_error(mocker, response_content):
-    client = AsyncBaseClient(base_url="base_url", http_client=mocker.MagicMock())
+    client = AsyncBaseClient(url="base_url", http_client=mocker.MagicMock())
 
     with pytest.raises(GraphQLClientGraphQLMultiError):
         client.get_data(
@@ -154,7 +144,7 @@ def test_get_data_raises_graphql_client_graphql_multi_error(mocker, response_con
     [{"errors": [], "data": {}}, {"errors": None, "data": {}}, {"data": {}}],
 )
 def test_get_data_doesnt_raise_exception(mocker, response_content):
-    client = AsyncBaseClient(base_url="base_url", http_client=mocker.MagicMock())
+    client = AsyncBaseClient(url="base_url", http_client=mocker.MagicMock())
 
     data = client.get_data(
         httpx.Response(status_code=200, content=json.dumps(response_content))
@@ -166,9 +156,7 @@ def test_get_data_doesnt_raise_exception(mocker, response_content):
 @pytest.mark.asyncio
 async def test_base_client_used_as_context_manager_closes_http_client(mocker):
     fake_client = mocker.AsyncMock()
-    async with AsyncBaseClient(
-        base_url="base_url", http_client=fake_client
-    ) as base_client:
+    async with AsyncBaseClient(url="base_url", http_client=fake_client) as base_client:
         await base_client.execute("")
 
     assert fake_client.aclose.called

--- a/tests/generators/dependencies/test_async_base_client.py
+++ b/tests/generators/dependencies/test_async_base_client.py
@@ -29,7 +29,7 @@ async def test_execute_sends_post_to_correct_endpoint_with_correct_payload(mocke
     assert fake_client.post.called
     assert len(fake_client.post.mock_calls) == 1
     call_kwargs = fake_client.post.mock_calls[0].kwargs
-    assert call_kwargs["url"] == "/graphql/"
+    assert call_kwargs["url"] == "/graphql"
     assert call_kwargs["json"] == {"query": query_str, "variables": {"v": "Xyz"}}
 
 
@@ -58,7 +58,7 @@ async def test_execute_parses_pydantic_variables_before_sending(mocker):
     assert fake_client.post.called
     assert len(fake_client.post.mock_calls) == 1
     call_kwargs = fake_client.post.mock_calls[0].kwargs
-    assert call_kwargs["url"] == "/graphql/"
+    assert call_kwargs["url"] == "/graphql"
     assert call_kwargs["json"] == {
         "query": query_str,
         "variables": {"v1": {"a": 5}, "v2": {"nested": {"a": 10}}},

--- a/tests/generators/dependencies/test_base_client.py
+++ b/tests/generators/dependencies/test_base_client.py
@@ -28,7 +28,7 @@ def test_execute_sends_post_to_correct_endpoint_with_correct_payload(mocker):
     assert fake_client.post.called
     assert len(fake_client.post.mock_calls) == 1
     call_kwargs = fake_client.post.mock_calls[0].kwargs
-    assert call_kwargs["url"] == "/graphql/"
+    assert call_kwargs["url"] == "/graphql"
     assert call_kwargs["json"] == {"query": query_str, "variables": {"v": "Xyz"}}
 
 
@@ -56,7 +56,7 @@ def test_execute_parses_pydantic_variables_before_sending(mocker):
     assert fake_client.post.called
     assert len(fake_client.post.mock_calls) == 1
     call_kwargs = fake_client.post.mock_calls[0].kwargs
-    assert call_kwargs["url"] == "/graphql/"
+    assert call_kwargs["url"] == "/graphql"
     assert call_kwargs["json"] == {
         "query": query_str,
         "variables": {"v1": {"a": 5}, "v2": {"nested": {"a": 10}}},

--- a/tests/main/custom_files_names/expected_client/async_base_client.py
+++ b/tests/main/custom_files_names/expected_client/async_base_client.py
@@ -43,7 +43,7 @@ class AsyncBaseClient:
         payload: Dict[str, Any] = {"query": query}
         if variables:
             payload["variables"] = self._convert_dict_to_json_serializable(variables)
-        return await self.http_client.post(url="/graphql/", json=payload)
+        return await self.http_client.post(url="/graphql", json=payload)
 
     def get_data(self, response: httpx.Response) -> dict:
         if not response.is_success:

--- a/tests/main/custom_files_names/expected_client/async_base_client.py
+++ b/tests/main/custom_files_names/expected_client/async_base_client.py
@@ -16,6 +16,7 @@ class AsyncBaseClient:
         base_url: str = "",
         headers: Optional[Dict[str, str]] = None,
         http_client: Optional[httpx.AsyncClient] = None,
+        endpoint: str = "/graphql/",
     ) -> None:
         self.base_url = base_url
         self.headers = headers
@@ -25,6 +26,7 @@ class AsyncBaseClient:
             if http_client
             else httpx.AsyncClient(base_url=base_url, headers=headers)
         )
+        self.endpoint = endpoint
 
     async def __aenter__(self):
         return self
@@ -43,7 +45,7 @@ class AsyncBaseClient:
         payload: Dict[str, Any] = {"query": query}
         if variables:
             payload["variables"] = self._convert_dict_to_json_serializable(variables)
-        return await self.http_client.post(url="/graphql", json=payload)
+        return await self.http_client.post(url=self.endpoint, json=payload)
 
     def get_data(self, response: httpx.Response) -> dict:
         if not response.is_success:

--- a/tests/main/custom_files_names/expected_client/async_base_client.py
+++ b/tests/main/custom_files_names/expected_client/async_base_client.py
@@ -13,20 +13,16 @@ from .exceptions import (
 class AsyncBaseClient:
     def __init__(
         self,
-        base_url: str = "",
+        url: str = "",
         headers: Optional[Dict[str, str]] = None,
         http_client: Optional[httpx.AsyncClient] = None,
-        endpoint: str = "/graphql/",
     ) -> None:
-        self.base_url = base_url
+        self.url = url
         self.headers = headers
 
         self.http_client = (
-            http_client
-            if http_client
-            else httpx.AsyncClient(base_url=base_url, headers=headers)
+            http_client if http_client else httpx.AsyncClient(headers=headers)
         )
-        self.endpoint = endpoint
 
     async def __aenter__(self):
         return self
@@ -45,7 +41,7 @@ class AsyncBaseClient:
         payload: Dict[str, Any] = {"query": query}
         if variables:
             payload["variables"] = self._convert_dict_to_json_serializable(variables)
-        return await self.http_client.post(url=self.endpoint, json=payload)
+        return await self.http_client.post(url=self.url, json=payload)
 
     def get_data(self, response: httpx.Response) -> dict:
         if not response.is_success:

--- a/tests/main/example/expected_client/async_base_client.py
+++ b/tests/main/example/expected_client/async_base_client.py
@@ -43,7 +43,7 @@ class AsyncBaseClient:
         payload: Dict[str, Any] = {"query": query}
         if variables:
             payload["variables"] = self._convert_dict_to_json_serializable(variables)
-        return await self.http_client.post(url="/graphql/", json=payload)
+        return await self.http_client.post(url="/graphql", json=payload)
 
     def get_data(self, response: httpx.Response) -> dict:
         if not response.is_success:

--- a/tests/main/example/expected_client/async_base_client.py
+++ b/tests/main/example/expected_client/async_base_client.py
@@ -16,6 +16,7 @@ class AsyncBaseClient:
         base_url: str = "",
         headers: Optional[Dict[str, str]] = None,
         http_client: Optional[httpx.AsyncClient] = None,
+        endpoint: str = "/graphql/",
     ) -> None:
         self.base_url = base_url
         self.headers = headers
@@ -25,6 +26,7 @@ class AsyncBaseClient:
             if http_client
             else httpx.AsyncClient(base_url=base_url, headers=headers)
         )
+        self.endpoint = endpoint
 
     async def __aenter__(self):
         return self
@@ -43,7 +45,7 @@ class AsyncBaseClient:
         payload: Dict[str, Any] = {"query": query}
         if variables:
             payload["variables"] = self._convert_dict_to_json_serializable(variables)
-        return await self.http_client.post(url="/graphql", json=payload)
+        return await self.http_client.post(url=self.endpoint, json=payload)
 
     def get_data(self, response: httpx.Response) -> dict:
         if not response.is_success:

--- a/tests/main/example/expected_client/async_base_client.py
+++ b/tests/main/example/expected_client/async_base_client.py
@@ -13,20 +13,16 @@ from .exceptions import (
 class AsyncBaseClient:
     def __init__(
         self,
-        base_url: str = "",
+        url: str = "",
         headers: Optional[Dict[str, str]] = None,
         http_client: Optional[httpx.AsyncClient] = None,
-        endpoint: str = "/graphql/",
     ) -> None:
-        self.base_url = base_url
+        self.url = url
         self.headers = headers
 
         self.http_client = (
-            http_client
-            if http_client
-            else httpx.AsyncClient(base_url=base_url, headers=headers)
+            http_client if http_client else httpx.AsyncClient(headers=headers)
         )
-        self.endpoint = endpoint
 
     async def __aenter__(self):
         return self
@@ -45,7 +41,7 @@ class AsyncBaseClient:
         payload: Dict[str, Any] = {"query": query}
         if variables:
             payload["variables"] = self._convert_dict_to_json_serializable(variables)
-        return await self.http_client.post(url=self.endpoint, json=payload)
+        return await self.http_client.post(url=self.url, json=payload)
 
     def get_data(self, response: httpx.Response) -> dict:
         if not response.is_success:

--- a/tests/main/extended_models/expected_client/async_base_client.py
+++ b/tests/main/extended_models/expected_client/async_base_client.py
@@ -43,7 +43,7 @@ class AsyncBaseClient:
         payload: Dict[str, Any] = {"query": query}
         if variables:
             payload["variables"] = self._convert_dict_to_json_serializable(variables)
-        return await self.http_client.post(url="/graphql/", json=payload)
+        return await self.http_client.post(url="/graphql", json=payload)
 
     def get_data(self, response: httpx.Response) -> dict:
         if not response.is_success:

--- a/tests/main/extended_models/expected_client/async_base_client.py
+++ b/tests/main/extended_models/expected_client/async_base_client.py
@@ -16,6 +16,7 @@ class AsyncBaseClient:
         base_url: str = "",
         headers: Optional[Dict[str, str]] = None,
         http_client: Optional[httpx.AsyncClient] = None,
+        endpoint: str = "/graphql/",
     ) -> None:
         self.base_url = base_url
         self.headers = headers
@@ -25,6 +26,7 @@ class AsyncBaseClient:
             if http_client
             else httpx.AsyncClient(base_url=base_url, headers=headers)
         )
+        self.endpoint = endpoint
 
     async def __aenter__(self):
         return self
@@ -43,7 +45,7 @@ class AsyncBaseClient:
         payload: Dict[str, Any] = {"query": query}
         if variables:
             payload["variables"] = self._convert_dict_to_json_serializable(variables)
-        return await self.http_client.post(url="/graphql", json=payload)
+        return await self.http_client.post(url=self.endpoint, json=payload)
 
     def get_data(self, response: httpx.Response) -> dict:
         if not response.is_success:

--- a/tests/main/extended_models/expected_client/async_base_client.py
+++ b/tests/main/extended_models/expected_client/async_base_client.py
@@ -13,20 +13,16 @@ from .exceptions import (
 class AsyncBaseClient:
     def __init__(
         self,
-        base_url: str = "",
+        url: str = "",
         headers: Optional[Dict[str, str]] = None,
         http_client: Optional[httpx.AsyncClient] = None,
-        endpoint: str = "/graphql/",
     ) -> None:
-        self.base_url = base_url
+        self.url = url
         self.headers = headers
 
         self.http_client = (
-            http_client
-            if http_client
-            else httpx.AsyncClient(base_url=base_url, headers=headers)
+            http_client if http_client else httpx.AsyncClient(headers=headers)
         )
-        self.endpoint = endpoint
 
     async def __aenter__(self):
         return self
@@ -45,7 +41,7 @@ class AsyncBaseClient:
         payload: Dict[str, Any] = {"query": query}
         if variables:
             payload["variables"] = self._convert_dict_to_json_serializable(variables)
-        return await self.http_client.post(url=self.endpoint, json=payload)
+        return await self.http_client.post(url=self.url, json=payload)
 
     def get_data(self, response: httpx.Response) -> dict:
         if not response.is_success:

--- a/tests/main/remote_schema/expected_client/async_base_client.py
+++ b/tests/main/remote_schema/expected_client/async_base_client.py
@@ -43,7 +43,7 @@ class AsyncBaseClient:
         payload: Dict[str, Any] = {"query": query}
         if variables:
             payload["variables"] = self._convert_dict_to_json_serializable(variables)
-        return await self.http_client.post(url="/graphql/", json=payload)
+        return await self.http_client.post(url="/graphql", json=payload)
 
     def get_data(self, response: httpx.Response) -> dict:
         if not response.is_success:

--- a/tests/main/remote_schema/expected_client/async_base_client.py
+++ b/tests/main/remote_schema/expected_client/async_base_client.py
@@ -16,6 +16,7 @@ class AsyncBaseClient:
         base_url: str = "",
         headers: Optional[Dict[str, str]] = None,
         http_client: Optional[httpx.AsyncClient] = None,
+        endpoint: str = "/graphql/",
     ) -> None:
         self.base_url = base_url
         self.headers = headers
@@ -25,6 +26,7 @@ class AsyncBaseClient:
             if http_client
             else httpx.AsyncClient(base_url=base_url, headers=headers)
         )
+        self.endpoint = endpoint
 
     async def __aenter__(self):
         return self
@@ -43,7 +45,7 @@ class AsyncBaseClient:
         payload: Dict[str, Any] = {"query": query}
         if variables:
             payload["variables"] = self._convert_dict_to_json_serializable(variables)
-        return await self.http_client.post(url="/graphql", json=payload)
+        return await self.http_client.post(url=self.endpoint, json=payload)
 
     def get_data(self, response: httpx.Response) -> dict:
         if not response.is_success:

--- a/tests/main/remote_schema/expected_client/async_base_client.py
+++ b/tests/main/remote_schema/expected_client/async_base_client.py
@@ -13,20 +13,16 @@ from .exceptions import (
 class AsyncBaseClient:
     def __init__(
         self,
-        base_url: str = "",
+        url: str = "",
         headers: Optional[Dict[str, str]] = None,
         http_client: Optional[httpx.AsyncClient] = None,
-        endpoint: str = "/graphql/",
     ) -> None:
-        self.base_url = base_url
+        self.url = url
         self.headers = headers
 
         self.http_client = (
-            http_client
-            if http_client
-            else httpx.AsyncClient(base_url=base_url, headers=headers)
+            http_client if http_client else httpx.AsyncClient(headers=headers)
         )
-        self.endpoint = endpoint
 
     async def __aenter__(self):
         return self
@@ -45,7 +41,7 @@ class AsyncBaseClient:
         payload: Dict[str, Any] = {"query": query}
         if variables:
             payload["variables"] = self._convert_dict_to_json_serializable(variables)
-        return await self.http_client.post(url=self.endpoint, json=payload)
+        return await self.http_client.post(url=self.url, json=payload)
 
     def get_data(self, response: httpx.Response) -> dict:
         if not response.is_success:

--- a/tests/main/test_main.py
+++ b/tests/main/test_main.py
@@ -35,7 +35,6 @@ def assert_the_same_files_in_directories(dir1: Path, dir2: Path):
 
     for file_ in files1:
         content1 = file_.read_text()
-        # dir2.joinpath(file_.name).write_text(content1)
         content2 = dir2.joinpath(file_.name).read_text()
         assert content1 == content2, file_.name
 

--- a/tests/main/test_main.py
+++ b/tests/main/test_main.py
@@ -35,6 +35,7 @@ def assert_the_same_files_in_directories(dir1: Path, dir2: Path):
 
     for file_ in files1:
         content1 = file_.read_text()
+        # dir2.joinpath(file_.name).write_text(content1)
         content2 = dir2.joinpath(file_.name).read_text()
         assert content1 == content2, file_.name
 


### PR DESCRIPTION
This replaces the `base_url` parameter to `BaseClient` and `AsyncBaseClient` with `url`. This is used as the literal thing to post the request to, to allow customising the URL path. This generalises the previous behaviour of always posting to the `/graphql/` endpoint of the base URL.

For instance, many servers use `/graphql` (without the trailing `/`) and reject requests to `/graphql/`, like GitHub's API (https://docs.github.com/en/graphql/guides/forming-calls-with-graphql#the-graphql-endpoint). This PR allows `Client(url="https://api.github.com/graphql", ...)` to handle this sort of server.

Existing callers like `Client(base_url="https://some_host")` need to be updated to `Client(url="https://some_host/graphql/")`.