### PR TITLE
Document httpx usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ For more complex scenarios, you can pass your own http client:
 client = Client(http_client=CustomComplexHttpClient())
 ```
 
+`CustomComplexHttpClient` needs to be instance of `httpx.AsyncClient` for async client, or `httpx.Client` for sync.
+
 
 ### Websockets
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ For more complex scenarios, you can pass your own http client:
 client = Client(http_client=CustomComplexHttpClient())
 ```
 
-`CustomComplexHttpClient` needs to be instance of `httpx.AsyncClient` for async client, or `httpx.Client` for sync.
+`CustomComplexHttpClient` needs to be an instance of `httpx.AsyncClient` for async client, or `httpx.Client` for sync.
 
 
 ### Websockets


### PR DESCRIPTION
This pr adds information about `http_client=` argument. Other than that we already mention httpx [here](https://github.com/mirumee/ariadne-codegen/blob/main/README.md#generated-code-dependencies). Not sure if this is enough?
resolves #134 