### PR TITLE
Support env variables for remote schema headers values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added `InputTypesGenerator` and `ResultTypesGenerator` plugin hooks.
 - Added `ScalarsDefinitionsGenerator` and `PackageGenerator` plugin hooks.
 - Added support for `[tool.ariadne-codegen]` section key. Deprecated `[ariadne-codegen]`.
+- Added support for environment variables to remote schema headers values.
 
 
 ## 0.3.0 (2023-02-21)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ One of the following 2 parameters is required, in case of providing both of them
 
 Optional settings:
 
-- `remote_schema_headers` - extra headers that are passed along with introspection query, eg. `{"Authorization" = "Bearer: token"}`
+- `remote_schema_headers` - extra headers that are passed along with introspection query, eg. `{"Authorization" = "Bearer: token"}`. To include an environment variable in a header value, prefix the variable with `$`, eg. `{"Authorization" = "$BEARER_TOKEN"}`
 - `target_package_name` (defaults to `"graphql_client"`) - name of generated package
 - `target_package_path` (defaults to cwd) - path where to generate package
 - `client_name` (defaults to `"Client"`) - name of generated client class


### PR DESCRIPTION
This pr adds support for env variables for remote schema headers values. Proposed in #91 `remote_schema_headers = {"Authorization" = $ENV_VAR_NAME}` is not a valid time entry. Instead, if the value starts with `$` then is treated as env variable -> `remote_schema_headers = {"Authorization" = "$ENV_VAR_NAME"}`

resolves #91 