### PR TITLE
Add process_name hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added escaping of GraphQL names which are Python keywords by appending `_` to them.
 - Fixed parsing of list variables.
 - Changed base clients to remove unset arguments and input fields from variables payload.
+- Added `process_name` plugin hook.
 
 
 ## 0.5.0 (2023-04-05)

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -287,7 +287,7 @@ Hook executed on generation of init code. Result is used as content of `__init__
 ### process_name
 
 ```py
-def process_name(self, name: str) -> str:
+def process_name(self, name: str, node: Optional[Node] = None) -> str:
 ```
 
 Hook executed on processing of GraphQL field, argument or operation name.

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -284,6 +284,14 @@ def generate_init_code(self, generated_code: str) -> str:
 
 Hook executed on generation of init code. Result is used as content of `__init__.py`.
 
+### process_name
+
+```py
+def process_name(self, name: str) -> str:
+```
+
+Hook executed on processing of GraphQL field, argument or operation name.
+
 
 ## Example
 
@@ -298,7 +306,7 @@ from ariadne_codegen.plugins.base import Plugin
 class VersionPlugin(Plugin):
     def generate_init_module(self, module: ast.Module) -> ast.Module:
         version = (
-            self.config_dict.get("tools", {})
+            self.config_dict.get("tool", {})
             .get("version_plugin", {})
             .get("version", "0.1")
         )

--- a/ariadne_codegen/client_generators/arguments.py
+++ b/ariadne_codegen/client_generators/arguments.py
@@ -62,6 +62,7 @@ class ArgumentsGenerator:
                 org_name,
                 convert_to_snake_case=self.convert_to_snake_case,
                 plugin_manager=self.plugin_manager,
+                node=variable_definition,
             )
             annotation, used_custom_scalar = self._parse_type_node(
                 variable_definition.type

--- a/ariadne_codegen/client_generators/arguments.py
+++ b/ariadne_codegen/client_generators/arguments.py
@@ -58,7 +58,11 @@ class ArgumentsGenerator:
         dict_ = generate_dict()
         for variable_definition in variable_definitions:
             org_name = variable_definition.variable.name.value
-            name = process_name(org_name, self.convert_to_snake_case)
+            name = process_name(
+                org_name,
+                convert_to_snake_case=self.convert_to_snake_case,
+                plugin_manager=self.plugin_manager,
+            )
             annotation, used_custom_scalar = self._parse_type_node(
                 variable_definition.type
             )

--- a/ariadne_codegen/client_generators/input_types.py
+++ b/ariadne_codegen/client_generators/input_types.py
@@ -113,6 +113,7 @@ class InputTypesGenerator:
                 org_name,
                 convert_to_snake_case=self.convert_to_snake_case,
                 plugin_manager=self.plugin_manager,
+                node=field,
             )
             annotation, field_type = parse_input_field_type(
                 field.type, custom_scalars=self.custom_scalars

--- a/ariadne_codegen/client_generators/input_types.py
+++ b/ariadne_codegen/client_generators/input_types.py
@@ -109,7 +109,11 @@ class InputTypesGenerator:
         )
 
         for lineno, (org_name, field) in enumerate(definition.fields.items(), start=1):
-            name = process_name(org_name, self.convert_to_snake_case)
+            name = process_name(
+                org_name,
+                convert_to_snake_case=self.convert_to_snake_case,
+                plugin_manager=self.plugin_manager,
+            )
             annotation, field_type = parse_input_field_type(
                 field.type, custom_scalars=self.custom_scalars
             )

--- a/ariadne_codegen/client_generators/package.py
+++ b/ariadne_codegen/client_generators/package.py
@@ -180,7 +180,9 @@ class PackageGenerator:
             raise ParsingError("Query without name.")
 
         return_type_name = str_to_pascal_case(name.value)
-        method_name = process_name(name.value, convert_to_snake_case=True)
+        method_name = process_name(
+            name.value, convert_to_snake_case=True, plugin_manager=self.plugin_manager
+        )
         module_name = method_name
         file_name = f"{module_name}.py"
 

--- a/ariadne_codegen/client_generators/package.py
+++ b/ariadne_codegen/client_generators/package.py
@@ -181,7 +181,10 @@ class PackageGenerator:
 
         return_type_name = str_to_pascal_case(name.value)
         method_name = process_name(
-            name.value, convert_to_snake_case=True, plugin_manager=self.plugin_manager
+            name.value,
+            convert_to_snake_case=True,
+            plugin_manager=self.plugin_manager,
+            node=definition,
         )
         module_name = method_name
         file_name = f"{module_name}.py"

--- a/ariadne_codegen/client_generators/result_types.py
+++ b/ariadne_codegen/client_generators/result_types.py
@@ -185,7 +185,7 @@ class ResultTypesGenerator:
             start=1,
         ):
             field_name = self._get_field_name(field)
-            name = self._process_field_name(field_name)
+            name = self._process_field_name(field_name, field=field)
             field_definition = self._get_field_from_schema(type_name, field.name.value)
             annotation, field_types_names = parse_operation_field(
                 field=field,
@@ -269,13 +269,14 @@ class ResultTypesGenerator:
             return field.alias.value
         return field.name.value
 
-    def _process_field_name(self, name: str) -> str:
+    def _process_field_name(self, name: str, field: FieldNode) -> str:
         if self.convert_to_snake_case and name == TYPENAME_FIELD_NAME:
             return "__typename__"
         return process_name(
             name,
             convert_to_snake_case=self.convert_to_snake_case,
             plugin_manager=self.plugin_manager,
+            node=field,
         )
 
     def _get_field_from_schema(self, type_name: str, field_name: str) -> GraphQLField:

--- a/ariadne_codegen/client_generators/result_types.py
+++ b/ariadne_codegen/client_generators/result_types.py
@@ -272,7 +272,11 @@ class ResultTypesGenerator:
     def _process_field_name(self, name: str) -> str:
         if self.convert_to_snake_case and name == TYPENAME_FIELD_NAME:
             return "__typename__"
-        return process_name(name, self.convert_to_snake_case)
+        return process_name(
+            name,
+            convert_to_snake_case=self.convert_to_snake_case,
+            plugin_manager=self.plugin_manager,
+        )
 
     def _get_field_from_schema(self, type_name: str, field_name: str) -> GraphQLField:
         try:

--- a/ariadne_codegen/plugins/base.py
+++ b/ariadne_codegen/plugins/base.py
@@ -144,3 +144,6 @@ class Plugin:
 
     def generate_init_code(self, generated_code: str) -> str:
         return generated_code
+
+    def process_name(self, name: str) -> str:
+        return name

--- a/ariadne_codegen/plugins/base.py
+++ b/ariadne_codegen/plugins/base.py
@@ -1,5 +1,5 @@
 import ast
-from typing import Dict, Tuple, Union
+from typing import Dict, Optional, Tuple, Union
 
 from graphql import (
     FieldNode,
@@ -7,6 +7,7 @@ from graphql import (
     GraphQLInputField,
     GraphQLInputObjectType,
     GraphQLSchema,
+    Node,
     OperationDefinitionNode,
     SelectionSetNode,
     VariableDefinitionNode,
@@ -145,5 +146,6 @@ class Plugin:
     def generate_init_code(self, generated_code: str) -> str:
         return generated_code
 
-    def process_name(self, name: str) -> str:
+    # pylint: disable=unused-argument
+    def process_name(self, name: str, node: Optional[Node] = None) -> str:
         return name

--- a/ariadne_codegen/plugins/manager.py
+++ b/ariadne_codegen/plugins/manager.py
@@ -7,6 +7,7 @@ from graphql import (
     GraphQLInputField,
     GraphQLInputObjectType,
     GraphQLSchema,
+    Node,
     OperationDefinitionNode,
     SelectionSetNode,
     VariableDefinitionNode,
@@ -187,5 +188,5 @@ class PluginManager:
     def generate_init_code(self, generated_code: str) -> str:
         return self._apply_plugins_on_object("generate_init_code", generated_code)
 
-    def process_name(self, name: str) -> str:
-        return self._apply_plugins_on_object("process_name", name)
+    def process_name(self, name: str, node: Optional[Node] = None) -> str:
+        return self._apply_plugins_on_object("process_name", name, node=node)

--- a/ariadne_codegen/plugins/manager.py
+++ b/ariadne_codegen/plugins/manager.py
@@ -186,3 +186,6 @@ class PluginManager:
 
     def generate_init_code(self, generated_code: str) -> str:
         return self._apply_plugins_on_object("generate_init_code", generated_code)
+
+    def process_name(self, name: str) -> str:
+        return self._apply_plugins_on_object("process_name", name)

--- a/ariadne_codegen/utils.py
+++ b/ariadne_codegen/utils.py
@@ -2,10 +2,12 @@ import ast
 import re
 from keyword import iskeyword
 from textwrap import indent
+from typing import Optional
 
 import isort
 from autoflake import fix_code  # type: ignore
 from black import Mode, format_str
+from .plugins.manager import PluginManager
 
 
 def ast_to_str(
@@ -73,7 +75,11 @@ def format_multiline_strings(source: str) -> str:
     return formatted_source
 
 
-def process_name(name: str, convert_to_snake_case: bool) -> str:
+def process_name(
+    name: str,
+    convert_to_snake_case: bool,
+    plugin_manager: Optional[PluginManager] = None,
+) -> str:
     """Processes the GraphQL name to remove keywords
     and optionally convert to snake_case."""
     processed_name = name
@@ -81,4 +87,6 @@ def process_name(name: str, convert_to_snake_case: bool) -> str:
         processed_name = str_to_snake_case(processed_name)
     if iskeyword(processed_name):
         processed_name += "_"
+    if plugin_manager:
+        processed_name = plugin_manager.process_name(processed_name)
     return processed_name

--- a/ariadne_codegen/utils.py
+++ b/ariadne_codegen/utils.py
@@ -7,6 +7,7 @@ from typing import Optional
 import isort
 from autoflake import fix_code  # type: ignore
 from black import Mode, format_str
+
 from .plugins.manager import PluginManager
 
 

--- a/ariadne_codegen/utils.py
+++ b/ariadne_codegen/utils.py
@@ -7,6 +7,7 @@ from typing import Optional
 import isort
 from autoflake import fix_code  # type: ignore
 from black import Mode, format_str
+from graphql import Node
 
 from .plugins.manager import PluginManager
 
@@ -80,6 +81,7 @@ def process_name(
     name: str,
     convert_to_snake_case: bool,
     plugin_manager: Optional[PluginManager] = None,
+    node: Optional[Node] = None,
 ) -> str:
     """Processes the GraphQL name to remove keywords
     and optionally convert to snake_case."""
@@ -89,5 +91,5 @@ def process_name(
     if iskeyword(processed_name):
         processed_name += "_"
     if plugin_manager:
-        processed_name = plugin_manager.process_name(processed_name)
+        processed_name = plugin_manager.process_name(processed_name, node=node)
     return processed_name

--- a/tests/client_generators/input_types_generator/test_plugin_hooks.py
+++ b/tests/client_generators/input_types_generator/test_plugin_hooks.py
@@ -9,7 +9,9 @@ from graphql import (
 from ariadne_codegen.client_generators.input_types import InputTypesGenerator
 
 
-def test_generator_triggers_generate_input_class_hook_for_every_input_type(mocker):
+def test_generator_triggers_generate_input_class_hook_for_every_input_type(
+    mocked_plugin_manager,
+):
     schema_str = """
     input TestInputA {
         fieldA: String!
@@ -19,7 +21,6 @@ def test_generator_triggers_generate_input_class_hook_for_every_input_type(mocke
         fieldB: Int!
     }
     """
-    mocked_plugin_manager = mocker.MagicMock()
 
     InputTypesGenerator(
         schema=build_ast_schema(parse(schema_str)),
@@ -37,7 +38,9 @@ def test_generator_triggers_generate_input_class_hook_for_every_input_type(mocke
     assert call1_input_type.name == "TestInputB"
 
 
-def test_generator_triggers_generate_input_field_hook_for_every_input_field(mocker):
+def test_generator_triggers_generate_input_field_hook_for_every_input_field(
+    mocked_plugin_manager,
+):
     schema_str = """
     input TestInputAB {
         fieldA: String!
@@ -48,7 +51,6 @@ def test_generator_triggers_generate_input_field_hook_for_every_input_field(mock
         fieldC: Int!
     }
     """
-    mocked_plugin_manager = mocker.MagicMock()
 
     InputTypesGenerator(
         schema=build_ast_schema(parse(schema_str)),
@@ -66,8 +68,7 @@ def test_generator_triggers_generate_input_field_hook_for_every_input_field(mock
     assert mock_calls[2].kwargs["field_name"] == "fieldC"
 
 
-def test_generate_triggers_generate_inputs_module_hook(mocker):
-    mocked_plugin_manager = mocker.MagicMock()
+def test_generate_triggers_generate_inputs_module_hook(mocked_plugin_manager):
     generator = InputTypesGenerator(
         schema=GraphQLSchema(),
         enums_module="enums",

--- a/tests/client_generators/input_types_generator/test_plugin_hooks.py
+++ b/tests/client_generators/input_types_generator/test_plugin_hooks.py
@@ -78,3 +78,27 @@ def test_generate_triggers_generate_inputs_module_hook(mocked_plugin_manager):
     generator.generate()
 
     assert mocked_plugin_manager.generate_inputs_module.called
+
+
+def test_generate_triggers_process_name_hook_for_every_field(mocked_plugin_manager):
+    schema_str = """
+    input TestInputAB {
+        fieldA: String!
+        fieldB: String!
+    }
+
+    input TestInputC {
+        fieldC: Int!
+    }
+    """
+
+    InputTypesGenerator(
+        schema=build_ast_schema(parse(schema_str)),
+        enums_module="enums",
+        convert_to_snake_case=False,
+        plugin_manager=mocked_plugin_manager,
+    )
+
+    assert mocked_plugin_manager.process_name.call_count == 3
+    mock_calls = mocked_plugin_manager.process_name.mock_calls
+    assert {call.args[0] for call in mock_calls} == {"fieldA", "fieldB", "fieldC"}

--- a/tests/client_generators/result_types_generator/test_plugin_hooks.py
+++ b/tests/client_generators/result_types_generator/test_plugin_hooks.py
@@ -89,3 +89,34 @@ def test_generator_triggers_generate_result_field_hook_for_every_field(
         c.kwargs["field"].name.value
         for c in mocked_plugin_manager.generate_result_field.mock_calls
     } == {"camelCaseQuery", "id", "field1", "fielda"}
+
+
+def test_generator_triggers_process_name_hook_for_every_field(mocked_plugin_manager):
+    query_str = """
+    query CustomQuery {
+        camelCaseQuery {
+            id
+            field1 {
+                fielda
+            }
+        }
+    }
+    """
+
+    ResultTypesGenerator(
+        schema=build_ast_schema(parse(SCHEMA_STR)),
+        operation_definition=cast(
+            OperationDefinitionNode, parse(query_str).definitions[0]
+        ),
+        enums_module_name="enums",
+        convert_to_snake_case=False,
+        plugin_manager=mocked_plugin_manager,
+    )
+
+    assert mocked_plugin_manager.process_name.call_count == 4
+    assert {c.args[0] for c in mocked_plugin_manager.process_name.mock_calls} == {
+        "camelCaseQuery",
+        "id",
+        "field1",
+        "fielda",
+    }

--- a/tests/client_generators/result_types_generator/test_plugin_hooks.py
+++ b/tests/client_generators/result_types_generator/test_plugin_hooks.py
@@ -7,9 +7,8 @@ from ariadne_codegen.client_generators.result_types import ResultTypesGenerator
 from .schema import SCHEMA_STR
 
 
-def test_generate_triggers_generate_result_types_module_hook(mocker):
+def test_generate_triggers_generate_result_types_module_hook(mocked_plugin_manager):
     query_str = "query CustomQuery { camelCaseQuery { id } }"
-    mocked_plugin_manager = mocker.MagicMock()
     generator = ResultTypesGenerator(
         schema=build_ast_schema(parse(SCHEMA_STR)),
         operation_definition=cast(
@@ -24,9 +23,10 @@ def test_generate_triggers_generate_result_types_module_hook(mocker):
     assert mocked_plugin_manager.generate_result_types_module.called
 
 
-def test_get_operation_as_str_triggers_generate_operation_str_hook(mocker):
+def test_get_operation_as_str_triggers_generate_operation_str_hook(
+    mocked_plugin_manager,
+):
     query_str = "query CustomQuery { camelCaseQuery { id } }"
-    mocked_plugin_manager = mocker.MagicMock()
     generator = ResultTypesGenerator(
         schema=build_ast_schema(parse(SCHEMA_STR)),
         operation_definition=cast(
@@ -41,9 +41,10 @@ def test_get_operation_as_str_triggers_generate_operation_str_hook(mocker):
     assert mocked_plugin_manager.generate_operation_str.called
 
 
-def test_generator_triggers_generate_result_class_hook_for_every_class(mocker):
+def test_generator_triggers_generate_result_class_hook_for_every_class(
+    mocked_plugin_manager,
+):
     query_str = "query CustomQuery { camelCaseQuery { id } }"
-    mocked_plugin_manager = mocker.MagicMock()
 
     ResultTypesGenerator(
         schema=build_ast_schema(parse(SCHEMA_STR)),
@@ -60,7 +61,9 @@ def test_generator_triggers_generate_result_class_hook_for_every_class(mocker):
     } == {"CustomQuery", "CustomQueryCamelCaseQuery"}
 
 
-def test_generator_triggers_generate_result_field_hook_for_every_field(mocker):
+def test_generator_triggers_generate_result_field_hook_for_every_field(
+    mocked_plugin_manager,
+):
     query_str = """
     query CustomQuery {
         camelCaseQuery {
@@ -71,7 +74,6 @@ def test_generator_triggers_generate_result_field_hook_for_every_field(mocker):
         }
     }
     """
-    mocked_plugin_manager = mocker.MagicMock()
 
     ResultTypesGenerator(
         schema=build_ast_schema(parse(SCHEMA_STR)),

--- a/tests/client_generators/test_arguments_generator.py
+++ b/tests/client_generators/test_arguments_generator.py
@@ -320,8 +320,7 @@ def test_generate_returns_arguments_with_custom_scalar_and_used_serialize_method
     assert compare_ast(arguments_dict, expected_arguments_dict)
 
 
-def test_generate_triggers_generate_arguments_hook(mocker):
-    mocked_plugin_manager = mocker.MagicMock()
+def test_generate_triggers_generate_arguments_hook(mocked_plugin_manager):
     schema_str = """
         schema { query: Query }
         type Query { _skip: String! }
@@ -337,8 +336,7 @@ def test_generate_triggers_generate_arguments_hook(mocker):
     assert mocked_plugin_manager.generate_arguments.called
 
 
-def test_generate_triggers_generate_arguments_dict_hook(mocker):
-    mocked_plugin_manager = mocker.MagicMock()
+def test_generate_triggers_generate_arguments_dict_hook(mocked_plugin_manager):
     schema_str = """
         schema { query: Query }
         type Query { _skip: String! }

--- a/tests/client_generators/test_arguments_generator.py
+++ b/tests/client_generators/test_arguments_generator.py
@@ -350,3 +350,25 @@ def test_generate_triggers_generate_arguments_dict_hook(mocked_plugin_manager):
     )
 
     assert mocked_plugin_manager.generate_arguments_dict.called
+
+
+def test_generate_triggers_process_name_hook_for_every_arg(mocked_plugin_manager):
+    schema_str = """
+        schema { query: Query }
+        type Query { _skip: String! }
+        """
+    generator = ArgumentsGenerator(
+        schema=build_schema(schema_str), plugin_manager=mocked_plugin_manager
+    )
+
+    generator.generate(
+        _get_variable_definitions_from_query_str(
+            "query q($arg1: String!, $arg2: String) { _skip }"
+        )
+    )
+
+    assert mocked_plugin_manager.process_name.call_count == 2
+    name1 = mocked_plugin_manager.process_name.mock_calls[0].args[0]
+    name2 = mocked_plugin_manager.process_name.mock_calls[1].args[0]
+    assert name1 == "arg1"
+    assert name2 == "arg2"

--- a/tests/client_generators/test_client_generator.py
+++ b/tests/client_generators/test_client_generator.py
@@ -73,8 +73,7 @@ def test_generate_returns_module_with_gql_lambda_definition():
     assert compare_ast(assign, expected_def)
 
 
-def test_generate_triggers_generate_gql_function_hook(mocker):
-    mocked_plugin_manager = mocker.MagicMock()
+def test_generate_triggers_generate_gql_function_hook(mocked_plugin_manager):
     generator = ClientGenerator(
         "ClientXYZ",
         base_client="BaseClient",
@@ -92,8 +91,7 @@ def test_generate_triggers_generate_gql_function_hook(mocker):
     assert mocked_plugin_manager.generate_gql_function.called
 
 
-def test_generate_triggers_generate_client_class_hook(mocker):
-    mocked_plugin_manager = mocker.MagicMock()
+def test_generate_triggers_generate_client_class_hook(mocked_plugin_manager):
     generator = ClientGenerator(
         "ClientXYZ",
         base_client="BaseClient",
@@ -110,8 +108,7 @@ def test_generate_triggers_generate_client_class_hook(mocker):
     assert mocked_plugin_manager.generate_client_class.called
 
 
-def test_generate_triggers_generate_client_module_hook(mocker):
-    mocked_plugin_manager = mocker.MagicMock()
+def test_generate_triggers_generate_client_module_hook(mocked_plugin_manager):
     generator = ClientGenerator(
         "ClientXYZ",
         base_client="BaseClient",
@@ -490,8 +487,7 @@ def test_add_method_generates_correct_method_body():
     assert compare_ast(method_def.body, expected_method_body)
 
 
-def test_add_method_triggers_generate_client_method_hook(mocker):
-    mocked_plugin_manager = mocker.MagicMock()
+def test_add_method_triggers_generate_client_method_hook(mocked_plugin_manager):
     schema_str = """
     schema { query: Query }
     type Query { xyz(arg1: Int!): TestType }

--- a/tests/client_generators/test_enums_generator.py
+++ b/tests/client_generators/test_enums_generator.py
@@ -131,8 +131,7 @@ def test_generate_returns_module_with_enum_class_definition_for_every_enum():
     assert compare_ast(class_defs, expected_class_defs)
 
 
-def test_generate_triggers_generate_enums_module_hook(mocker):
-    mocked_plugin_manager = mocker.MagicMock()
+def test_generate_triggers_generate_enums_module_hook(mocked_plugin_manager):
     generator = EnumsGenerator(
         schema=GraphQLSchema(), plugin_manager=mocked_plugin_manager
     )
@@ -142,8 +141,9 @@ def test_generate_triggers_generate_enums_module_hook(mocker):
     assert mocked_plugin_manager.generate_enums_module.called
 
 
-def test_generate_triggers_generate_enum_hook_for_every_definition(mocker):
-    mocked_plugin_manager = mocker.MagicMock()
+def test_generate_triggers_generate_enum_hook_for_every_definition(
+    mocked_plugin_manager,
+):
     schema_str = """
     enum TestEnumAB {
         A

--- a/tests/client_generators/test_init_file_generator.py
+++ b/tests/client_generators/test_init_file_generator.py
@@ -20,8 +20,7 @@ def test_add_import_adds_correct_objects_to_list():
     assert import_.level == 1
 
 
-def test_add_import_triggers_generate_init_import_hook_method(mocker):
-    mocked_plugin_manager = mocker.MagicMock()
+def test_add_import_triggers_generate_init_import_hook_method(mocked_plugin_manager):
     generator = InitFileGenerator(plugin_manager=mocked_plugin_manager)
 
     generator.add_import(names=["TestClass"], from_="test", level=1)
@@ -64,8 +63,9 @@ def test_generate_with_added_imports_returns_module():
     assert [c.value for c in assign_stmt.value.elts] == [name1, name2]
 
 
-def test_generate_triggers_generate_init_module_from_plugin_manager(mocker):
-    mocked_plugin_manager = mocker.MagicMock()
+def test_generate_triggers_generate_init_module_from_plugin_manager(
+    mocked_plugin_manager,
+):
     generator = InitFileGenerator(plugin_manager=mocked_plugin_manager)
 
     generator.generate()

--- a/tests/client_generators/test_package_generator.py
+++ b/tests/client_generators/test_package_generator.py
@@ -52,19 +52,6 @@ scalar SCALARABC
 """
 
 
-@pytest.fixture
-def mocked_plugin_manager(mocker):
-    manager = mocker.MagicMock()
-    manager.generate_client_code.return_value = ""
-    manager.generate_enums_code.return_value = ""
-    manager.generate_inputs_code.return_value = ""
-    manager.generate_result_types_code.return_value = ""
-    manager.copy_code.return_value = ""
-    manager.generate_scalars_code.return_value = ""
-    manager.generate_init_code.return_value = ""
-    return manager
-
-
 def test_generate_creates_directory_and_files(tmp_path):
     package_name = "test_graphql_client"
     generator = PackageGenerator(package_name, tmp_path.as_posix(), GraphQLSchema())

--- a/tests/client_generators/test_package_generator.py
+++ b/tests/client_generators/test_package_generator.py
@@ -656,3 +656,24 @@ def test_generate_triggers_generate_init_code_hook(mocked_plugin_manager, tmp_pa
     ).generate()
 
     assert mocked_plugin_manager.generate_init_code.called
+
+
+def test_add_operation_triggers_process_name_hook(mocked_plugin_manager, tmp_path):
+    query_str = """
+    query custom_query_name {
+        query2 {
+            id
+        }
+    }
+    """
+    PackageGenerator(
+        "package_name",
+        tmp_path.as_posix(),
+        build_ast_schema(parse(SCHEMA_STR)),
+        plugin_manager=mocked_plugin_manager,
+    ).add_operation(parse(query_str).definitions[0])
+
+    assert mocked_plugin_manager.process_name.called
+    assert "custom_query_name" in {
+        c.args[0] for c in mocked_plugin_manager.process_name.mock_calls
+    }

--- a/tests/client_generators/test_scalars.py
+++ b/tests/client_generators/test_scalars.py
@@ -255,25 +255,19 @@ def test_generate_returns_module_with_dictionaries_with_scalars_methods():
     assert compare_ast(module, expected_module)
 
 
-def test_generate_triggers_generate_scalars_module_hook(mocker):
-    mocked_plugin_manager = mocker.MagicMock()
-
+def test_generate_triggers_generate_scalars_module_hook(mocked_plugin_manager):
     ScalarsDefinitionsGenerator(plugin_manager=mocked_plugin_manager).generate()
 
     assert mocked_plugin_manager.generate_scalars_module.called
 
 
-def test_generate_triggers_generate_scalars_parse_dict_hook(mocker):
-    mocked_plugin_manager = mocker.MagicMock()
-
+def test_generate_triggers_generate_scalars_parse_dict_hook(mocked_plugin_manager):
     ScalarsDefinitionsGenerator(plugin_manager=mocked_plugin_manager).generate()
 
     assert mocked_plugin_manager.generate_scalars_parse_dict.called
 
 
-def test_generate_triggers_generate_scalars_serialize_dict_hook(mocker):
-    mocked_plugin_manager = mocker.MagicMock()
-
+def test_generate_triggers_generate_scalars_serialize_dict_hook(mocked_plugin_manager):
     ScalarsDefinitionsGenerator(plugin_manager=mocked_plugin_manager).generate()
 
     assert mocked_plugin_manager.generate_scalars_serialize_dict.called

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import pytest
 
 @pytest.fixture
 def mocked_plugin_manager(mocker):
-    def no_effect_method(obj, *_):
+    def no_effect_method(obj, *_, **__):
         return obj
 
     manager = mocker.MagicMock()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+
+
+@pytest.fixture
+def mocked_plugin_manager(mocker):
+    def no_effect_method(obj, *_):
+        return obj
+
+    manager = mocker.MagicMock()
+    manager.generate_client_code.side_effect = no_effect_method
+    manager.generate_enums_code.side_effect = no_effect_method
+    manager.generate_inputs_code.side_effect = no_effect_method
+    manager.generate_result_types_code.side_effect = no_effect_method
+    manager.copy_code.side_effect = no_effect_method
+    manager.generate_scalars_code.side_effect = no_effect_method
+    manager.generate_init_code.side_effect = no_effect_method
+    manager.process_name.side_effect = no_effect_method
+    return manager

--- a/tests/plugins/test_manager.py
+++ b/tests/plugins/test_manager.py
@@ -323,3 +323,10 @@ def test_generate_init_code_calls_plugins_generate_init_code(
 
     assert plugin_manager_with_mocked_plugins.plugins[0].generate_init_code.called
     assert plugin_manager_with_mocked_plugins.plugins[1].generate_init_code.called
+
+
+def test_process_name_calls_plugins_process_name(plugin_manager_with_mocked_plugins):
+    plugin_manager_with_mocked_plugins.process_name("")
+
+    assert plugin_manager_with_mocked_plugins.plugins[0].process_name.called
+    assert plugin_manager_with_mocked_plugins.plugins[1].process_name.called

--- a/tests/plugins/test_manager.py
+++ b/tests/plugins/test_manager.py
@@ -19,7 +19,7 @@ from ariadne_codegen.plugins.manager import PluginManager
 
 
 @pytest.fixture
-def mocked_plugin_manager(mocker):
+def plugin_manager_with_mocked_plugins(mocker):
     return PluginManager(
         schema=GraphQLSchema(),
         plugins_types=[mocker.MagicMock(), mocker.MagicMock()],
@@ -36,264 +36,290 @@ def test_init_creates_plugins_instances():
     assert isinstance(manager.plugins[0], TestPlugin)
 
 
-def test_generate_init_module_calls_plugins_generate_init_module(mocked_plugin_manager):
-    mocked_plugin_manager.generate_init_module(ast.Module(body=[]))
+def test_generate_init_module_calls_plugins_generate_init_module(
+    plugin_manager_with_mocked_plugins,
+):
+    plugin_manager_with_mocked_plugins.generate_init_module(ast.Module(body=[]))
 
-    assert mocked_plugin_manager.plugins[0].generate_init_module.called
-    assert mocked_plugin_manager.plugins[1].generate_init_module.called
-
-
-def test_generate_init_import_calls_plugins_generate_init_import(mocked_plugin_manager):
-    mocked_plugin_manager.generate_init_import(ast.ImportFrom())
-
-    assert mocked_plugin_manager.plugins[0].generate_init_import.called
-    assert mocked_plugin_manager.plugins[1].generate_init_import.called
+    assert plugin_manager_with_mocked_plugins.plugins[0].generate_init_module.called
+    assert plugin_manager_with_mocked_plugins.plugins[1].generate_init_module.called
 
 
-def test_generate_enum_calls_plugins_generate_enum(mocked_plugin_manager):
-    mocked_plugin_manager.generate_enum(
+def test_generate_init_import_calls_plugins_generate_init_import(
+    plugin_manager_with_mocked_plugins,
+):
+    plugin_manager_with_mocked_plugins.generate_init_import(ast.ImportFrom())
+
+    assert plugin_manager_with_mocked_plugins.plugins[0].generate_init_import.called
+    assert plugin_manager_with_mocked_plugins.plugins[1].generate_init_import.called
+
+
+def test_generate_enum_calls_plugins_generate_enum(plugin_manager_with_mocked_plugins):
+    plugin_manager_with_mocked_plugins.generate_enum(
         ast.ClassDef(),
         enum_type=GraphQLEnumType("TestEnum", values=cast(GraphQLEnumValueMap, {})),
     )
 
-    assert mocked_plugin_manager.plugins[0].generate_enum.called
-    assert mocked_plugin_manager.plugins[1].generate_enum.called
+    assert plugin_manager_with_mocked_plugins.plugins[0].generate_enum.called
+    assert plugin_manager_with_mocked_plugins.plugins[1].generate_enum.called
 
 
 def test_generate_enums_module_calls_plugins_generate_enums_module(
-    mocked_plugin_manager,
+    plugin_manager_with_mocked_plugins,
 ):
-    mocked_plugin_manager.generate_enums_module(ast.Module())
+    plugin_manager_with_mocked_plugins.generate_enums_module(ast.Module())
 
-    assert mocked_plugin_manager.plugins[0].generate_enums_module.called
-    assert mocked_plugin_manager.plugins[1].generate_enums_module.called
+    assert plugin_manager_with_mocked_plugins.plugins[0].generate_enums_module.called
+    assert plugin_manager_with_mocked_plugins.plugins[1].generate_enums_module.called
 
 
 def test_generate_client_module_calls_plugins_generate_client_module(
-    mocked_plugin_manager,
+    plugin_manager_with_mocked_plugins,
 ):
-    mocked_plugin_manager.generate_client_module(ast.Module())
+    plugin_manager_with_mocked_plugins.generate_client_module(ast.Module())
 
-    assert mocked_plugin_manager.plugins[0].generate_client_module.called
-    assert mocked_plugin_manager.plugins[1].generate_client_module.called
+    assert plugin_manager_with_mocked_plugins.plugins[0].generate_client_module.called
+    assert plugin_manager_with_mocked_plugins.plugins[1].generate_client_module.called
 
 
 def test_generate_gql_function_calls_plugins_generate_gql_function(
-    mocked_plugin_manager,
+    plugin_manager_with_mocked_plugins,
 ):
-    mocked_plugin_manager.generate_gql_function(ast.FunctionDef())
+    plugin_manager_with_mocked_plugins.generate_gql_function(ast.FunctionDef())
 
-    assert mocked_plugin_manager.plugins[0].generate_gql_function.called
-    assert mocked_plugin_manager.plugins[1].generate_gql_function.called
+    assert plugin_manager_with_mocked_plugins.plugins[0].generate_gql_function.called
+    assert plugin_manager_with_mocked_plugins.plugins[1].generate_gql_function.called
 
 
 def test_generate_client_class_calls_plugins_generate_client_class(
-    mocked_plugin_manager,
+    plugin_manager_with_mocked_plugins,
 ):
-    mocked_plugin_manager.generate_client_class(ast.ClassDef())
+    plugin_manager_with_mocked_plugins.generate_client_class(ast.ClassDef())
 
-    assert mocked_plugin_manager.plugins[0].generate_client_class.called
-    assert mocked_plugin_manager.plugins[1].generate_client_class.called
+    assert plugin_manager_with_mocked_plugins.plugins[0].generate_client_class.called
+    assert plugin_manager_with_mocked_plugins.plugins[1].generate_client_class.called
 
 
 def test_generate_client_import_calls_plugins_generate_client_import(
-    mocked_plugin_manager,
+    plugin_manager_with_mocked_plugins,
 ):
-    mocked_plugin_manager.generate_client_import(ast.ImportFrom())
+    plugin_manager_with_mocked_plugins.generate_client_import(ast.ImportFrom())
 
-    assert mocked_plugin_manager.plugins[0].generate_client_import.called
-    assert mocked_plugin_manager.plugins[1].generate_client_import.called
+    assert plugin_manager_with_mocked_plugins.plugins[0].generate_client_import.called
+    assert plugin_manager_with_mocked_plugins.plugins[1].generate_client_import.called
 
 
 def test_generate_client_method_calls_plugins_generate_client_method(
-    mocked_plugin_manager,
+    plugin_manager_with_mocked_plugins,
 ):
-    mocked_plugin_manager.generate_client_method(ast.AsyncFunctionDef())
+    plugin_manager_with_mocked_plugins.generate_client_method(ast.AsyncFunctionDef())
 
-    assert mocked_plugin_manager.plugins[0].generate_client_method.called
-    assert mocked_plugin_manager.plugins[1].generate_client_method.called
+    assert plugin_manager_with_mocked_plugins.plugins[0].generate_client_method.called
+    assert plugin_manager_with_mocked_plugins.plugins[1].generate_client_method.called
 
 
 def test_generate_arguments_calls_plugins_generate_arguments(
-    mocked_plugin_manager,
+    plugin_manager_with_mocked_plugins,
 ):
-    mocked_plugin_manager.generate_arguments(
+    plugin_manager_with_mocked_plugins.generate_arguments(
         ast.arguments(), variable_definitions=(VariableDefinitionNode(),)
     )
 
-    assert mocked_plugin_manager.plugins[0].generate_arguments.called
-    assert mocked_plugin_manager.plugins[1].generate_arguments.called
+    assert plugin_manager_with_mocked_plugins.plugins[0].generate_arguments.called
+    assert plugin_manager_with_mocked_plugins.plugins[1].generate_arguments.called
 
 
 def test_generate_arguments_dict_calls_plugins_generate_arguments_dict(
-    mocked_plugin_manager,
+    plugin_manager_with_mocked_plugins,
 ):
-    mocked_plugin_manager.generate_arguments_dict(
+    plugin_manager_with_mocked_plugins.generate_arguments_dict(
         ast.Dict(), variable_definitions=(VariableDefinitionNode(),)
     )
 
-    assert mocked_plugin_manager.plugins[0].generate_arguments_dict.called
-    assert mocked_plugin_manager.plugins[1].generate_arguments_dict.called
+    assert plugin_manager_with_mocked_plugins.plugins[0].generate_arguments_dict.called
+    assert plugin_manager_with_mocked_plugins.plugins[1].generate_arguments_dict.called
 
 
 def test_generate_inputs_module_calls_plugins_generate_inputs_module(
-    mocked_plugin_manager,
+    plugin_manager_with_mocked_plugins,
 ):
-    mocked_plugin_manager.generate_inputs_module(ast.Module())
+    plugin_manager_with_mocked_plugins.generate_inputs_module(ast.Module())
 
-    assert mocked_plugin_manager.plugins[0].generate_inputs_module.called
-    assert mocked_plugin_manager.plugins[1].generate_inputs_module.called
+    assert plugin_manager_with_mocked_plugins.plugins[0].generate_inputs_module.called
+    assert plugin_manager_with_mocked_plugins.plugins[1].generate_inputs_module.called
 
 
-def test_generate_input_class_calls_plugins_generate_input_class(mocked_plugin_manager):
-    mocked_plugin_manager.generate_input_class(
+def test_generate_input_class_calls_plugins_generate_input_class(
+    plugin_manager_with_mocked_plugins,
+):
+    plugin_manager_with_mocked_plugins.generate_input_class(
         ast.ClassDef(), input_type=GraphQLInputObjectType("TestInput", fields={})
     )
 
-    assert mocked_plugin_manager.plugins[0].generate_input_class.called
-    assert mocked_plugin_manager.plugins[1].generate_input_class.called
+    assert plugin_manager_with_mocked_plugins.plugins[0].generate_input_class.called
+    assert plugin_manager_with_mocked_plugins.plugins[1].generate_input_class.called
 
 
-def test_generate_input_field_calls_plugins_generate_input_field(mocked_plugin_manager):
-    mocked_plugin_manager.generate_input_field(
+def test_generate_input_field_calls_plugins_generate_input_field(
+    plugin_manager_with_mocked_plugins,
+):
+    plugin_manager_with_mocked_plugins.generate_input_field(
         ast.AnnAssign(),
         input_field=GraphQLInputField(GraphQLInputObjectType("TestInput", fields={})),
         field_name="fieldA",
     )
 
-    assert mocked_plugin_manager.plugins[0].generate_input_field.called
-    assert mocked_plugin_manager.plugins[1].generate_input_field.called
+    assert plugin_manager_with_mocked_plugins.plugins[0].generate_input_field.called
+    assert plugin_manager_with_mocked_plugins.plugins[1].generate_input_field.called
 
 
 def test_generate_result_types_module_calls_plugins_generate_result_types_module(
-    mocked_plugin_manager,
+    plugin_manager_with_mocked_plugins,
 ):
-    mocked_plugin_manager.generate_result_types_module(
+    plugin_manager_with_mocked_plugins.generate_result_types_module(
         ast.Module(), operation_definition=OperationDefinitionNode()
     )
 
-    assert mocked_plugin_manager.plugins[0].generate_result_types_module.called
-    assert mocked_plugin_manager.plugins[1].generate_result_types_module.called
+    assert plugin_manager_with_mocked_plugins.plugins[
+        0
+    ].generate_result_types_module.called
+    assert plugin_manager_with_mocked_plugins.plugins[
+        1
+    ].generate_result_types_module.called
 
 
 def test_generate_operation_str_calls_plugins_generate_operation_str(
-    mocked_plugin_manager,
+    plugin_manager_with_mocked_plugins,
 ):
-    mocked_plugin_manager.generate_operation_str(
+    plugin_manager_with_mocked_plugins.generate_operation_str(
         "", operation_definition=OperationDefinitionNode()
     )
 
-    assert mocked_plugin_manager.plugins[0].generate_operation_str.called
-    assert mocked_plugin_manager.plugins[1].generate_operation_str.called
+    assert plugin_manager_with_mocked_plugins.plugins[0].generate_operation_str.called
+    assert plugin_manager_with_mocked_plugins.plugins[1].generate_operation_str.called
 
 
 def test_generate_result_class_calls_plugins_generate_result_class(
-    mocked_plugin_manager,
+    plugin_manager_with_mocked_plugins,
 ):
-    mocked_plugin_manager.generate_result_class(
+    plugin_manager_with_mocked_plugins.generate_result_class(
         ast.ClassDef(),
         operation_definition=OperationDefinitionNode(),
         selection_set=SelectionSetNode(),
     )
 
-    assert mocked_plugin_manager.plugins[0].generate_result_class.called
-    assert mocked_plugin_manager.plugins[1].generate_result_class.called
+    assert plugin_manager_with_mocked_plugins.plugins[0].generate_result_class.called
+    assert plugin_manager_with_mocked_plugins.plugins[1].generate_result_class.called
 
 
 def test_generate_result_field_calls_plugins_generate_result_field(
-    mocked_plugin_manager,
+    plugin_manager_with_mocked_plugins,
 ):
-    mocked_plugin_manager.generate_result_field(
+    plugin_manager_with_mocked_plugins.generate_result_field(
         ast.AnnAssign(),
         operation_definition=OperationDefinitionNode(),
         field=FieldNode(),
     )
 
-    assert mocked_plugin_manager.plugins[0].generate_result_field.called
-    assert mocked_plugin_manager.plugins[1].generate_result_field.called
+    assert plugin_manager_with_mocked_plugins.plugins[0].generate_result_field.called
+    assert plugin_manager_with_mocked_plugins.plugins[1].generate_result_field.called
 
 
 def test_generate_scalars_module_calls_plugins_generate_scalars_module(
-    mocked_plugin_manager,
+    plugin_manager_with_mocked_plugins,
 ):
-    mocked_plugin_manager.generate_scalars_module(ast.Module())
+    plugin_manager_with_mocked_plugins.generate_scalars_module(ast.Module())
 
-    assert mocked_plugin_manager.plugins[0].generate_scalars_module.called
-    assert mocked_plugin_manager.plugins[1].generate_scalars_module.called
+    assert plugin_manager_with_mocked_plugins.plugins[0].generate_scalars_module.called
+    assert plugin_manager_with_mocked_plugins.plugins[1].generate_scalars_module.called
 
 
 def test_generate_scalars_parse_dict_calls_plugins_generate_scalars_parse_dict(
-    mocked_plugin_manager,
+    plugin_manager_with_mocked_plugins,
 ):
-    mocked_plugin_manager.generate_scalars_parse_dict(ast.Dict())
+    plugin_manager_with_mocked_plugins.generate_scalars_parse_dict(ast.Dict())
 
-    assert mocked_plugin_manager.plugins[0].generate_scalars_parse_dict.called
-    assert mocked_plugin_manager.plugins[1].generate_scalars_parse_dict.called
+    assert plugin_manager_with_mocked_plugins.plugins[
+        0
+    ].generate_scalars_parse_dict.called
+    assert plugin_manager_with_mocked_plugins.plugins[
+        1
+    ].generate_scalars_parse_dict.called
 
 
 def test_generate_scalars_serialize_dict_calls_plugins_generate_scalars_serialize_dict(
-    mocked_plugin_manager,
+    plugin_manager_with_mocked_plugins,
 ):
-    mocked_plugin_manager.generate_scalars_serialize_dict(ast.Dict())
+    plugin_manager_with_mocked_plugins.generate_scalars_serialize_dict(ast.Dict())
 
-    assert mocked_plugin_manager.plugins[0].generate_scalars_serialize_dict.called
-    assert mocked_plugin_manager.plugins[1].generate_scalars_serialize_dict.called
+    assert plugin_manager_with_mocked_plugins.plugins[
+        0
+    ].generate_scalars_serialize_dict.called
+    assert plugin_manager_with_mocked_plugins.plugins[
+        1
+    ].generate_scalars_serialize_dict.called
 
 
 def test_generate_client_code_calls_plugins_generate_client_code(
-    mocked_plugin_manager,
+    plugin_manager_with_mocked_plugins,
 ):
-    mocked_plugin_manager.generate_client_code("")
+    plugin_manager_with_mocked_plugins.generate_client_code("")
 
-    assert mocked_plugin_manager.plugins[0].generate_client_code.called
-    assert mocked_plugin_manager.plugins[1].generate_client_code.called
+    assert plugin_manager_with_mocked_plugins.plugins[0].generate_client_code.called
+    assert plugin_manager_with_mocked_plugins.plugins[1].generate_client_code.called
 
 
 def test_generate_enums_code_calls_plugins_generate_enums_code(
-    mocked_plugin_manager,
+    plugin_manager_with_mocked_plugins,
 ):
-    mocked_plugin_manager.generate_enums_code("")
+    plugin_manager_with_mocked_plugins.generate_enums_code("")
 
-    assert mocked_plugin_manager.plugins[0].generate_enums_code.called
-    assert mocked_plugin_manager.plugins[1].generate_enums_code.called
+    assert plugin_manager_with_mocked_plugins.plugins[0].generate_enums_code.called
+    assert plugin_manager_with_mocked_plugins.plugins[1].generate_enums_code.called
 
 
 def test_generate_inputs_code_calls_plugins_generate_inputs_code(
-    mocked_plugin_manager,
+    plugin_manager_with_mocked_plugins,
 ):
-    mocked_plugin_manager.generate_inputs_code("")
+    plugin_manager_with_mocked_plugins.generate_inputs_code("")
 
-    assert mocked_plugin_manager.plugins[0].generate_inputs_code.called
-    assert mocked_plugin_manager.plugins[1].generate_inputs_code.called
+    assert plugin_manager_with_mocked_plugins.plugins[0].generate_inputs_code.called
+    assert plugin_manager_with_mocked_plugins.plugins[1].generate_inputs_code.called
 
 
 def test_generate_result_types_code_calls_plugins_generate_result_types_code(
-    mocked_plugin_manager,
+    plugin_manager_with_mocked_plugins,
 ):
-    mocked_plugin_manager.generate_result_types_code("")
+    plugin_manager_with_mocked_plugins.generate_result_types_code("")
 
-    assert mocked_plugin_manager.plugins[0].generate_result_types_code.called
-    assert mocked_plugin_manager.plugins[1].generate_result_types_code.called
+    assert plugin_manager_with_mocked_plugins.plugins[
+        0
+    ].generate_result_types_code.called
+    assert plugin_manager_with_mocked_plugins.plugins[
+        1
+    ].generate_result_types_code.called
 
 
-def test_copy_code_calls_plugins_copy_code(mocked_plugin_manager):
-    mocked_plugin_manager.copy_code("")
+def test_copy_code_calls_plugins_copy_code(plugin_manager_with_mocked_plugins):
+    plugin_manager_with_mocked_plugins.copy_code("")
 
-    assert mocked_plugin_manager.plugins[0].copy_code.called
-    assert mocked_plugin_manager.plugins[1].copy_code.called
+    assert plugin_manager_with_mocked_plugins.plugins[0].copy_code.called
+    assert plugin_manager_with_mocked_plugins.plugins[1].copy_code.called
 
 
 def test_generate_scalars_code_calls_plugins_generate_scalars_code(
-    mocked_plugin_manager,
+    plugin_manager_with_mocked_plugins,
 ):
-    mocked_plugin_manager.generate_scalars_code("")
+    plugin_manager_with_mocked_plugins.generate_scalars_code("")
 
-    assert mocked_plugin_manager.plugins[0].generate_scalars_code.called
-    assert mocked_plugin_manager.plugins[1].generate_scalars_code.called
+    assert plugin_manager_with_mocked_plugins.plugins[0].generate_scalars_code.called
+    assert plugin_manager_with_mocked_plugins.plugins[1].generate_scalars_code.called
 
 
-def test_generate_init_code_calls_plugins_generate_init_code(mocked_plugin_manager):
-    mocked_plugin_manager.generate_init_code("")
+def test_generate_init_code_calls_plugins_generate_init_code(
+    plugin_manager_with_mocked_plugins,
+):
+    plugin_manager_with_mocked_plugins.generate_init_code("")
 
-    assert mocked_plugin_manager.plugins[0].generate_init_code.called
-    assert mocked_plugin_manager.plugins[1].generate_init_code.called
+    assert plugin_manager_with_mocked_plugins.plugins[0].generate_init_code.called
+    assert plugin_manager_with_mocked_plugins.plugins[1].generate_init_code.called

--- a/tests/plugins/test_manager.py
+++ b/tests/plugins/test_manager.py
@@ -326,7 +326,7 @@ def test_generate_init_code_calls_plugins_generate_init_code(
 
 
 def test_process_name_calls_plugins_process_name(plugin_manager_with_mocked_plugins):
-    plugin_manager_with_mocked_plugins.process_name("")
+    plugin_manager_with_mocked_plugins.process_name("", OperationDefinitionNode())
 
     assert plugin_manager_with_mocked_plugins.plugins[0].process_name.called
     assert plugin_manager_with_mocked_plugins.plugins[1].process_name.called

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@ from ariadne_codegen.utils import (
     convert_to_multiline_string,
     format_multiline_strings,
     get_variable_indent_size,
+    process_name,
 )
 
 
@@ -113,3 +114,9 @@ def test_format_multiline_strings_returns_code_with_formatted_multiline_strings(
     '''
 
     assert format_multiline_strings(source) == expected
+
+
+def test_process_name_triggers_plugin_manager_process_name(mocked_plugin_manager):
+    process_name("", convert_to_snake_case=False, plugin_manager=mocked_plugin_manager)
+
+    assert mocked_plugin_manager.process_name.called


### PR DESCRIPTION
This pr adds `process_name` hook to allow further customization of generated fields/arguments/method names. Requested [here](https://github.com/mirumee/ariadne-codegen/issues/100#issuecomment-1499754435)