### PR TITLE
Handle top level lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Changed logic how custom scalar imports are generated. Deprecated `import_` key.
 - Added escaping of GraphQL names which are Python keywords by appending `_` to them.
+- Fixed parsing of list variables.
 
 
 ## 0.5.0 (2023-04-05)

--- a/ariadne_codegen/client_generators/dependencies/async_base_client.py
+++ b/ariadne_codegen/client_generators/dependencies/async_base_client.py
@@ -69,12 +69,14 @@ class AsyncBaseClient:
 
         return cast(dict[str, Any], data)
 
+    def _convert_value(self, value: Any) -> Any:
+        if isinstance(value, BaseModel):
+            return value.dict(by_alias=True)
+        if isinstance(value, list):
+            return [self._convert_value(item) for item in value]
+        return value
+
     def _convert_dict_to_json_serializable(
         self, dict_: Dict[str, Any]
     ) -> Dict[str, Any]:
-        return {
-            key: value
-            if not isinstance(value, BaseModel)
-            else value.dict(by_alias=True)
-            for key, value in dict_.items()
-        }
+        return {key: self._convert_value(value) for key, value in dict_.items()}

--- a/ariadne_codegen/client_generators/dependencies/base_client.py
+++ b/ariadne_codegen/client_generators/dependencies/base_client.py
@@ -67,12 +67,14 @@ class BaseClient:
 
         return cast(dict[str, Any], data)
 
+    def _convert_value(self, value: Any) -> Any:
+        if isinstance(value, BaseModel):
+            return value.dict(by_alias=True)
+        if isinstance(value, list):
+            return [self._convert_value(item) for item in value]
+        return value
+
     def _convert_dict_to_json_serializable(
         self, dict_: Dict[str, Any]
     ) -> Dict[str, Any]:
-        return {
-            key: value
-            if not isinstance(value, BaseModel)
-            else value.dict(by_alias=True)
-            for key, value in dict_.items()
-        }
+        return {key: self._convert_value(value) for key, value in dict_.items()}

--- a/tests/client_generators/dependencies/test_base_client.py
+++ b/tests/client_generators/dependencies/test_base_client.py
@@ -63,6 +63,40 @@ def test_execute_parses_pydantic_variables_before_sending(mocker):
     }
 
 
+def test_execute_correctly_parses_top_level_list_variables(mocker):
+    class TestModel1(BaseModel):
+        a: int
+
+    fake_client = mocker.MagicMock()
+    client = BaseClient(url="base_url", http_client=fake_client)
+    query_str = """
+    query Abc($v1: [[TestModel1!]!]!) {
+        abc(v1: $v1){
+            field1
+        }
+    }
+    """
+
+    client.execute(
+        query_str,
+        {
+            "v1": [[TestModel1(a=1), TestModel1(a=2)]],
+        },
+    )
+
+    assert fake_client.post.called
+    assert len(fake_client.post.mock_calls) == 1
+    call_kwargs = fake_client.post.mock_calls[0].kwargs
+    assert call_kwargs["url"] == "base_url"
+    assert call_kwargs["json"] == {
+        "query": query_str,
+        "variables": {"v1": [[{"a": 1}, {"a": 2}]]},
+    }
+    assert not any(
+        isinstance(x, BaseModel) for x in call_kwargs["json"]["variables"]["v1"][0]
+    )
+
+
 @pytest.mark.parametrize(
     "status_code, response_content",
     [

--- a/tests/main/clients/custom_config_file/expected_client/async_base_client.py
+++ b/tests/main/clients/custom_config_file/expected_client/async_base_client.py
@@ -69,12 +69,14 @@ class AsyncBaseClient:
 
         return cast(dict[str, Any], data)
 
+    def _convert_value(self, value: Any) -> Any:
+        if isinstance(value, BaseModel):
+            return value.dict(by_alias=True)
+        if isinstance(value, list):
+            return [self._convert_value(item) for item in value]
+        return value
+
     def _convert_dict_to_json_serializable(
         self, dict_: Dict[str, Any]
     ) -> Dict[str, Any]:
-        return {
-            key: value
-            if not isinstance(value, BaseModel)
-            else value.dict(by_alias=True)
-            for key, value in dict_.items()
-        }
+        return {key: self._convert_value(value) for key, value in dict_.items()}

--- a/tests/main/clients/custom_files_names/expected_client/async_base_client.py
+++ b/tests/main/clients/custom_files_names/expected_client/async_base_client.py
@@ -69,12 +69,14 @@ class AsyncBaseClient:
 
         return cast(dict[str, Any], data)
 
+    def _convert_value(self, value: Any) -> Any:
+        if isinstance(value, BaseModel):
+            return value.dict(by_alias=True)
+        if isinstance(value, list):
+            return [self._convert_value(item) for item in value]
+        return value
+
     def _convert_dict_to_json_serializable(
         self, dict_: Dict[str, Any]
     ) -> Dict[str, Any]:
-        return {
-            key: value
-            if not isinstance(value, BaseModel)
-            else value.dict(by_alias=True)
-            for key, value in dict_.items()
-        }
+        return {key: self._convert_value(value) for key, value in dict_.items()}

--- a/tests/main/clients/custom_scalars/expected_client/async_base_client.py
+++ b/tests/main/clients/custom_scalars/expected_client/async_base_client.py
@@ -69,12 +69,14 @@ class AsyncBaseClient:
 
         return cast(dict[str, Any], data)
 
+    def _convert_value(self, value: Any) -> Any:
+        if isinstance(value, BaseModel):
+            return value.dict(by_alias=True)
+        if isinstance(value, list):
+            return [self._convert_value(item) for item in value]
+        return value
+
     def _convert_dict_to_json_serializable(
         self, dict_: Dict[str, Any]
     ) -> Dict[str, Any]:
-        return {
-            key: value
-            if not isinstance(value, BaseModel)
-            else value.dict(by_alias=True)
-            for key, value in dict_.items()
-        }
+        return {key: self._convert_value(value) for key, value in dict_.items()}

--- a/tests/main/clients/example/expected_client/async_base_client.py
+++ b/tests/main/clients/example/expected_client/async_base_client.py
@@ -69,12 +69,14 @@ class AsyncBaseClient:
 
         return cast(dict[str, Any], data)
 
+    def _convert_value(self, value: Any) -> Any:
+        if isinstance(value, BaseModel):
+            return value.dict(by_alias=True)
+        if isinstance(value, list):
+            return [self._convert_value(item) for item in value]
+        return value
+
     def _convert_dict_to_json_serializable(
         self, dict_: Dict[str, Any]
     ) -> Dict[str, Any]:
-        return {
-            key: value
-            if not isinstance(value, BaseModel)
-            else value.dict(by_alias=True)
-            for key, value in dict_.items()
-        }
+        return {key: self._convert_value(value) for key, value in dict_.items()}

--- a/tests/main/clients/extended_models/expected_client/async_base_client.py
+++ b/tests/main/clients/extended_models/expected_client/async_base_client.py
@@ -69,12 +69,14 @@ class AsyncBaseClient:
 
         return cast(dict[str, Any], data)
 
+    def _convert_value(self, value: Any) -> Any:
+        if isinstance(value, BaseModel):
+            return value.dict(by_alias=True)
+        if isinstance(value, list):
+            return [self._convert_value(item) for item in value]
+        return value
+
     def _convert_dict_to_json_serializable(
         self, dict_: Dict[str, Any]
     ) -> Dict[str, Any]:
-        return {
-            key: value
-            if not isinstance(value, BaseModel)
-            else value.dict(by_alias=True)
-            for key, value in dict_.items()
-        }
+        return {key: self._convert_value(value) for key, value in dict_.items()}

--- a/tests/main/clients/inline_fragments/expected_client/async_base_client.py
+++ b/tests/main/clients/inline_fragments/expected_client/async_base_client.py
@@ -69,12 +69,14 @@ class AsyncBaseClient:
 
         return cast(dict[str, Any], data)
 
+    def _convert_value(self, value: Any) -> Any:
+        if isinstance(value, BaseModel):
+            return value.dict(by_alias=True)
+        if isinstance(value, list):
+            return [self._convert_value(item) for item in value]
+        return value
+
     def _convert_dict_to_json_serializable(
         self, dict_: Dict[str, Any]
     ) -> Dict[str, Any]:
-        return {
-            key: value
-            if not isinstance(value, BaseModel)
-            else value.dict(by_alias=True)
-            for key, value in dict_.items()
-        }
+        return {key: self._convert_value(value) for key, value in dict_.items()}

--- a/tests/main/clients/remote_schema/expected_client/async_base_client.py
+++ b/tests/main/clients/remote_schema/expected_client/async_base_client.py
@@ -69,12 +69,14 @@ class AsyncBaseClient:
 
         return cast(dict[str, Any], data)
 
+    def _convert_value(self, value: Any) -> Any:
+        if isinstance(value, BaseModel):
+            return value.dict(by_alias=True)
+        if isinstance(value, list):
+            return [self._convert_value(item) for item in value]
+        return value
+
     def _convert_dict_to_json_serializable(
         self, dict_: Dict[str, Any]
     ) -> Dict[str, Any]:
-        return {
-            key: value
-            if not isinstance(value, BaseModel)
-            else value.dict(by_alias=True)
-            for key, value in dict_.items()
-        }
+        return {key: self._convert_value(value) for key, value in dict_.items()}


### PR DESCRIPTION
Fixes issue described in #114.

Uses remap from the boltons package (https://boltons.readthedocs.io/en/latest/iterutils.html#boltons.iterutils.remap) to iterate over the dictionary of variables and recursively look into lists to call `dict()` on each model within each list.

Also removes `None`s from the dictionary to handle optional inputs.