### PR TITLE
Provide a basic configuration block

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ $ pip install ariadne-codegen[subscriptions]
 
 `ariadne-codegen` reads configuration from `[tool.ariadne-codegen]` section in your `pyproject.toml`. You can use other configuration file with `--config` option, eg. `ariadne-codegen --config custom_file.toml`
 
-Example minimum onfiguration block:
+Minimal configuration for client generation:
+
 ```toml
 [tool.ariadne-codegen]
 schema_path = "schema.graphql"

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Minimal configuration for client generation:
 ```toml
 [tool.ariadne-codegen]
 schema_path = "schema.graphql"
-queries_path="queries.graphql"
+queries_path = "queries.graphql"
 ```
 
 Required settings:

--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ $ pip install ariadne-codegen[subscriptions]
 
 `ariadne-codegen` reads configuration from `[tool.ariadne-codegen]` section in your `pyproject.toml`. You can use other configuration file with `--config` option, eg. `ariadne-codegen --config custom_file.toml`
 
+Example minimum onfiguration block:
+```toml
+[tool.ariadne-codegen]
+schema_path = "schema.graphql"
+queries_path="queries.graphql"
+```
+
 Required settings:
 
 - `queries_path` - path to file/directory with queries


### PR DESCRIPTION
This is to make it dirt simple for someone to get started. This makes it easy to copy past and get started a smidge faster than copy/pasting each element that they may need.