### PR TITLE
Mixins for fragments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## UNRELEASED
 
 - Added support for subscriptions as async generators.
+- Changed how fragments are handled to generate separate module with fragments as mixins.
 
 
 ## 0.6.0 (2023-04-18)

--- a/EXAMPLE.md
+++ b/EXAMPLE.md
@@ -151,6 +151,7 @@ grapql_client/
     create_user.py
     enums.py
     exceptions.py
+    fragments.py
     get_users_counter.py
     input_types.py
     list_all_users.py
@@ -413,17 +414,14 @@ from pydantic import Field
 
 from .base_model import BaseModel
 from .enums import Color
+from .fragments import BasicUser, UserPersonalData
 
 
 class ListUsersByCountry(BaseModel):
     users: List["ListUsersByCountryUsers"]
 
 
-class ListUsersByCountryUsers(BaseModel):
-    id: str
-    email: str
-    first_name: Optional[str] = Field(alias="firstName")
-    last_name: Optional[str] = Field(alias="lastName")
+class ListUsersByCountryUsers(BasicUser, UserPersonalData):
     favourite_color: Optional[Color] = Field(alias="favouriteColor")
 
 
@@ -446,6 +444,34 @@ class GetUsersCounter(BaseModel):
 GetUsersCounter.update_forward_refs()
 ```
 
+### Fragments file
+
+This file contains classes generated from all fragments used in any provided operation.
+
+```py
+# graphql_client/fragments.py
+
+from typing import Optional
+
+from pydantic import Field
+
+from .base_model import BaseModel
+
+
+class BasicUser(BaseModel):
+    id: str
+    email: str
+
+
+class UserPersonalData(BaseModel):
+    first_name: Optional[str] = Field(alias="firstName")
+    last_name: Optional[str] = Field(alias="lastName")
+
+
+BasicUser.update_forward_refs()
+UserPersonalData.update_forward_refs()
+```
+
 ### Init file
 
 Generated init file contains reimports and list of all generated classes.
@@ -465,6 +491,7 @@ from .exceptions import (
     GraphQLClientHttpError,
     GraphQlClientInvalidResponseError,
 )
+from .fragments import BasicUser, UserPersonalData
 from .get_users_counter import GetUsersCounter
 from .input_types import (
     LocationInput,
@@ -478,6 +505,7 @@ from .list_users_by_country import ListUsersByCountry, ListUsersByCountryUsers
 __all__ = [
     "AsyncBaseClient",
     "BaseModel",
+    "BasicUser",
     "Client",
     "Color",
     "CreateUser",
@@ -496,6 +524,7 @@ __all__ = [
     "LocationInput",
     "NotificationsPreferencesInput",
     "UserCreateInput",
+    "UserPersonalData",
     "UserPreferencesInput",
 ]
 ```

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -156,7 +156,7 @@ Hook executed on generation of representation for input field.
 
 ```py
 def generate_result_types_module(
-    self, module: ast.Module, operation_definition: OperationDefinitionNode
+    self, module: ast.Module, operation_definition: ExecutableDefinitionNode
 ) -> ast.Module:
 ```
 
@@ -166,7 +166,7 @@ Hook executed on generation of module with models reprenting result of given ope
 
 ```py
 def generate_operation_str(
-    self, operation_str: str, operation_definition: OperationDefinitionNode
+    self, operation_str: str, operation_definition: ExecutableDefinitionNode
 ) -> str:
 ```
 
@@ -178,7 +178,7 @@ Hook executed on generation of string representation of given operation. Result 
 def generate_result_class(
     self,
     class_def: ast.ClassDef,
-    operation_definition: OperationDefinitionNode,
+    operation_definition: ExecutableDefinitionNode,
     selection_set: SelectionSetNode,
 ) -> ast.ClassDef:
 ```
@@ -192,7 +192,7 @@ Hook executed on generation of single model, part of result of given query or mu
 def generate_result_field(
     self,
     field_implementation: ast.AnnAssign,
-    operation_definition: OperationDefinitionNode,
+    operation_definition: ExecutableDefinitionNode,
     field: FieldNode,
 ) -> ast.AnnAssign:
 ```

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -292,6 +292,18 @@ def process_name(self, name: str, node: Optional[Node] = None) -> str:
 
 Hook executed on processing of GraphQL field, argument or operation name.
 
+### generate_fragments_module
+
+```py
+def generate_fragments_module(
+    self,
+    module: ast.Module,
+    fragments_definitions: Dict[str, FragmentDefinitionNode],
+) -> ast.Module:
+```
+
+Hook executed on generation of fragments module. Module has classes representing all fragments from provided queries. Later this module will be saved as `{fragments_module_name}.py`, `fragments_module_name` is taken from config.
+
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Optional settings:
 - `base_client_file_path` (defaults to `.../graphql_sdk_gen/generators/async_base_client.py`) - path to file where `base_client_name` is defined
 - `enums_module_name` (defaults to `"enums"`) - name of file with generated enums models
 - `input_types_module_name` (defaults to `"input_types"`) - name of file with generated input types models
+- `fragments_module_name` (defaults to `"fragments"`) - name of file with generated fragments models
 - `include_comments` (defaults to `true`) - a flag that specifies whether to include comments in generated files
 - `convert_to_snake_case` (defaults to `true`) - a flag that specifies whether to convert fields and arguments names to snake case
 - `async_client` (defaults to `true`) - default generated client is `async`, change this to option `false` to generate synchronous client instead

--- a/ariadne_codegen/client_generators/fragments.py
+++ b/ariadne_codegen/client_generators/fragments.py
@@ -57,11 +57,16 @@ class FragmentsGenerator:
             for c in sorted_class_defs
         ]
 
-        return generate_module(
+        module = generate_module(
             body=cast(List[ast.stmt], imports)
             + cast(List[ast.stmt], sorted_class_defs)
             + cast(List[ast.stmt], update_forward_refs_calls)
         )
+        if self.plugin_manager:
+            module = self.plugin_manager.generate_fragments_module(
+                module, fragments_definitions=self.fragments_definitions
+            )
+        return module
 
     def _get_sorted_class_defs(
         self,

--- a/ariadne_codegen/client_generators/fragments.py
+++ b/ariadne_codegen/client_generators/fragments.py
@@ -1,0 +1,98 @@
+import ast
+from typing import Dict, List, Optional, Set, cast
+
+from graphql import FragmentDefinitionNode, GraphQLSchema
+
+from ..codegen import generate_expr, generate_method_call, generate_module
+from ..plugins.manager import PluginManager
+from .constants import UPDATE_FORWARD_REFS_METHOD
+from .result_types import ResultTypesGenerator
+from .scalars import ScalarData
+
+
+class FragmentsGenerator:
+    def __init__(
+        self,
+        schema: GraphQLSchema,
+        enums_module_name: str,
+        fragments_definitions: Dict[str, FragmentDefinitionNode],
+        base_model_import: Optional[ast.ImportFrom] = None,
+        convert_to_snake_case: bool = True,
+        custom_scalars: Optional[Dict[str, ScalarData]] = None,
+        plugin_manager: Optional[PluginManager] = None,
+    ) -> None:
+        self.schema = schema
+        self.enums_module_name = enums_module_name
+        self.fragments_definitions = fragments_definitions
+        self.base_model_import = base_model_import
+        self.convert_to_snake_case = convert_to_snake_case
+        self.custom_scalars = custom_scalars
+        self.plugin_manager = plugin_manager
+
+    def generate(self) -> ast.Module:
+        class_defs_dict: Dict[str, List[ast.ClassDef]] = {}
+        imports: List[ast.ImportFrom] = []
+        dependencies_dict: Dict[str, List[str]] = {}
+
+        for name, fragmanet_def in self.fragments_definitions.items():
+            generator = ResultTypesGenerator(
+                schema=self.schema,
+                operation_definition=fragmanet_def,
+                enums_module_name=self.enums_module_name,
+                fragments_definitions=self.fragments_definitions,
+                base_model_import=self.base_model_import,
+                convert_to_snake_case=self.convert_to_snake_case,
+                custom_scalars=self.custom_scalars,
+                plugin_manager=self.plugin_manager,
+            )
+            imports.extend(generator.get_imports())
+            class_defs_dict[name] = generator.get_classes()
+            dependencies_dict[name] = generator.get_used_fragments()
+
+        sorted_class_defs = self._get_sorted_class_defs(
+            class_defs_dict=class_defs_dict, dependencies_dict=dependencies_dict
+        )
+        update_forward_refs_calls = [
+            generate_expr(generate_method_call(c.name, UPDATE_FORWARD_REFS_METHOD))
+            for c in sorted_class_defs
+        ]
+
+        return generate_module(
+            body=cast(List[ast.stmt], imports)
+            + cast(List[ast.stmt], sorted_class_defs)
+            + cast(List[ast.stmt], update_forward_refs_calls)
+        )
+
+    def _get_sorted_class_defs(
+        self,
+        class_defs_dict: Dict[str, List[ast.ClassDef]],
+        dependencies_dict: Dict[str, List[str]],
+    ) -> List[ast.ClassDef]:
+        sorted_class_defs: List[ast.ClassDef] = []
+
+        for name in self._get_sorted_fragments_names(
+            fragments_names=list(self.fragments_definitions.keys()),
+            dependencies_dict=dependencies_dict,
+        ):
+            sorted_class_defs.extend(class_defs_dict[name])
+
+        return sorted_class_defs
+
+    def _get_sorted_fragments_names(
+        self, fragments_names: List[str], dependencies_dict: Dict[str, List[str]]
+    ) -> List[str]:
+        sorted_names: List[str] = []
+        visited: Set[str] = set()
+
+        def visit(name):
+            if name in visited:
+                return
+            visited.add(name)
+            for dep in dependencies_dict.get(name, []):
+                visit(dep)
+            sorted_names.append(name)
+
+        for name in fragments_names:
+            visit(name)
+
+        return sorted_names

--- a/ariadne_codegen/client_generators/fragments.py
+++ b/ariadne_codegen/client_generators/fragments.py
@@ -29,6 +29,8 @@ class FragmentsGenerator:
         self.custom_scalars = custom_scalars
         self.plugin_manager = plugin_manager
 
+        self._generated_public_names: List[str] = []
+
     def generate(self) -> ast.Module:
         class_defs_dict: Dict[str, List[ast.ClassDef]] = {}
         imports: List[ast.ImportFrom] = []
@@ -48,6 +50,7 @@ class FragmentsGenerator:
             imports.extend(generator.get_imports())
             class_defs_dict[name] = generator.get_classes()
             dependencies_dict[name] = generator.get_used_fragments()
+            self._generated_public_names.extend(generator.get_generated_public_names())
 
         sorted_class_defs = self._get_sorted_class_defs(
             class_defs_dict=class_defs_dict, dependencies_dict=dependencies_dict
@@ -67,6 +70,9 @@ class FragmentsGenerator:
                 module, fragments_definitions=self.fragments_definitions
             )
         return module
+
+    def get_generated_public_names(self) -> List[str]:
+        return self._generated_public_names
 
     def _get_sorted_class_defs(
         self,

--- a/ariadne_codegen/client_generators/package.py
+++ b/ariadne_codegen/client_generators/package.py
@@ -315,7 +315,8 @@ class PackageGenerator:
     def _generate_fragments(self):
         if not self.fragments_definitions:
             return
-        module = FragmentsGenerator(
+
+        generator = FragmentsGenerator(
             schema=self.schema,
             enums_module_name=self.enums_module_name,
             fragments_definitions=self.fragments_definitions,
@@ -323,11 +324,15 @@ class PackageGenerator:
             convert_to_snake_case=self.convert_to_snake_case,
             custom_scalars=self.custom_scalars,
             plugin_manager=self.plugin_manager,
-        ).generate()
+        )
+        module = generator.generate()
         file_path = self.package_path / f"{self.fragments_module_name}.py"
         code = self._proccess_generated_code(ast_to_str(module), self.queries_source)
         file_path.write_text(code)
         self.generated_files.append(file_path.name)
+        self.init_generator.add_import(
+            generator.get_generated_public_names(), self.fragments_module_name, 1
+        )
 
     def _copy_files(self):
         files_to_copy = self.files_to_include + [

--- a/ariadne_codegen/client_generators/package.py
+++ b/ariadne_codegen/client_generators/package.py
@@ -312,6 +312,8 @@ class PackageGenerator:
             self.generated_files.append(file_path.name)
 
     def _generate_fragments(self):
+        if not self.fragments_definitions:
+            return
         module = FragmentsGenerator(
             schema=self.schema,
             enums_module_name=self.enums_module_name,

--- a/ariadne_codegen/client_generators/package.py
+++ b/ariadne_codegen/client_generators/package.py
@@ -42,6 +42,7 @@ class PackageGenerator:
         base_client_file_path: Optional[str] = None,
         enums_module_name: str = "enums",
         input_types_module_name: str = "input_types",
+        fragments_module_name: str = "fragments",
         include_comments: bool = True,
         queries_source: str = "",
         schema_source: str = "",
@@ -85,6 +86,7 @@ class PackageGenerator:
 
         self.enums_module_name = enums_module_name
         self.input_types_module_name = input_types_module_name
+        self.fragments_module_name = fragments_module_name
         self.client_file_name = client_file_name
 
         self.include_comments = include_comments
@@ -159,7 +161,6 @@ class PackageGenerator:
             plugin_manager=self.plugin_manager,
         )
         self.scalars_definitions_file_name = "scalars"
-        self.fragments_module_name = "fragments"
 
     def generate(self) -> List[str]:
         """Generate package with graphql client."""

--- a/ariadne_codegen/client_generators/result_types.py
+++ b/ariadne_codegen/client_generators/result_types.py
@@ -199,7 +199,7 @@ class ResultTypesGenerator:
             )
 
         if fragments:
-            class_bases = [str_to_pascal_case(f) for f in fragments]
+            class_bases = [str_to_pascal_case(f) for f in sorted(fragments)]
         else:
             class_bases = [BASE_MODEL_CLASS_NAME]
         if extra_bases:

--- a/ariadne_codegen/client_generators/result_types.py
+++ b/ariadne_codegen/client_generators/result_types.py
@@ -1,8 +1,9 @@
 import ast
-from typing import Dict, List, Optional, Tuple, cast
+from typing import Dict, List, Optional, Set, Tuple, cast
 
 from graphql import (
     DirectiveNode,
+    ExecutableDefinitionNode,
     FieldNode,
     FragmentDefinitionNode,
     FragmentSpreadNode,
@@ -30,6 +31,7 @@ from ..codegen import (
     generate_import_from,
     generate_method_call,
     generate_module,
+    generate_pass,
 )
 from ..exceptions import NotSupported, ParsingError
 from ..plugins.manager import PluginManager
@@ -58,8 +60,9 @@ class ResultTypesGenerator:
     def __init__(
         self,
         schema: GraphQLSchema,
-        operation_definition: OperationDefinitionNode,
+        operation_definition: ExecutableDefinitionNode,
         enums_module_name: str,
+        fragments_module_name: Optional[str] = None,
         fragments_definitions: Optional[Dict[str, FragmentDefinitionNode]] = None,
         base_model_import: Optional[ast.ImportFrom] = None,
         convert_to_snake_case: bool = True,
@@ -70,8 +73,10 @@ class ResultTypesGenerator:
         self.operation_definition = operation_definition
         if not self.operation_definition.name:
             raise NotSupported("Operations without name are not supported.")
+        self._operation_name = self.operation_definition.name.value
 
         self.enums_module_name = enums_module_name
+        self.fragments_module_name = fragments_module_name
         self.fragments_definitions = (
             fragments_definitions if fragments_definitions else {}
         )
@@ -86,53 +91,56 @@ class ResultTypesGenerator:
             or generate_import_from([BASE_MODEL_CLASS_NAME], PYDANTIC_MODULE),
         ]
         self._public_names: List[str] = []
-        self._class_defs: List[ast.ClassDef] = []
         self._used_enums: List[str] = []
         self._used_scalars: List[str] = []
         self._used_fragments_names: set[str] = set()
 
         self._class_defs = self._parse_type_definition(
-            class_name=str_to_pascal_case(self.operation_definition.name.value),
-            type_name=self._get_operation_type_name(
-                self.operation_definition.operation
-            ),
+            class_name=str_to_pascal_case(self._operation_name),
+            type_name=self._get_operation_type_name(self.operation_definition),
             selection_set=self.operation_definition.selection_set,
         )
 
-    def _get_operation_type_name(self, operation_type: OperationType) -> str:
-        if operation_type == OperationType.QUERY and self.schema.query_type:
+    def _get_operation_type_name(self, definition: ExecutableDefinitionNode) -> str:
+        if isinstance(definition, FragmentDefinitionNode):
+            return definition.type_condition.name.value
+
+        if (
+            isinstance(definition, OperationDefinitionNode)
+            and definition.operation == OperationType.QUERY
+            and self.schema.query_type
+        ):
             return self.schema.query_type.name
 
-        if operation_type == OperationType.MUTATION and self.schema.mutation_type:
+        if (
+            isinstance(definition, OperationDefinitionNode)
+            and definition.operation == OperationType.MUTATION
+            and self.schema.mutation_type
+        ):
             return self.schema.mutation_type.name
 
         if (
-            operation_type == OperationType.SUBSCRIPTION
+            isinstance(definition, OperationDefinitionNode)
+            and definition.operation == OperationType.SUBSCRIPTION
             and self.schema.subscription_type
         ):
             return self.schema.subscription_type.name
 
-        raise NotSupported(f"Not supported operation type: {operation_type}")
+        raise NotSupported(f"Not supported operation type: {definition}")
 
     def generate(self) -> ast.Module:
-        if self._used_enums:
-            self._imports.append(
-                generate_import_from(self._used_enums, self.enums_module_name, 1)
-            )
-        if self._used_scalars:
-            for scalar_name in self._used_scalars:
-                scalar_data = self.custom_scalars[scalar_name]
-                self._imports.extend(generate_scalar_imports(scalar_data))
+        imports = self.get_imports()
+        class_defs = self.get_classes()
 
         update_forward_refs_calls = [
             generate_expr(
                 generate_method_call(class_def.name, UPDATE_FORWARD_REFS_METHOD)
             )
-            for class_def in self._class_defs
+            for class_def in class_defs
         ]
         module_body = (
-            cast(List[ast.stmt], self._imports)
-            + cast(List[ast.stmt], self._class_defs)
+            cast(List[ast.stmt], imports)
+            + cast(List[ast.stmt], class_defs)
             + cast(List[ast.stmt], update_forward_refs_calls)
         )
 
@@ -142,6 +150,33 @@ class ResultTypesGenerator:
                 module, operation_definition=self.operation_definition
             )
         return module
+
+    def get_imports(self) -> List[ast.ImportFrom]:
+        if self._used_enums:
+            self._imports.append(
+                generate_import_from(self._used_enums, self.enums_module_name, 1)
+            )
+        if self._used_scalars:
+            for scalar_name in self._used_scalars:
+                scalar_data = self.custom_scalars[scalar_name]
+                self._imports.extend(generate_scalar_imports(scalar_data))
+
+        if (
+            isinstance(self.operation_definition, OperationDefinitionNode)
+            and self._used_fragments_names
+            and self.fragments_module_name
+        ):
+            self._imports.append(
+                generate_import_from(
+                    [str_to_pascal_case(f) for f in self._used_fragments_names],
+                    self.fragments_module_name,
+                    1,
+                )
+            )
+        return self._imports
+
+    def get_classes(self) -> List[ast.ClassDef]:
+        return self._class_defs
 
     def get_operation_as_str(self) -> str:
         operation_str = print_ast(self.operation_definition)
@@ -160,6 +195,9 @@ class ResultTypesGenerator:
     def get_generated_public_names(self) -> List[str]:
         return self._public_names
 
+    def get_used_fragments(self) -> List[str]:
+        return list(self._used_fragments_names)
+
     def _parse_type_definition(
         self,
         class_name: str,
@@ -168,17 +206,13 @@ class ResultTypesGenerator:
         add_typename: bool = False,
         extra_bases: Optional[List[str]] = None,
     ) -> List[ast.ClassDef]:
-        class_bases = [BASE_MODEL_CLASS_NAME]
-        if extra_bases:
-            class_bases.extend(extra_bases)
-        class_def = generate_class_def(class_name, class_bases)
-
-        if class_def.name in self._public_names:
+        if class_name in self._public_names:
             return []
-        self._public_names.append(class_def.name)
+        self._public_names.append(class_name)
 
-        extra_classes = []
-        resolved_selection_set = self._resolve_selection_set(selection_set, type_name)
+        resolved_selection_set, fragments = self._resolve_selection_set(
+            selection_set, type_name
+        )
         if add_typename:
             (
                 resolved_selection_set,
@@ -186,6 +220,16 @@ class ResultTypesGenerator:
             ) = self._add_typename_field_to_selections(
                 resolved_selection_set, selection_set
             )
+
+        if fragments:
+            class_bases = [str_to_pascal_case(f) for f in fragments]
+        else:
+            class_bases = [BASE_MODEL_CLASS_NAME]
+        if extra_bases:
+            class_bases.extend(extra_bases)
+        class_def = generate_class_def(class_name, class_bases)
+
+        extra_classes = []
         for lineno, field in enumerate(
             resolved_selection_set,
             start=1,
@@ -234,29 +278,31 @@ class ResultTypesGenerator:
                     operation_definition=self.operation_definition,
                     selection_set=selection_set,
                 )
+
+        if not class_def.body:
+            class_def.body.append(generate_pass())
+
         return [class_def] + extra_classes
 
     def _resolve_selection_set(
         self, selection_set: SelectionSetNode, root_type: str = ""
-    ) -> List[FieldNode]:
+    ) -> Tuple[List[FieldNode], Set[str]]:
         fields = []
+        fragments = set()
         for selection in selection_set.selections:
             if isinstance(selection, FieldNode):
                 fields.append(selection)
             elif isinstance(selection, FragmentSpreadNode):
-                self._used_fragments_names.add(selection.name.value)
-                fields.extend(
-                    self._resolve_selection_set(
-                        self.fragments_definitions[selection.name.value].selection_set,
-                        root_type,
-                    )
-                )
+                fragments.add(selection.name.value)
             elif isinstance(selection, InlineFragmentNode):
                 if selection.type_condition.name.value == root_type:
-                    fields.extend(
-                        self._resolve_selection_set(selection.selection_set, root_type)
+                    sub_fields, sub_fragments = self._resolve_selection_set(
+                        selection.selection_set, root_type
                     )
-        return fields
+                    fields.extend(sub_fields)
+                    fragments = fragments.union(sub_fragments)
+        self._used_fragments_names = self._used_fragments_names.union(set(fragments))
+        return fields, fragments
 
     def _add_typename_field_to_selections(
         self, resolved_fields: List[FieldNode], selection_set: SelectionSetNode

--- a/ariadne_codegen/codegen.py
+++ b/ariadne_codegen/codegen.py
@@ -336,3 +336,7 @@ def generate_async_for(
 
 def generate_yield(value: Optional[ast.expr] = None) -> ast.Yield:
     return ast.Yield(value=value)
+
+
+def generate_pass() -> ast.Pass:
+    return ast.Pass()

--- a/ariadne_codegen/main.py
+++ b/ariadne_codegen/main.py
@@ -63,6 +63,7 @@ def client(config_dict):
         base_client_name=settings.base_client_name,
         base_client_file_path=settings.base_client_file_path,
         input_types_module_name=settings.input_types_module_name,
+        fragments_module_name=settings.fragments_module_name,
         queries_source=settings.queries_path,
         schema_source=schema_source,
         include_comments=settings.include_comments,

--- a/ariadne_codegen/plugins/base.py
+++ b/ariadne_codegen/plugins/base.py
@@ -4,6 +4,7 @@ from typing import Dict, Optional, Tuple, Union
 from graphql import (
     ExecutableDefinitionNode,
     FieldNode,
+    FragmentDefinitionNode,
     GraphQLEnumType,
     GraphQLInputField,
     GraphQLInputObjectType,
@@ -149,3 +150,11 @@ class Plugin:
     # pylint: disable=unused-argument
     def process_name(self, name: str, node: Optional[Node] = None) -> str:
         return name
+
+    # pylint: disable=unused-argument
+    def generate_fragments_module(
+        self,
+        module: ast.Module,
+        fragments_definitions: Dict[str, FragmentDefinitionNode],
+    ) -> ast.Module:
+        return module

--- a/ariadne_codegen/plugins/base.py
+++ b/ariadne_codegen/plugins/base.py
@@ -2,13 +2,13 @@ import ast
 from typing import Dict, Optional, Tuple, Union
 
 from graphql import (
+    ExecutableDefinitionNode,
     FieldNode,
     GraphQLEnumType,
     GraphQLInputField,
     GraphQLInputObjectType,
     GraphQLSchema,
     Node,
-    OperationDefinitionNode,
     SelectionSetNode,
     VariableDefinitionNode,
 )
@@ -88,13 +88,13 @@ class Plugin:
 
     # pylint: disable=unused-argument
     def generate_result_types_module(
-        self, module: ast.Module, operation_definition: OperationDefinitionNode
+        self, module: ast.Module, operation_definition: ExecutableDefinitionNode
     ) -> ast.Module:
         return module
 
     # pylint: disable=unused-argument
     def generate_operation_str(
-        self, operation_str: str, operation_definition: OperationDefinitionNode
+        self, operation_str: str, operation_definition: ExecutableDefinitionNode
     ) -> str:
         return operation_str
 
@@ -102,7 +102,7 @@ class Plugin:
     def generate_result_class(
         self,
         class_def: ast.ClassDef,
-        operation_definition: OperationDefinitionNode,
+        operation_definition: ExecutableDefinitionNode,
         selection_set: SelectionSetNode,
     ) -> ast.ClassDef:
         return class_def
@@ -111,7 +111,7 @@ class Plugin:
     def generate_result_field(
         self,
         field_implementation: ast.AnnAssign,
-        operation_definition: OperationDefinitionNode,
+        operation_definition: ExecutableDefinitionNode,
         field: FieldNode,
     ) -> ast.AnnAssign:
         return field_implementation

--- a/ariadne_codegen/plugins/manager.py
+++ b/ariadne_codegen/plugins/manager.py
@@ -2,13 +2,13 @@ import ast
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 from graphql import (
+    ExecutableDefinitionNode,
     FieldNode,
     GraphQLEnumType,
     GraphQLInputField,
     GraphQLInputObjectType,
     GraphQLSchema,
     Node,
-    OperationDefinitionNode,
     SelectionSetNode,
     VariableDefinitionNode,
 )
@@ -113,7 +113,7 @@ class PluginManager:
         )
 
     def generate_result_types_module(
-        self, module: ast.Module, operation_definition: OperationDefinitionNode
+        self, module: ast.Module, operation_definition: ExecutableDefinitionNode
     ) -> ast.Module:
         return self._apply_plugins_on_object(
             "generate_result_types_module",
@@ -122,7 +122,7 @@ class PluginManager:
         )
 
     def generate_operation_str(
-        self, operation_str: str, operation_definition: OperationDefinitionNode
+        self, operation_str: str, operation_definition: ExecutableDefinitionNode
     ) -> str:
         return self._apply_plugins_on_object(
             "generate_operation_str",
@@ -133,7 +133,7 @@ class PluginManager:
     def generate_result_class(
         self,
         class_def: ast.ClassDef,
-        operation_definition: OperationDefinitionNode,
+        operation_definition: ExecutableDefinitionNode,
         selection_set: SelectionSetNode,
     ) -> ast.ClassDef:
         return self._apply_plugins_on_object(
@@ -146,7 +146,7 @@ class PluginManager:
     def generate_result_field(
         self,
         field_implementation: ast.AnnAssign,
-        operation_definition: OperationDefinitionNode,
+        operation_definition: ExecutableDefinitionNode,
         field: FieldNode,
     ) -> ast.AnnAssign:
         return self._apply_plugins_on_object(

--- a/ariadne_codegen/plugins/manager.py
+++ b/ariadne_codegen/plugins/manager.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional, Tuple, Type, Union
 from graphql import (
     ExecutableDefinitionNode,
     FieldNode,
+    FragmentDefinitionNode,
     GraphQLEnumType,
     GraphQLInputField,
     GraphQLInputObjectType,
@@ -190,3 +191,14 @@ class PluginManager:
 
     def process_name(self, name: str, node: Optional[Node] = None) -> str:
         return self._apply_plugins_on_object("process_name", name, node=node)
+
+    def generate_fragments_module(
+        self,
+        module: ast.Module,
+        fragments_definitions: Dict[str, FragmentDefinitionNode],
+    ) -> ast.Module:
+        return self._apply_plugins_on_object(
+            "generate_fragments_module",
+            module,
+            fragments_definitions=fragments_definitions,
+        )

--- a/ariadne_codegen/settings.py
+++ b/ariadne_codegen/settings.py
@@ -49,6 +49,7 @@ class ClientSettings(BaseSettings):
     base_client_file_path: Optional[str] = None
     enums_module_name: str = "enums"
     input_types_module_name: str = "input_types"
+    fragments_module_name: str = "fragments"
     include_comments: bool = True
     convert_to_snake_case: bool = True
     async_client: bool = True
@@ -132,6 +133,7 @@ class ClientSettings(BaseSettings):
             Coping base client class from '{self.base_client_file_path}'.
             Generating enums into '{self.enums_module_name}.py'.
             Generating inputs into '{self.input_types_module_name}.py'.
+            Generating fragments into '{self.fragments_module_name}.py'.
             {comments_msg}
             {snake_case_msg}
             {async_client_msg}

--- a/tests/client_generators/result_types_generator/test_imports.py
+++ b/tests/client_generators/result_types_generator/test_imports.py
@@ -63,3 +63,25 @@ def test_generate_returns_module_with_used_custom_scalars_imports():
     assert isinstance(module, ast.Module)
     import_ = filter_imports(module)[-1]
     assert compare_ast(import_, expected_import)
+
+
+def test_generate_returns_module_with_used_fragment_import():
+    query_str = "query CustomQuery { query2 { ...TestFragment } }"
+    operation_definition = cast(
+        OperationDefinitionNode, parse(query_str).definitions[0]
+    )
+    generator = ResultTypesGenerator(
+        schema=build_ast_schema(parse(SCHEMA_STR)),
+        operation_definition=operation_definition,
+        enums_module_name="enums",
+        fragments_module_name="fragments",
+    )
+
+    module = generator.generate()
+
+    assert isinstance(module, ast.Module)
+    import_ = filter_imports(module)[-1]
+    assert compare_ast(
+        import_,
+        ast.ImportFrom(module="fragments", names=[ast.alias("TestFragment")], level=1),
+    )

--- a/tests/client_generators/result_types_generator/test_parsing_fragments.py
+++ b/tests/client_generators/result_types_generator/test_parsing_fragments.py
@@ -1,0 +1,119 @@
+import ast
+from typing import cast
+
+from graphql import FragmentDefinitionNode, build_schema, parse
+
+from ariadne_codegen.client_generators.constants import BASE_MODEL_CLASS_NAME
+from ariadne_codegen.client_generators.result_types import ResultTypesGenerator
+
+from ...utils import compare_ast
+from .schema import SCHEMA_STR
+
+
+def test_get_classes_returns_list_with_types_generated_from_fragment():
+    fragment_str = """
+        fragment TestFragment on CustomType {
+            id
+            field1 { fielda }
+        }
+    """
+    fragment_definition = cast(
+        FragmentDefinitionNode, parse(fragment_str).definitions[0]
+    )
+    expected_class_defs = [
+        ast.ClassDef(
+            name="TestFragment",
+            bases=[ast.Name(id=BASE_MODEL_CLASS_NAME)],
+            keywords=[],
+            body=[
+                ast.AnnAssign(
+                    target=ast.Name(id="id"), annotation=ast.Name(id="str"), simple=1
+                ),
+                ast.AnnAssign(
+                    target=ast.Name(id="field1"),
+                    annotation=ast.Name(id='"TestFragmentField1"'),
+                    simple=1,
+                ),
+            ],
+            decorator_list=[],
+        ),
+        ast.ClassDef(
+            name="TestFragmentField1",
+            bases=[ast.Name(id=BASE_MODEL_CLASS_NAME)],
+            keywords=[],
+            body=[
+                ast.AnnAssign(
+                    target=ast.Name(id="fielda"),
+                    annotation=ast.Name(id="int"),
+                    simple=1,
+                )
+            ],
+            decorator_list=[],
+        ),
+    ]
+    generator = ResultTypesGenerator(
+        schema=build_schema(SCHEMA_STR),
+        operation_definition=fragment_definition,
+        enums_module_name="enums",
+    )
+
+    generated_class_defs = generator.get_classes()
+
+    assert compare_ast(generated_class_defs, expected_class_defs)
+    assert set(generator.get_generated_public_names()) == {
+        c.name for c in expected_class_defs
+    }
+
+
+def test_get_classes_returns_types_generated_from_fragment_which_uses_other_fragment():
+    fragment_str = """
+        fragment TestFragment on CustomType {
+            id
+            field1 { ...TestNestedFragment }
+        }
+
+        fragment TestNestedFragment on CustomType1 {
+            fielda
+        }
+    """
+    fragment_definition = cast(
+        FragmentDefinitionNode, parse(fragment_str).definitions[0]
+    )
+    expected_class_defs = [
+        ast.ClassDef(
+            name="TestFragment",
+            bases=[ast.Name(id=BASE_MODEL_CLASS_NAME)],
+            keywords=[],
+            body=[
+                ast.AnnAssign(
+                    target=ast.Name(id="id"), annotation=ast.Name(id="str"), simple=1
+                ),
+                ast.AnnAssign(
+                    target=ast.Name(id="field1"),
+                    annotation=ast.Name(id='"TestFragmentField1"'),
+                    simple=1,
+                ),
+            ],
+            decorator_list=[],
+        ),
+        ast.ClassDef(
+            name="TestFragmentField1",
+            bases=[ast.Name(id="TestNestedFragment")],
+            keywords=[],
+            body=[ast.Pass()],
+            decorator_list=[],
+        ),
+    ]
+    generator = ResultTypesGenerator(
+        schema=build_schema(SCHEMA_STR),
+        operation_definition=fragment_definition,
+        enums_module_name="enums",
+    )
+
+    generated_class_defs = generator.get_classes()
+
+    assert compare_ast(generated_class_defs, expected_class_defs)
+    assert set(generator.get_generated_public_names()) == {
+        c.name for c in expected_class_defs
+    }
+    assert generator.get_used_fragments() == ["TestNestedFragment"]

--- a/tests/client_generators/result_types_generator/test_parsing_operations.py
+++ b/tests/client_generators/result_types_generator/test_parsing_operations.py
@@ -341,17 +341,9 @@ def test_generate_returns_module_with_types_generated_from_query_that_uses_fragm
     )
     expected_class_def = ast.ClassDef(
         name="CustomQueryQuery2",
-        bases=[ast.Name(id=BASE_MODEL_CLASS_NAME)],
+        bases=[ast.Name(id="TestFragment")],
         keywords=[],
         body=[
-            ast.AnnAssign(
-                target=ast.Name(id="id"), annotation=ast.Name(id="str"), simple=1
-            ),
-            ast.AnnAssign(
-                target=ast.Name(id="field1"),
-                annotation=ast.Name(id='"CustomQueryQuery2Field1"'),
-                simple=1,
-            ),
             ast.AnnAssign(
                 target=ast.Name(id="field2"),
                 annotation=ast.Subscript(
@@ -373,7 +365,7 @@ def test_generate_returns_module_with_types_generated_from_query_that_uses_fragm
     module = generator.generate()
 
     class_defs = filter_class_defs(module)
-    assert len(class_defs) == 4
+    assert len(class_defs) == 3
     custom_type_class_def = class_defs[1]
     assert custom_type_class_def.name == "CustomQueryQuery2"
     assert compare_ast(custom_type_class_def, expected_class_def)

--- a/tests/client_generators/test_fragments_generator.py
+++ b/tests/client_generators/test_fragments_generator.py
@@ -1,0 +1,166 @@
+import ast
+from typing import cast
+
+import pytest
+from graphql import FragmentDefinitionNode, GraphQLSchema, build_schema, parse
+
+from ariadne_codegen.client_generators.constants import UPDATE_FORWARD_REFS_METHOD
+from ariadne_codegen.client_generators.fragments import FragmentsGenerator
+
+from ..utils import compare_ast, filter_ast_objects, filter_class_defs
+
+
+@pytest.fixture
+def schema() -> GraphQLSchema:
+    schema_str = """
+    schema { query: Query }
+    type Query { testQuery: CustomType! }
+    type CustomType {
+        id: ID!
+        fieldA: String!
+        fieldB: Int!
+    }
+    """
+    return build_schema(schema_str)
+
+
+@pytest.fixture
+def fragment_a() -> FragmentDefinitionNode:
+    return cast(
+        FragmentDefinitionNode,
+        parse("fragment FragmentA on CustomType { fieldA }").definitions[0],
+    )
+
+
+@pytest.fixture
+def fragment_b() -> FragmentDefinitionNode:
+    return cast(
+        FragmentDefinitionNode,
+        parse("fragment FragmentB on CustomType { fieldB }").definitions[0],
+    )
+
+
+@pytest.fixture
+def test_fragment() -> FragmentDefinitionNode:
+    fragment_str = """
+    fragment TestFragment on CustomType {
+        id
+        ...FragmentA
+    }"""
+    return cast(FragmentDefinitionNode, parse(fragment_str).definitions[0])
+
+
+def test_generate_returns_module_with_class_for_every_fragment(
+    schema, fragment_a, fragment_b
+):
+    expected_class_defs = [
+        ast.ClassDef(
+            name="FragmentA",
+            bases=[ast.Name(id="BaseModel")],
+            keywords=[],
+            body=[
+                ast.AnnAssign(
+                    target=ast.Name(id="field_a"),
+                    annotation=ast.Name(id="str"),
+                    value=ast.Call(
+                        func=ast.Name(id="Field"),
+                        args=[],
+                        keywords=[
+                            ast.keyword(arg="alias", value=ast.Constant(value="fieldA"))
+                        ],
+                    ),
+                    simple=1,
+                )
+            ],
+            decorator_list=[],
+        ),
+        ast.ClassDef(
+            name="FragmentB",
+            bases=[ast.Name(id="BaseModel")],
+            keywords=[],
+            body=[
+                ast.AnnAssign(
+                    target=ast.Name(id="field_b"),
+                    annotation=ast.Name(id="int"),
+                    value=ast.Call(
+                        func=ast.Name(id="Field"),
+                        args=[],
+                        keywords=[
+                            ast.keyword(arg="alias", value=ast.Constant(value="fieldB"))
+                        ],
+                    ),
+                    simple=1,
+                )
+            ],
+            decorator_list=[],
+        ),
+    ]
+    generator = FragmentsGenerator(
+        schema=schema,
+        enums_module_name="enums",
+        fragments_definitions={"FragmentA": fragment_a, "FragmentB": fragment_b},
+        convert_to_snake_case=True,
+    )
+
+    module = generator.generate()
+
+    generated_class_defs = filter_class_defs(module)
+    assert compare_ast(generated_class_defs, expected_class_defs)
+
+
+def test_generate_returns_module_with_correct_order_of_classes(
+    schema, fragment_a, test_fragment
+):
+    generator = FragmentsGenerator(
+        schema=schema,
+        enums_module_name="enums",
+        fragments_definitions={
+            "TestFragment": test_fragment,
+            "FragmentA": fragment_a,
+        },
+        convert_to_snake_case=True,
+    )
+
+    module = generator.generate()
+
+    generated_class_defs = filter_class_defs(module)
+    assert [c.name for c in generated_class_defs] == ["FragmentA", "TestFragment"]
+
+
+def test_generate_returns_module_with_update_refs_calls(
+    schema, fragment_a, test_fragment
+):
+    expected_update_refs_calls = [
+        ast.Expr(
+            value=ast.Call(
+                func=ast.Attribute(
+                    value=ast.Name(id="FragmentA"), attr=UPDATE_FORWARD_REFS_METHOD
+                ),
+                args=[],
+                keywords=[],
+            )
+        ),
+        ast.Expr(
+            value=ast.Call(
+                func=ast.Attribute(
+                    value=ast.Name(id="TestFragment"), attr=UPDATE_FORWARD_REFS_METHOD
+                ),
+                args=[],
+                keywords=[],
+            )
+        ),
+    ]
+    generator = FragmentsGenerator(
+        schema=schema,
+        enums_module_name="enums",
+        fragments_definitions={
+            "TestFragment": test_fragment,
+            "FragmentA": fragment_a,
+        },
+        convert_to_snake_case=True,
+    )
+
+    module = generator.generate()
+
+    generated_update_refs_calls = filter_ast_objects(module, ast.Expr)
+    assert compare_ast(generated_update_refs_calls, expected_update_refs_calls)

--- a/tests/client_generators/test_fragments_generator.py
+++ b/tests/client_generators/test_fragments_generator.py
@@ -164,3 +164,15 @@ def test_generate_returns_module_with_update_refs_calls(
 
     generated_update_refs_calls = filter_ast_objects(module, ast.Expr)
     assert compare_ast(generated_update_refs_calls, expected_update_refs_calls)
+
+
+def test_generate_triggers_generate_fragments_module_hook(mocked_plugin_manager):
+    generator = FragmentsGenerator(
+        schema=GraphQLSchema(),
+        enums_module_name="enums",
+        fragments_definitions={},
+        plugin_manager=mocked_plugin_manager,
+    )
+    generator.generate()
+
+    assert mocked_plugin_manager.generate_fragments_module.called

--- a/tests/client_generators/test_package_generator.py
+++ b/tests/client_generators/test_package_generator.py
@@ -471,7 +471,7 @@ def test_generate_returns_list_of_generated_files(tmp_path):
         "test_graphql_client",
         tmp_path.as_posix(),
         build_ast_schema(parse(SCHEMA_STR)),
-        fragments=[parse("fragment TestFragment on CustomType { id }").definitions[0]]
+        fragments=[parse("fragment TestFragment on CustomType { id }").definitions[0]],
     )
     query_str = """
     query CustomQuery {

--- a/tests/client_generators/test_package_generator.py
+++ b/tests/client_generators/test_package_generator.py
@@ -446,14 +446,8 @@ def test_generate_creates_result_types_from_operation_that_uses_fragment(tmp_pat
         query1: Optional["CustomQueryQuery1"]
 
 
-    class CustomQueryQuery1(BaseModel):
-        field1: Optional[List[Optional[str]]]
-        field2: Optional["CustomQueryQuery1Field2"]
+    class CustomQueryQuery1(TestFragment):
         field3: CustomEnum
-
-
-    class CustomQueryQuery1Field2(BaseModel):
-        fieldb: Optional[int]
     """
     query_def, fragment_def = parse(query_str).definitions
     generator = PackageGenerator(
@@ -500,6 +494,7 @@ def test_generate_returns_list_of_generated_files(tmp_path):
             f"{generator.enums_module_name}.py",
             "custom_query.py",
             f"{generator.scalars_definitions_file_name}.py",
+            f"{generator.fragments_module_name}.py",
         ]
     )
 

--- a/tests/client_generators/test_package_generator.py
+++ b/tests/client_generators/test_package_generator.py
@@ -471,11 +471,12 @@ def test_generate_returns_list_of_generated_files(tmp_path):
         "test_graphql_client",
         tmp_path.as_posix(),
         build_ast_schema(parse(SCHEMA_STR)),
+        fragments=[parse("fragment TestFragment on CustomType { id }").definitions[0]]
     )
     query_str = """
     query CustomQuery {
         query2 {
-            id
+            ...TestFragment
         }
     }
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ def mocked_plugin_manager(mocker):
     manager.generate_client_code.side_effect = no_effect_method
     manager.generate_enums_code.side_effect = no_effect_method
     manager.generate_inputs_code.side_effect = no_effect_method
+    manager.generate_result_class.side_effect = no_effect_method
     manager.generate_result_types_code.side_effect = no_effect_method
     manager.copy_code.side_effect = no_effect_method
     manager.generate_scalars_code.side_effect = no_effect_method

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,4 +16,5 @@ def mocked_plugin_manager(mocker):
     manager.generate_scalars_code.side_effect = no_effect_method
     manager.generate_init_code.side_effect = no_effect_method
     manager.process_name.side_effect = no_effect_method
+    manager.generate_fragments_module.side_effect = no_effect_method
     return manager

--- a/tests/main/clients/example/expected_client/__init__.py
+++ b/tests/main/clients/example/expected_client/__init__.py
@@ -10,6 +10,7 @@ from .exceptions import (
     GraphQLClientHttpError,
     GraphQlClientInvalidResponseError,
 )
+from .fragments import BasicUser, UserPersonalData
 from .get_users_counter import GetUsersCounter
 from .input_types import (
     LocationInput,
@@ -23,6 +24,7 @@ from .list_users_by_country import ListUsersByCountry, ListUsersByCountryUsers
 __all__ = [
     "AsyncBaseClient",
     "BaseModel",
+    "BasicUser",
     "Client",
     "Color",
     "CreateUser",
@@ -41,5 +43,6 @@ __all__ = [
     "LocationInput",
     "NotificationsPreferencesInput",
     "UserCreateInput",
+    "UserPersonalData",
     "UserPreferencesInput",
 ]

--- a/tests/main/clients/example/expected_client/fragments.py
+++ b/tests/main/clients/example/expected_client/fragments.py
@@ -1,0 +1,19 @@
+from typing import Optional
+
+from pydantic import Field
+
+from .base_model import BaseModel
+
+
+class BasicUser(BaseModel):
+    id: str
+    email: str
+
+
+class UserPersonalData(BaseModel):
+    first_name: Optional[str] = Field(alias="firstName")
+    last_name: Optional[str] = Field(alias="lastName")
+
+
+BasicUser.update_forward_refs()
+UserPersonalData.update_forward_refs()

--- a/tests/main/clients/example/expected_client/list_users_by_country.py
+++ b/tests/main/clients/example/expected_client/list_users_by_country.py
@@ -4,17 +4,14 @@ from pydantic import Field
 
 from .base_model import BaseModel
 from .enums import Color
+from .fragments import BasicUser, UserPersonalData
 
 
 class ListUsersByCountry(BaseModel):
     users: List["ListUsersByCountryUsers"]
 
 
-class ListUsersByCountryUsers(BaseModel):
-    id: str
-    email: str
-    first_name: Optional[str] = Field(alias="firstName")
-    last_name: Optional[str] = Field(alias="lastName")
+class ListUsersByCountryUsers(BasicUser, UserPersonalData):
     favourite_color: Optional[Color] = Field(alias="favouriteColor")
 
 

--- a/tests/main/clients/multiple_fragments/expected_client/__init__.py
+++ b/tests/main/clients/multiple_fragments/expected_client/__init__.py
@@ -1,0 +1,30 @@
+from .async_base_client import AsyncBaseClient
+from .base_model import BaseModel
+from .client import Client
+from .example_query1 import ExampleQuery1, ExampleQuery1ExampleQuery
+from .example_query2 import ExampleQuery2, ExampleQuery2ExampleQuery
+from .example_query3 import ExampleQuery3, ExampleQuery3ExampleQuery
+from .exceptions import (
+    GraphQLClientError,
+    GraphQLClientGraphQLError,
+    GraphQLClientGraphQLMultiError,
+    GraphQLClientHttpError,
+    GraphQlClientInvalidResponseError,
+)
+
+__all__ = [
+    "AsyncBaseClient",
+    "BaseModel",
+    "Client",
+    "ExampleQuery1",
+    "ExampleQuery1ExampleQuery",
+    "ExampleQuery2",
+    "ExampleQuery2ExampleQuery",
+    "ExampleQuery3",
+    "ExampleQuery3ExampleQuery",
+    "GraphQLClientError",
+    "GraphQLClientGraphQLError",
+    "GraphQLClientGraphQLMultiError",
+    "GraphQLClientHttpError",
+    "GraphQlClientInvalidResponseError",
+]

--- a/tests/main/clients/multiple_fragments/expected_client/__init__.py
+++ b/tests/main/clients/multiple_fragments/expected_client/__init__.py
@@ -11,20 +11,38 @@ from .exceptions import (
     GraphQLClientHttpError,
     GraphQlClientInvalidResponseError,
 )
+from .fragments import (
+    CompleteA,
+    CompleteAFieldB,
+    FullA,
+    FullAFieldB,
+    FullB,
+    MinimalA,
+    MinimalAFieldB,
+    MinimalB,
+)
 
 __all__ = [
     "AsyncBaseClient",
     "BaseModel",
     "Client",
+    "CompleteA",
+    "CompleteAFieldB",
     "ExampleQuery1",
     "ExampleQuery1ExampleQuery",
     "ExampleQuery2",
     "ExampleQuery2ExampleQuery",
     "ExampleQuery3",
     "ExampleQuery3ExampleQuery",
+    "FullA",
+    "FullAFieldB",
+    "FullB",
     "GraphQLClientError",
     "GraphQLClientGraphQLError",
     "GraphQLClientGraphQLMultiError",
     "GraphQLClientHttpError",
     "GraphQlClientInvalidResponseError",
+    "MinimalA",
+    "MinimalAFieldB",
+    "MinimalB",
 ]

--- a/tests/main/clients/multiple_fragments/expected_client/async_base_client.py
+++ b/tests/main/clients/multiple_fragments/expected_client/async_base_client.py
@@ -1,0 +1,210 @@
+import enum
+import json
+from typing import Any, AsyncIterator, Dict, Optional, TypeVar, cast
+from uuid import uuid4
+
+import httpx
+from pydantic import BaseModel
+
+from .base_model import UNSET
+from .exceptions import (
+    GraphQLClientGraphQLMultiError,
+    GraphQLClientHttpError,
+    GraphQLClientInvalidMessageFormat,
+    GraphQlClientInvalidResponseError,
+)
+
+try:
+    from websockets.client import WebSocketClientProtocol
+    from websockets.client import connect as ws_connect
+    from websockets.typing import Data, Origin, Subprotocol
+except ImportError:
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager  # type: ignore
+    async def ws_connect(*args, **kwargs):  # pylint: disable=unused-argument
+        raise NotImplementedError("Subscriptions require 'websockets' package.")
+        yield  # pylint: disable=unreachable
+
+    WebSocketClientProtocol = Any  # type: ignore
+    Data = Any  # type: ignore
+    Origin = Any  # type: ignore
+    Subprotocol = Any  # type: ignore
+
+
+Self = TypeVar("Self", bound="AsyncBaseClient")
+
+GRAPHQL_TRANSPORT_WS = "graphql-transport-ws"
+
+
+class GraphQLTransportWSMessageType(str, enum.Enum):
+    CONNECTION_INIT = "connection_init"
+    CONNECTION_ACK = "connection_ack"
+    PING = "ping"
+    PONG = "pong"
+    SUBSCRIBE = "subscribe"
+    NEXT = "next"
+    ERROR = "error"
+    COMPLETE = "complete"
+
+
+class AsyncBaseClient:
+    def __init__(
+        self,
+        url: str = "",
+        headers: Optional[Dict[str, str]] = None,
+        http_client: Optional[httpx.AsyncClient] = None,
+        ws_url: str = "",
+        ws_headers: Optional[Dict[str, Any]] = None,
+        ws_origin: Optional[str] = None,
+        ws_connection_init_payload: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.url = url
+        self.headers = headers
+        self.http_client = (
+            http_client if http_client else httpx.AsyncClient(headers=headers)
+        )
+        self.ws_url = ws_url
+        self.ws_headers = ws_headers or {}
+        self.ws_origin = Origin(ws_origin) if ws_origin else None
+        self.ws_connection_init_payload = ws_connection_init_payload
+
+    async def __aenter__(self: Self) -> Self:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: object,
+        exc_val: object,
+        exc_tb: object,
+    ) -> None:
+        await self.http_client.aclose()
+
+    async def execute(
+        self, query: str, variables: Optional[Dict[str, Any]] = None
+    ) -> httpx.Response:
+        payload: Dict[str, Any] = {"query": query}
+        if variables:
+            payload["variables"] = self._convert_dict_to_json_serializable(variables)
+        return await self.http_client.post(url=self.url, json=payload)
+
+    def get_data(self, response: httpx.Response) -> Dict[str, Any]:
+        if not response.is_success:
+            raise GraphQLClientHttpError(
+                status_code=response.status_code, response=response
+            )
+
+        try:
+            response_json = response.json()
+        except ValueError as exc:
+            raise GraphQlClientInvalidResponseError(response=response) from exc
+
+        if (not isinstance(response_json, dict)) or ("data" not in response_json):
+            raise GraphQlClientInvalidResponseError(response=response)
+
+        data = response_json["data"]
+        errors = response_json.get("errors")
+
+        if errors:
+            raise GraphQLClientGraphQLMultiError.from_errors_dicts(
+                errors_dicts=errors, data=data
+            )
+
+        return cast(dict[str, Any], data)
+
+    async def execute_ws(
+        self, query: str, variables: Optional[Dict[str, Any]] = None
+    ) -> AsyncIterator[Dict[str, Any]]:
+        operation_id = str(uuid4())
+        async with ws_connect(
+            self.ws_url,
+            subprotocols=[Subprotocol(GRAPHQL_TRANSPORT_WS)],
+            origin=self.ws_origin,
+            extra_headers=self.ws_headers,
+        ) as websocket:
+            await self._send_connection_init(websocket)
+            await self._send_subscribe(
+                websocket,
+                operation_id=operation_id,
+                query=query,
+                variables=variables,
+            )
+
+            async for message in websocket:
+                data = await self._handle_ws_message(message, websocket)
+                if data:
+                    yield data
+
+    def _convert_dict_to_json_serializable(
+        self, dict_: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        return {
+            key: self._convert_value(value)
+            for key, value in dict_.items()
+            if value is not UNSET
+        }
+
+    def _convert_value(self, value: Any) -> Any:
+        if isinstance(value, BaseModel):
+            return value.dict(by_alias=True, exclude_unset=True)
+        if isinstance(value, list):
+            return [self._convert_value(item) for item in value]
+        return value
+
+    async def _send_connection_init(self, websocket: WebSocketClientProtocol) -> None:
+        payload: Dict[str, Any] = {
+            "type": GraphQLTransportWSMessageType.CONNECTION_INIT.value
+        }
+        if self.ws_connection_init_payload:
+            payload["payload"] = self.ws_connection_init_payload
+        await websocket.send(json.dumps(payload))
+
+    async def _send_subscribe(
+        self,
+        websocket: WebSocketClientProtocol,
+        operation_id: str,
+        query: str,
+        variables: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        payload: Dict[str, Any] = {
+            "id": operation_id,
+            "type": GraphQLTransportWSMessageType.SUBSCRIBE.value,
+            "payload": {"query": query},
+        }
+        if variables:
+            payload["payload"]["variables"] = self._convert_dict_to_json_serializable(
+                variables
+            )
+        await websocket.send(json.dumps(payload))
+
+    async def _handle_ws_message(
+        self, message: Data, websocket: WebSocketClientProtocol
+    ) -> Optional[Dict[str, Any]]:
+        try:
+            message_dict = json.loads(message)
+        except json.JSONDecodeError as exc:
+            raise GraphQLClientInvalidMessageFormat(message=message) from exc
+
+        type_ = message_dict.get("type")
+        payload = message_dict.get("payload", {})
+
+        if not type_ or type_ not in {t.value for t in GraphQLTransportWSMessageType}:
+            raise GraphQLClientInvalidMessageFormat(message=message)
+
+        if type_ == GraphQLTransportWSMessageType.NEXT:
+            if "data" not in payload:
+                raise GraphQLClientInvalidMessageFormat(message=message)
+            return cast(Dict[str, Any], payload["data"])
+
+        if type_ == GraphQLTransportWSMessageType.COMPLETE:
+            await websocket.close()
+        elif type_ == GraphQLTransportWSMessageType.PING:
+            await websocket.send(
+                json.dumps({"type": GraphQLTransportWSMessageType.PONG.value})
+            )
+        elif type_ == GraphQLTransportWSMessageType.ERROR:
+            raise GraphQLClientGraphQLMultiError.from_errors_dicts(
+                errors_dicts=payload, data=message_dict
+            )
+
+        return None

--- a/tests/main/clients/multiple_fragments/expected_client/base_model.py
+++ b/tests/main/clients/multiple_fragments/expected_client/base_model.py
@@ -1,0 +1,58 @@
+from typing import Any, Dict, Type, Union, get_args, get_origin
+
+from pydantic import BaseModel as PydanticBaseModel
+from pydantic.class_validators import validator
+from pydantic.fields import ModelField
+
+from .scalars import SCALARS_PARSE_FUNCTIONS, SCALARS_SERIALIZE_FUNCTIONS
+
+
+class UnsetType:
+    def __bool__(self) -> bool:
+        return False
+
+
+UNSET = UnsetType()
+
+
+class BaseModel(PydanticBaseModel):
+    class Config:
+        allow_population_by_field_name = True
+        validate_assignment = True
+        arbitrary_types_allowed = True
+
+    # pylint: disable=no-self-argument
+    @validator("*", pre=True)
+    def parse_custom_scalars(cls, value: Any, field: ModelField) -> Any:
+        return cls._parse_custom_scalar_value(value, field.annotation)
+
+    @classmethod
+    def _parse_custom_scalar_value(cls, value: Any, type_: Type[Any]) -> Any:
+        origin = get_origin(type_)
+        args = get_args(type_)
+        if origin is list and isinstance(value, list):
+            return [cls._parse_custom_scalar_value(item, args[0]) for item in value]
+
+        if origin is Union and type(None) in args:
+            sub_type: Any = list(filter(None, args))[0]
+            return cls._parse_custom_scalar_value(value, sub_type)
+
+        decode = SCALARS_PARSE_FUNCTIONS.get(type_)
+        if value and decode and callable(decode):
+            return decode(value)
+
+        return value
+
+    def dict(self, **kwargs: Any) -> Dict[str, Any]:
+        dict_ = super().dict(**kwargs)
+        return {key: self._serialize_value(value) for key, value in dict_.items()}
+
+    def _serialize_value(self, value: Any) -> Any:
+        serialize = SCALARS_SERIALIZE_FUNCTIONS.get(type(value))
+        if serialize and callable(serialize):
+            return serialize(value)
+
+        if isinstance(value, list):
+            return [self._serialize_value(item) for item in value]
+
+        return value

--- a/tests/main/clients/multiple_fragments/expected_client/client.py
+++ b/tests/main/clients/multiple_fragments/expected_client/client.py
@@ -1,0 +1,89 @@
+from .async_base_client import AsyncBaseClient
+from .example_query1 import ExampleQuery1
+from .example_query2 import ExampleQuery2
+from .example_query3 import ExampleQuery3
+
+
+def gql(q: str) -> str:
+    return q
+
+
+class Client(AsyncBaseClient):
+    async def example_query1(self) -> ExampleQuery1:
+        query = gql(
+            """
+            query exampleQuery1 {
+              exampleQuery {
+                value
+                ...MinimalA
+              }
+            }
+
+            fragment MinimalA on TypeA {
+              id
+              fieldB {
+                ...MinimalB
+              }
+            }
+
+            fragment MinimalB on TypeB {
+              id
+            }
+            """
+        )
+        variables: dict[str, object] = {}
+        response = await self.execute(query=query, variables=variables)
+        data = self.get_data(response)
+        return ExampleQuery1.parse_obj(data)
+
+    async def example_query2(self) -> ExampleQuery2:
+        query = gql(
+            """
+            query exampleQuery2 {
+              exampleQuery {
+                ...FullA
+              }
+            }
+
+            fragment FullA on TypeA {
+              id
+              value
+              fieldB {
+                ...FullB
+              }
+            }
+
+            fragment FullB on TypeB {
+              id
+              value
+            }
+            """
+        )
+        variables: dict[str, object] = {}
+        response = await self.execute(query=query, variables=variables)
+        data = self.get_data(response)
+        return ExampleQuery2.parse_obj(data)
+
+    async def example_query3(self) -> ExampleQuery3:
+        query = gql(
+            """
+            query exampleQuery3 {
+              exampleQuery {
+                ...CompleteA
+              }
+            }
+
+            fragment CompleteA on TypeA {
+              id
+              value
+              fieldB {
+                id
+                value
+              }
+            }
+            """
+        )
+        variables: dict[str, object] = {}
+        response = await self.execute(query=query, variables=variables)
+        data = self.get_data(response)
+        return ExampleQuery3.parse_obj(data)

--- a/tests/main/clients/multiple_fragments/expected_client/example_query1.py
+++ b/tests/main/clients/multiple_fragments/expected_client/example_query1.py
@@ -1,0 +1,16 @@
+from pydantic import Field
+
+from .base_model import BaseModel
+from .fragments import MinimalA
+
+
+class ExampleQuery1(BaseModel):
+    example_query: "ExampleQuery1ExampleQuery" = Field(alias="exampleQuery")
+
+
+class ExampleQuery1ExampleQuery(MinimalA):
+    value: str
+
+
+ExampleQuery1.update_forward_refs()
+ExampleQuery1ExampleQuery.update_forward_refs()

--- a/tests/main/clients/multiple_fragments/expected_client/example_query2.py
+++ b/tests/main/clients/multiple_fragments/expected_client/example_query2.py
@@ -1,0 +1,16 @@
+from pydantic import Field
+
+from .base_model import BaseModel
+from .fragments import FullA
+
+
+class ExampleQuery2(BaseModel):
+    example_query: "ExampleQuery2ExampleQuery" = Field(alias="exampleQuery")
+
+
+class ExampleQuery2ExampleQuery(FullA):
+    pass
+
+
+ExampleQuery2.update_forward_refs()
+ExampleQuery2ExampleQuery.update_forward_refs()

--- a/tests/main/clients/multiple_fragments/expected_client/example_query3.py
+++ b/tests/main/clients/multiple_fragments/expected_client/example_query3.py
@@ -1,0 +1,16 @@
+from pydantic import Field
+
+from .base_model import BaseModel
+from .fragments import CompleteA
+
+
+class ExampleQuery3(BaseModel):
+    example_query: "ExampleQuery3ExampleQuery" = Field(alias="exampleQuery")
+
+
+class ExampleQuery3ExampleQuery(CompleteA):
+    pass
+
+
+ExampleQuery3.update_forward_refs()
+ExampleQuery3ExampleQuery.update_forward_refs()

--- a/tests/main/clients/multiple_fragments/expected_client/exceptions.py
+++ b/tests/main/clients/multiple_fragments/expected_client/exceptions.py
@@ -1,0 +1,79 @@
+from typing import Any, Dict, List, Optional, Union
+
+import httpx
+
+
+class GraphQLClientError(Exception):
+    """Base exception."""
+
+
+class GraphQLClientHttpError(GraphQLClientError):
+    def __init__(self, status_code: int, response: httpx.Response) -> None:
+        self.status_code = status_code
+        self.response = response
+
+    def __str__(self) -> str:
+        return f"HTTP status code: {self.status_code}"
+
+
+class GraphQlClientInvalidResponseError(GraphQLClientError):
+    def __init__(self, response: httpx.Response) -> None:
+        self.response = response
+
+    def __str__(self) -> str:
+        return "Invalid response format."
+
+
+class GraphQLClientGraphQLError(GraphQLClientError):
+    def __init__(
+        self,
+        message: str,
+        locations: Optional[List[Dict[str, int]]] = None,
+        path: Optional[List[str]] = None,
+        extensions: Optional[Dict[str, object]] = None,
+        orginal: Optional[Dict[str, object]] = None,
+    ):
+        self.message = message
+        self.locations = locations
+        self.path = path
+        self.extensions = extensions
+        self.orginal = orginal
+
+    def __str__(self) -> str:
+        return self.message
+
+    @classmethod
+    def from_dict(cls, error: dict[str, Any]) -> "GraphQLClientGraphQLError":
+        return cls(
+            message=error["message"],
+            locations=error.get("locations"),
+            path=error.get("path"),
+            extensions=error.get("extensions"),
+            orginal=error,
+        )
+
+
+class GraphQLClientGraphQLMultiError(GraphQLClientError):
+    def __init__(self, errors: List[GraphQLClientGraphQLError], data: dict[str, Any]):
+        self.errors = errors
+        self.data = data
+
+    def __str__(self) -> str:
+        return "; ".join(str(e) for e in self.errors)
+
+    @classmethod
+    def from_errors_dicts(
+        cls, errors_dicts: List[dict[str, Any]], data: dict[str, Any]
+    ) -> "GraphQLClientGraphQLMultiError":
+        return cls(
+            errors=[GraphQLClientGraphQLError.from_dict(e) for e in errors_dicts],
+            data=data,
+        )
+
+
+class GraphQLClientInvalidMessageFormat(GraphQLClientError):
+    def __init__(self, message: Union[str, bytes]) -> None:
+        self.message = message
+
+    def __str__(self) -> str:
+        return "Invalid message format."

--- a/tests/main/clients/multiple_fragments/expected_client/fragments.py
+++ b/tests/main/clients/multiple_fragments/expected_client/fragments.py
@@ -1,0 +1,52 @@
+from pydantic import Field
+
+from .base_model import BaseModel
+
+
+class MinimalB(BaseModel):
+    id: str
+
+
+class MinimalA(BaseModel):
+    id: str
+    field_b: "MinimalAFieldB" = Field(alias="fieldB")
+
+
+class MinimalAFieldB(MinimalB):
+    pass
+
+
+class FullB(BaseModel):
+    id: str
+    value: float
+
+
+class FullA(BaseModel):
+    id: str
+    value: str
+    field_b: "FullAFieldB" = Field(alias="fieldB")
+
+
+class FullAFieldB(FullB):
+    pass
+
+
+class CompleteA(BaseModel):
+    id: str
+    value: str
+    field_b: "CompleteAFieldB" = Field(alias="fieldB")
+
+
+class CompleteAFieldB(BaseModel):
+    id: str
+    value: float
+
+
+MinimalB.update_forward_refs()
+MinimalA.update_forward_refs()
+MinimalAFieldB.update_forward_refs()
+FullB.update_forward_refs()
+FullA.update_forward_refs()
+FullAFieldB.update_forward_refs()
+CompleteA.update_forward_refs()
+CompleteAFieldB.update_forward_refs()

--- a/tests/main/clients/multiple_fragments/expected_client/scalars.py
+++ b/tests/main/clients/multiple_fragments/expected_client/scalars.py
@@ -1,0 +1,4 @@
+from typing import Any, Callable, Dict
+
+SCALARS_PARSE_FUNCTIONS: Dict[Any, Callable[[str], Any]] = {}
+SCALARS_SERIALIZE_FUNCTIONS: Dict[Any, Callable[[Any], str]] = {}

--- a/tests/main/clients/multiple_fragments/pyproject.toml
+++ b/tests/main/clients/multiple_fragments/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.ariadne-codegen]
+schema_path = "schema.graphql"
+queries_path = "queries.graphql"
+include_comments = false
+target_package_name = "multiple_fragments_client"

--- a/tests/main/clients/multiple_fragments/queries.graphql
+++ b/tests/main/clients/multiple_fragments/queries.graphql
@@ -1,0 +1,51 @@
+query exampleQuery1 {
+    exampleQuery {
+        value
+        ...MinimalA
+    }
+}
+
+query exampleQuery2 {
+    exampleQuery {
+        ...FullA
+    }
+}
+
+query exampleQuery3 {
+    exampleQuery {
+        ...CompleteA
+    }
+}
+
+fragment MinimalA on TypeA {
+    id
+    fieldB {
+        ...MinimalB
+    }
+}
+
+fragment MinimalB on TypeB {
+    id
+}
+
+fragment FullA on TypeA{
+    id
+    value
+    fieldB {
+        ...FullB
+    }
+}
+
+fragment FullB on TypeB {
+    id
+    value
+}
+
+fragment CompleteA on TypeA {
+    id
+    value
+    fieldB {
+        id
+        value
+    }
+}

--- a/tests/main/clients/multiple_fragments/schema.graphql
+++ b/tests/main/clients/multiple_fragments/schema.graphql
@@ -1,0 +1,18 @@
+schema {
+    query: Query
+}
+
+type Query {
+    exampleQuery: TypeA!
+}
+
+type TypeA {
+    id: ID!
+    value: String!
+    fieldB: TypeB!
+}
+
+type TypeB {
+    id: ID!
+    value: Float!
+}

--- a/tests/main/test_main.py
+++ b/tests/main/test_main.py
@@ -130,6 +130,17 @@ def test_main_shows_version():
             "inline_fragments_client",
             CLIENTS_PATH / "inline_fragments" / "expected_client",
         ),
+        (
+            (
+                CLIENTS_PATH / "multiple_fragments" / "pyproject.toml",
+                (
+                    CLIENTS_PATH / "multiple_fragments" / "queries.graphql",
+                    CLIENTS_PATH / "multiple_fragments" / "schema.graphql",
+                ),
+            ),
+            "multiple_fragments_client",
+            CLIENTS_PATH / "multiple_fragments" / "expected_client",
+        ),
     ],
     indirect=["project_dir"],
 )

--- a/tests/plugins/test_manager.py
+++ b/tests/plugins/test_manager.py
@@ -330,3 +330,15 @@ def test_process_name_calls_plugins_process_name(plugin_manager_with_mocked_plug
 
     assert plugin_manager_with_mocked_plugins.plugins[0].process_name.called
     assert plugin_manager_with_mocked_plugins.plugins[1].process_name.called
+
+
+def test_generate_fragments_module_calls_plugins_generate_fragments_module(
+    plugin_manager_with_mocked_plugins,
+):
+    plugin_manager_with_mocked_plugins.generate_fragments_module(
+        ast.Module(body=[]), {}
+    )
+
+    plugin1, plugin2 = plugin_manager_with_mocked_plugins.plugins
+    assert plugin1.generate_fragments_module.called
+    assert plugin2.generate_fragments_module.called


### PR DESCRIPTION
It took a while, but this pr resolves #135
Now generated client has extra file - `{fragments_module_name}.py` (by default `fragments.py`) which has classes for fragments from all operations. Now instead of "unpacking" fragment generated result class inherits from corresponding mixin.