### PR TITLE
Add __main__ to allow executing via python -m ariadne_codegen

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ It's available as `ariadne-codegen` command and reads configuration from the `py
 $ ariadne-codegen
 ```
 
+It can also be run as `python -m ariadne_codegen`.
+
 
 ## Features
 

--- a/ariadne_codegen/__main__.py
+++ b/ariadne_codegen/__main__.py
@@ -1,0 +1,3 @@
+from . import main
+
+main.main()

--- a/ariadne_codegen/main.py
+++ b/ariadne_codegen/main.py
@@ -104,7 +104,3 @@ def graphql_schema(config_dict):
         type_map_name=settings.type_map_variable_name,
         schema_variable_name=settings.schema_variable_name,
     )
-
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
This adds a `__main__.py` file, which acts as an entry point when the `ariadne_codegen` module is executed directly, such as via `python -m ariadne_codegen`. This is in addition to the existing console script (i.e. `ariadne-codegen` directly still works).

Docs: https://docs.python.org/3/library/__main__.html#main-py-in-python-packages

Executing a module directly like this is widely supported by other python tools, and is often even recommended, because, AIUI, `python -m ...` will execute within `python`'s venv, while a console script wrapper may not and thus pick up an unexpected version. For instance, other tools like `pytest` and `mypy` support these parallel models of execution.
