### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing
+
+Thank you for your interest in contributing to Ariadne Code Generator!
+
+We welcome bug reports, questions, pull requests, and general feedback.
+
+We also ask all contributors to familiarize themselves with and follow code of conduct, available in the [CODE_OF_CONDUCT.md](https://github.com/mirumee/ariadne/blob/master/CODE_OF_CONDUCT.md) file kept in the main project's repository.
+
+
+# Reporting bugs, asking for help, offering feedback and ideas
+
+You can use [GitHub issues](https://github.com/mirumee/ariadne-codegen/issues) to report bugs, ask for help, share your ideas, or simply offer feedback. We are curious what you think of Ariadne!
+
+
+## Development setup
+
+Ariadne Code Generator is written to support Python 3.9, 3.10 and 3.11.
+
+Codebase is formatted using [black](https://github.com/ambv/black) and [isort](https://github.com/PyCQA/isort), the contents of the `ariadne-codegen` package are annotated with types and validated using [mypy](http://mypy-lang.org/index.html). [Pylint](https://github.com/pylint-dev/pylint) is used to catch errors in code.
+
+Tests are developed using [pytest](https://pytest.org/).
+
+Dev requirements can be installed using Pip extras. For example, to install all dependencies for doing local development and running the tests, run `pip install -e .[dev]`.
+
+We require all changes to be done via pull requests, and to be approved by member-ranked users before merging.
+
+All changes should pass these linter checks:
+
+```bash
+pylint ariadne_codegen tests
+mypy ariadne_codegen --ignore-missing-imports
+mypy --strict tests/main/clients/*/expected_client
+mypy --strict tests/main/graphql_schemas/*/expected_schema.py
+black --check .
+isort . --check-only
+```
+
+
+## Working on issues
+
+We consider all issues which are not assigned to anybody as being available for contributors. The **[help wanted](https://github.com/mirumee/ariadne-codegen/labels/help%20wanted)** label is used to single out issues that we consider easier or higher priority on the list of things that we would like to see.
+
+If you've found issue you want to help with, please add your comment to it - this lets other contributors know what issues are being worked on, as well as allowing maintainers to offer guidance and help.
+
+
+## Pull requests
+
+We don't require pull requests to be followed with bug reports. If you've found a typo or a silly little bug that has no issue or pull request already, you can open your own pull request. We only ask that this PR provides context or explanation for what problem it fixes, or which area of the project it improves.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thank you for your interest in contributing to Ariadne Code Generator!
+Thank you for your interest in contributing to Ariadne Codegen!
 
 We welcome bug reports, questions, pull requests, and general feedback.
 

--- a/README.md
+++ b/README.md
@@ -238,6 +238,8 @@ Generated file contains:
 
 We welcome all contributions to Ariadne! If you've found a bug or issue, feel free to use [GitHub issues](https://github.com/mirumee/ariadne-codegen/issues). If you have any questions or feedback, don't hesitate to catch us on [GitHub discussions](https://github.com/mirumee/ariadne/discussions/).
 
+For guidance and instructions, please see [CONTRIBUTING.md](CONTRIBUTING.md).
+
 Also make sure you follow [@AriadneGraphQL](https://twitter.com/AriadneGraphQL) on Twitter for latest updates, news and random musings!
 
 


### PR DESCRIPTION
resolves #118
This pr adds `CONTRIBUTING.md` file, which is mostly the same as the file in the [main repo](https://github.com/mirumee/ariadne/blob/master/CODE_OF_CONDUCT.md). I changed urls to point to this repo's issues and  added repo-specific info to `## Development setup` secton.