### PR TITLE
Change order of generation 

### DIFF
--- a/ariadne_codegen/client_generators/package.py
+++ b/ariadne_codegen/client_generators/package.py
@@ -167,13 +167,13 @@ class PackageGenerator:
         self._validate_unique_file_names()
         if not self.package_path.exists():
             self.package_path.mkdir()
-        self._generate_client()
         self._generate_enums()
         self._generate_input_types()
         self._generate_result_types()
         self._generate_fragments()
         self._copy_files()
         self._generate_scalars_definitions()
+        self._generate_client()
         self._generate_init()
 
         return sorted(self.generated_files)


### PR DESCRIPTION
This pr changes order in which specific files are generated. Client generation is put as last to simplify work with client related hooks. This way when one of these hooks is called, plugin class can already have complete information from other hooks.
I propose this because of #141 because also I don't see downside, and I think this can also be helpful for other cases.