### PR TITLE
Fix ResultTypesGenerator to call generate_result_class only once for every class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added support for subscriptions as async generators.
 - Changed how fragments are handled to generate separate module with fragments as mixins.
+- Fixed `ResultTypesGenerator` to trigger `generate_result_class` for each result model.
 
 
 ## 0.6.0 (2023-04-18)

--- a/ariadne_codegen/client_generators/result_types.py
+++ b/ariadne_codegen/client_generators/result_types.py
@@ -249,15 +249,15 @@ class ResultTypesGenerator:
             self._save_used_enums(field_types_names)
             self._save_used_scalars(field_types_names)
 
-            if self.plugin_manager:
-                class_def = self.plugin_manager.generate_result_class(
-                    class_def,
-                    operation_definition=self.operation_definition,
-                    selection_set=selection_set,
-                )
-
         if not class_def.body:
             class_def.body.append(generate_pass())
+
+        if self.plugin_manager:
+            class_def = self.plugin_manager.generate_result_class(
+                class_def,
+                operation_definition=self.operation_definition,
+                selection_set=selection_set,
+            )
 
         return [class_def] + extra_classes
 


### PR DESCRIPTION
This pr fixes an issue with `generate_result_class` hook. Instead of being called once for model it was called once for each  model's field. Also it wasn't called at all for class which only has `pass` in body.