### PR TITLE
Unlock dev dependencies versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   pull_request:
+  schedule:
+    - cron:  "0 7 * * 1,3"
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added generation of GraphQL schema's Python representation.
 - Fixed annotations for lists.
 - Fixed support of custom operation types names.
+- Unlocked versions of black, isort, autoflake and dev dependencies
 
 
 ## 0.4.0 (2023-03-20)

--- a/EXAMPLE.md
+++ b/EXAMPLE.md
@@ -156,7 +156,7 @@ Generated client class inherits from `AsyncBaseClient` and has async method for 
 ```py
 # graphql_client/client.py
 
-from typing import Any, List, Optional
+from typing import Optional
 
 from .async_base_client import AsyncBaseClient
 from .create_user import CreateUser

--- a/ariadne_codegen/client_generators/client.py
+++ b/ariadne_codegen/client_generators/client.py
@@ -67,6 +67,8 @@ class ClientGenerator:
 
     def add_import(self, names: List[str], from_: str, level: int = 0) -> None:
         """Add import to be included in module file."""
+        if not names:
+            return
         import_ = generate_import_from(names=names, from_=from_, level=level)
         if self.plugin_manager:
             import_ = self.plugin_manager.generate_client_import(import_)

--- a/ariadne_codegen/client_generators/init_file.py
+++ b/ariadne_codegen/client_generators/init_file.py
@@ -12,6 +12,8 @@ class InitFileGenerator:
 
     def add_import(self, names: List[str], from_: str, level: int = 0) -> None:
         """Add import to be included in init file."""
+        if not names:
+            return
         import_ = generate_import_from(names=names, from_=from_, level=level)
         if self.plugin_manager:
             import_ = self.plugin_manager.generate_init_import(import_)

--- a/ariadne_codegen/client_generators/input_types.py
+++ b/ariadne_codegen/client_generators/input_types.py
@@ -74,7 +74,7 @@ class InputTypesGenerator:
         if self._used_scalars:
             for scalar_name in self._used_scalars:
                 scalar_data = self.custom_scalars[scalar_name]
-                if scalar_data.import_:
+                if scalar_data.import_ and scalar_data.names_to_import:
                     self._imports.append(
                         generate_import_from(
                             names=scalar_data.names_to_import, from_=scalar_data.import_

--- a/ariadne_codegen/client_generators/result_types.py
+++ b/ariadne_codegen/client_generators/result_types.py
@@ -116,7 +116,7 @@ class ResultTypesGenerator:
         if self._used_scalars:
             for scalar_name in self._used_scalars:
                 scalar_data = self.custom_scalars[scalar_name]
-                if scalar_data.import_:
+                if scalar_data.import_ and scalar_data.names_to_import:
                     self._imports.append(
                         generate_import_from(
                             names=scalar_data.names_to_import, from_=scalar_data.import_

--- a/ariadne_codegen/graphql_schema_generators/named_types.py
+++ b/ariadne_codegen/graphql_schema_generators/named_types.py
@@ -132,7 +132,6 @@ def generate_enum_type(type_: GraphQLEnumType, *_) -> ast.Call:
 def generate_input_object_type(
     type_: GraphQLInputObjectType, type_map_name: str
 ) -> ast.Call:
-
     return generate_call(
         func=generate_name("GraphQLInputObjectType"),
         keywords=[

--- a/ariadne_codegen/plugins/manager.py
+++ b/ariadne_codegen/plugins/manager.py
@@ -23,7 +23,6 @@ class PluginManager:
         config_dict: Optional[Dict] = None,
         plugins_types: Optional[List[Type[Plugin]]] = None,
     ) -> None:
-
         self.plugins: List[Plugin] = [
             cls(schema=schema, config_dict=config_dict or {})
             for cls in plugins_types or []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,22 +23,22 @@ dependencies = [
   "click~=8.1",
   "graphql-core>=3.2.0,<3.3",
   "toml~=0.10",
-  "black~=22.8",
-  "isort~=5.10.1",
   "httpx~=0.23",
   "pydantic~=1.10",
-  "autoflake~=1.7",
+  "black",
+  "isort",
+  "autoflake",
 ]
 
 [project.optional-dependencies]
 dev = [
-  "pytest~=7.1.3",
-  "pylint~=2.15.3",
-  "mypy~=0.971",
-  "types-toml~=0.10.8",
-  "pytest-mock~=3.8.2",
-  "pytest-asyncio~=0.19.0",
-  "freezegun~=1.2.2",
+  "pytest",
+  "pylint",
+  "mypy",
+  "types-toml",
+  "pytest-mock",
+  "pytest-asyncio",
+  "freezegun",
 ]
 
 [project.scripts]

--- a/tests/client_generators/test_client_generator.py
+++ b/tests/client_generators/test_client_generator.py
@@ -2,7 +2,7 @@ import ast
 
 from ariadne_codegen.client_generators.client import ClientGenerator
 
-from ..utils import compare_ast, get_class_def
+from ..utils import compare_ast, filter_imports, get_class_def
 
 
 def test_generate_returns_module_with_correct_class_name():
@@ -87,6 +87,17 @@ def test_add_import_adds_import_to_generated_module():
     assert isinstance(generated_import, ast.ImportFrom)
     assert generated_import.module == from_
     assert [n.name for n in generated_import.names] == [name]
+
+
+def test_add_import_with_empty_names_list_doesnt_add_invalid_import():
+    generator = ClientGenerator("Client", "BaseClient")
+    number_of_pre_existing_imports = len(generator.imports)
+
+    generator.add_import([], from_="abc")
+    module = generator.generate()
+
+    imports = filter_imports(module)
+    assert len(imports) == number_of_pre_existing_imports
 
 
 def test_add_import_triggers_generate_client_import_hook(mocker):

--- a/tests/client_generators/test_init_file_generator.py
+++ b/tests/client_generators/test_init_file_generator.py
@@ -2,6 +2,8 @@ import ast
 
 from ariadne_codegen.client_generators.init_file import InitFileGenerator
 
+from ..utils import filter_imports
+
 
 def test_add_import_adds_correct_objects_to_list():
     from_ = "file_name"
@@ -25,6 +27,16 @@ def test_add_import_triggers_generate_init_import_hook_method(mocker):
     generator.add_import(names=["TestClass"], from_="test", level=1)
 
     assert mocked_plugin_manager.generate_init_import.called
+
+
+def test_add_import_with_empty_names_list_doesnt_add_invalid_import():
+    generator = InitFileGenerator()
+
+    generator.add_import(names=[], from_="abcd", level=1)
+    module = generator.generate()
+
+    imports = filter_imports(module)
+    assert not imports
 
 
 def test_generate_without_imports_returns_empty_module():

--- a/tests/main/clients/custom_base_client/expected_client/client.py
+++ b/tests/main/clients/custom_base_client/expected_client/client.py
@@ -1,5 +1,3 @@
-from typing import Any, List, Optional
-
 from .custom_base_client import CustomAsyncBaseClient
 from .get_query_a import GetQueryA
 from .input_types import inputA

--- a/tests/main/clients/custom_config_file/expected_client/client.py
+++ b/tests/main/clients/custom_config_file/expected_client/client.py
@@ -1,5 +1,3 @@
-from typing import Any, List, Optional
-
 from .async_base_client import AsyncBaseClient
 from .test import Test
 

--- a/tests/main/clients/custom_files_names/expected_client/custom_client.py
+++ b/tests/main/clients/custom_files_names/expected_client/custom_client.py
@@ -1,5 +1,3 @@
-from typing import Any, List, Optional
-
 from .async_base_client import AsyncBaseClient
 from .custom_input_types import inputA
 from .get_query_a import GetQueryA

--- a/tests/main/clients/custom_scalars/expected_client/client.py
+++ b/tests/main/clients/custom_scalars/expected_client/client.py
@@ -1,8 +1,8 @@
 from datetime import datetime
-from typing import Any, List, Optional
+from typing import Any
 
 from .async_base_client import AsyncBaseClient
-from .custom_scalars import Code, parse_code, serialize_code
+from .custom_scalars import Code, serialize_code
 from .get_test import GetTest
 from .input_types import TestInput
 

--- a/tests/main/clients/example/expected_client/client.py
+++ b/tests/main/clients/example/expected_client/client.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional
+from typing import Optional
 
 from .async_base_client import AsyncBaseClient
 from .create_user import CreateUser

--- a/tests/main/clients/extended_models/expected_client/client.py
+++ b/tests/main/clients/extended_models/expected_client/client.py
@@ -1,5 +1,3 @@
-from typing import Any, List, Optional
-
 from .async_base_client import AsyncBaseClient
 from .get_query_a import GetQueryA
 from .get_query_b import GetQueryB

--- a/tests/main/clients/inline_fragments/expected_client/client.py
+++ b/tests/main/clients/inline_fragments/expected_client/client.py
@@ -1,5 +1,3 @@
-from typing import Any, List, Optional
-
 from .async_base_client import AsyncBaseClient
 from .interface_a import InterfaceA
 from .interface_b import InterfaceB

--- a/tests/main/clients/remote_schema/expected_client/client.py
+++ b/tests/main/clients/remote_schema/expected_client/client.py
@@ -1,5 +1,3 @@
-from typing import Any, List, Optional
-
 from .async_base_client import AsyncBaseClient
 from .test import Test
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -358,7 +358,6 @@ def test_get_graphql_queries_returns_schema_definitions_from_single_file(
 def test_get_graphql_queries_returns_schema_definitions_from_directory(
     queries_directory,
 ):
-
     queries = get_graphql_queries(queries_directory.as_posix())
     assert len(queries) == 2
     assert isinstance(queries[0], OperationDefinitionNode)


### PR DESCRIPTION
resolves #103 
This pr unlocks versions of black, isort, autoflake and dev dependencies. Tests are run on schedule, in the same way as in the main repo.

Newer versions required a few changes:
- In some cases, codegen generated "broken" imports, eg. `from .enums import `, and then relied on isort to remove them from generated code, but the new version of isort doesn't handle it anymore. I changed codegen to not create these invalid imports at all.
- The previous version of autoflake didn't handle unused `typing` imports very well, newer version takes care of them, so I updated e2e tests.