### PR TITLE
Set type hints for parse and serialize to `typing.Any`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Removed `mixin` directive from operation string sent to server.
 - Fixed `ShorterResultsPlugin` that generated faulty code for discriminated unions.
 - Changed generator to ignore unused fragments which should be unpacked in queries.
+- Changed type hints for parse and serialize methods of scalars to `typing.Any`.
 
 
 ## 0.6.0 (2023-04-18)

--- a/ariadne_codegen/client_generators/dependencies/scalars.py
+++ b/ariadne_codegen/client_generators/dependencies/scalars.py
@@ -1,4 +1,4 @@
 from typing import Any, Callable, Dict
 
-SCALARS_PARSE_FUNCTIONS: Dict[Any, Callable[[str], Any]] = {}
-SCALARS_SERIALIZE_FUNCTIONS: Dict[Any, Callable[[Any], str]] = {}
+SCALARS_PARSE_FUNCTIONS: Dict[Any, Callable[[Any], Any]] = {}
+SCALARS_SERIALIZE_FUNCTIONS: Dict[Any, Callable[[Any], Any]] = {}

--- a/ariadne_codegen/client_generators/scalars.py
+++ b/ariadne_codegen/client_generators/scalars.py
@@ -120,14 +120,14 @@ class ScalarsDefinitionsGenerator:
                         name=SCALARS_PARSE_DICT_NAME,
                         dict_=self._parse_dict,
                         callable_annotation=generate_tuple(
-                            [generate_list([generate_name("str")]), generate_name(ANY)]
+                            [generate_list([generate_name(ANY)]), generate_name(ANY)]
                         ),
                     ),
                     self._generate_dict_assignment(
                         name=SCALARS_SERIALIZE_DICT_NAME,
                         dict_=self._serialize_dict,
                         callable_annotation=generate_tuple(
-                            [generate_list([generate_name(ANY)]), generate_name("str")]
+                            [generate_list([generate_name(ANY)]), generate_name(ANY)]
                         ),
                     ),
                 ],

--- a/tests/client_generators/test_scalars.py
+++ b/tests/client_generators/test_scalars.py
@@ -102,7 +102,7 @@ def test_generate_without_scalars_returns_module_with_empty_dicts():
                                 value=ast.Name(id=CALLABLE),
                                 slice=ast.Tuple(
                                     elts=[
-                                        ast.List(elts=[ast.Name(id="str")]),
+                                        ast.List(elts=[ast.Name(id=ANY)]),
                                         ast.Name(id=ANY),
                                     ]
                                 ),
@@ -125,7 +125,7 @@ def test_generate_without_scalars_returns_module_with_empty_dicts():
                                 slice=ast.Tuple(
                                     elts=[
                                         ast.List(elts=[ast.Name(id=ANY)]),
-                                        ast.Name(id="str"),
+                                        ast.Name(id=ANY),
                                     ]
                                 ),
                             ),
@@ -207,7 +207,7 @@ def test_generate_returns_module_with_dictionaries_with_scalars_methods():
                                 value=ast.Name(id=CALLABLE),
                                 slice=ast.Tuple(
                                     elts=[
-                                        ast.List(elts=[ast.Name(id="str")]),
+                                        ast.List(elts=[ast.Name(id=ANY)]),
                                         ast.Name(id=ANY),
                                     ]
                                 ),
@@ -233,7 +233,7 @@ def test_generate_returns_module_with_dictionaries_with_scalars_methods():
                                 slice=ast.Tuple(
                                     elts=[
                                         ast.List(elts=[ast.Name(id=ANY)]),
-                                        ast.Name(id="str"),
+                                        ast.Name(id=ANY),
                                     ]
                                 ),
                             ),

--- a/tests/main/clients/custom_base_client/expected_client/scalars.py
+++ b/tests/main/clients/custom_base_client/expected_client/scalars.py
@@ -1,4 +1,4 @@
 from typing import Any, Callable, Dict
 
-SCALARS_PARSE_FUNCTIONS: Dict[Any, Callable[[str], Any]] = {}
-SCALARS_SERIALIZE_FUNCTIONS: Dict[Any, Callable[[Any], str]] = {}
+SCALARS_PARSE_FUNCTIONS: Dict[Any, Callable[[Any], Any]] = {}
+SCALARS_SERIALIZE_FUNCTIONS: Dict[Any, Callable[[Any], Any]] = {}

--- a/tests/main/clients/custom_config_file/expected_client/scalars.py
+++ b/tests/main/clients/custom_config_file/expected_client/scalars.py
@@ -1,4 +1,4 @@
 from typing import Any, Callable, Dict
 
-SCALARS_PARSE_FUNCTIONS: Dict[Any, Callable[[str], Any]] = {}
-SCALARS_SERIALIZE_FUNCTIONS: Dict[Any, Callable[[Any], str]] = {}
+SCALARS_PARSE_FUNCTIONS: Dict[Any, Callable[[Any], Any]] = {}
+SCALARS_SERIALIZE_FUNCTIONS: Dict[Any, Callable[[Any], Any]] = {}

--- a/tests/main/clients/custom_files_names/expected_client/scalars.py
+++ b/tests/main/clients/custom_files_names/expected_client/scalars.py
@@ -1,4 +1,4 @@
 from typing import Any, Callable, Dict
 
-SCALARS_PARSE_FUNCTIONS: Dict[Any, Callable[[str], Any]] = {}
-SCALARS_SERIALIZE_FUNCTIONS: Dict[Any, Callable[[Any], str]] = {}
+SCALARS_PARSE_FUNCTIONS: Dict[Any, Callable[[Any], Any]] = {}
+SCALARS_SERIALIZE_FUNCTIONS: Dict[Any, Callable[[Any], Any]] = {}

--- a/tests/main/clients/custom_scalars/expected_client/scalars.py
+++ b/tests/main/clients/custom_scalars/expected_client/scalars.py
@@ -2,5 +2,5 @@ from typing import Any, Callable, Dict
 
 from .custom_scalars import Code, parse_code, serialize_code
 
-SCALARS_PARSE_FUNCTIONS: Dict[Any, Callable[[str], Any]] = {Code: parse_code}
-SCALARS_SERIALIZE_FUNCTIONS: Dict[Any, Callable[[Any], str]] = {Code: serialize_code}
+SCALARS_PARSE_FUNCTIONS: Dict[Any, Callable[[Any], Any]] = {Code: parse_code}
+SCALARS_SERIALIZE_FUNCTIONS: Dict[Any, Callable[[Any], Any]] = {Code: serialize_code}

--- a/tests/main/clients/example/expected_client/scalars.py
+++ b/tests/main/clients/example/expected_client/scalars.py
@@ -1,4 +1,4 @@
 from typing import Any, Callable, Dict
 
-SCALARS_PARSE_FUNCTIONS: Dict[Any, Callable[[str], Any]] = {}
-SCALARS_SERIALIZE_FUNCTIONS: Dict[Any, Callable[[Any], str]] = {}
+SCALARS_PARSE_FUNCTIONS: Dict[Any, Callable[[Any], Any]] = {}
+SCALARS_SERIALIZE_FUNCTIONS: Dict[Any, Callable[[Any], Any]] = {}

--- a/tests/main/clients/extended_models/expected_client/scalars.py
+++ b/tests/main/clients/extended_models/expected_client/scalars.py
@@ -1,4 +1,4 @@
 from typing import Any, Callable, Dict
 
-SCALARS_PARSE_FUNCTIONS: Dict[Any, Callable[[str], Any]] = {}
-SCALARS_SERIALIZE_FUNCTIONS: Dict[Any, Callable[[Any], str]] = {}
+SCALARS_PARSE_FUNCTIONS: Dict[Any, Callable[[Any], Any]] = {}
+SCALARS_SERIALIZE_FUNCTIONS: Dict[Any, Callable[[Any], Any]] = {}

--- a/tests/main/clients/inline_fragments/expected_client/scalars.py
+++ b/tests/main/clients/inline_fragments/expected_client/scalars.py
@@ -1,4 +1,4 @@
 from typing import Any, Callable, Dict
 
-SCALARS_PARSE_FUNCTIONS: Dict[Any, Callable[[str], Any]] = {}
-SCALARS_SERIALIZE_FUNCTIONS: Dict[Any, Callable[[Any], str]] = {}
+SCALARS_PARSE_FUNCTIONS: Dict[Any, Callable[[Any], Any]] = {}
+SCALARS_SERIALIZE_FUNCTIONS: Dict[Any, Callable[[Any], Any]] = {}

--- a/tests/main/clients/multiple_fragments/expected_client/scalars.py
+++ b/tests/main/clients/multiple_fragments/expected_client/scalars.py
@@ -1,4 +1,4 @@
 from typing import Any, Callable, Dict
 
-SCALARS_PARSE_FUNCTIONS: Dict[Any, Callable[[str], Any]] = {}
-SCALARS_SERIALIZE_FUNCTIONS: Dict[Any, Callable[[Any], str]] = {}
+SCALARS_PARSE_FUNCTIONS: Dict[Any, Callable[[Any], Any]] = {}
+SCALARS_SERIALIZE_FUNCTIONS: Dict[Any, Callable[[Any], Any]] = {}

--- a/tests/main/clients/remote_schema/expected_client/scalars.py
+++ b/tests/main/clients/remote_schema/expected_client/scalars.py
@@ -1,4 +1,4 @@
 from typing import Any, Callable, Dict
 
-SCALARS_PARSE_FUNCTIONS: Dict[Any, Callable[[str], Any]] = {}
-SCALARS_SERIALIZE_FUNCTIONS: Dict[Any, Callable[[Any], str]] = {}
+SCALARS_PARSE_FUNCTIONS: Dict[Any, Callable[[Any], Any]] = {}
+SCALARS_SERIALIZE_FUNCTIONS: Dict[Any, Callable[[Any], Any]] = {}

--- a/tests/main/clients/shorter_results/expected_client/scalars.py
+++ b/tests/main/clients/shorter_results/expected_client/scalars.py
@@ -1,4 +1,4 @@
 from typing import Any, Callable, Dict
 
-SCALARS_PARSE_FUNCTIONS: Dict[Any, Callable[[str], Any]] = {}
-SCALARS_SERIALIZE_FUNCTIONS: Dict[Any, Callable[[Any], str]] = {}
+SCALARS_PARSE_FUNCTIONS: Dict[Any, Callable[[Any], Any]] = {}
+SCALARS_SERIALIZE_FUNCTIONS: Dict[Any, Callable[[Any], Any]] = {}


### PR DESCRIPTION
It's possible to use scalars for other types than `str`, f.ex. raw JSON with objects and/or lists or floats.

Given a scalar type that's not a `pydantic` class we might want to return a JSON serializable type like a `dict` or `list` from the serialize function.

Similarly we might want to accept such type when parsing it to our custom type.

---

We use custom scalars for raw JSON in some cases. Maybe this is a weird example but to demonstrate how this would be used.

```graphql
# schema.graphql
scalar MyScalar

type Mutation {
  create(input: MyScalar!): String!
}

# query.graphql
mutation TestMutation($input: MyScalar!) {
  create(input: $input)
}
```

```python
@dataclass
class SnowmanKeys:
    keys: list[str]
    value: str = "⛄️"


MyScalar = SnowmanKeys


def serialize_my_scalar(value: MyScalar):
    return {k: value.value for k in value.keys}
```

```toml
[tool.ariadne-codegen.scalars.MyScalar]
type = "scalars.MyScalar"
serialize = "scalars.serialize_my_scalar"
```

With this setup, given the following code

```python
await Client().test_mutation(input=SnowmanKeys(keys=["foo", "bar"]))
```

The generated GraphQL request would be

```graphql
{
    'query': 'mutation TestMutation($input: MyScalar!) { create(input: $input) }',
    'variables': {
        'input': { 'foo': '⛄️', 'bar': '⛄️' }
    }
}
```
