### PR TITLE
Support single underscore as a field name

### DIFF
--- a/ariadne_codegen/utils.py
+++ b/ariadne_codegen/utils.py
@@ -93,6 +93,8 @@ def process_name(
         processed_name += "_"
     if trim_leading_underscore:
         processed_name = processed_name.lstrip("_")
+        if not processed_name:
+            processed_name = "underscore_"
     if plugin_manager:
         processed_name = plugin_manager.process_name(processed_name, node=node)
     return processed_name

--- a/tests/client_generators/input_types_generator/test_names.py
+++ b/tests/client_generators/input_types_generator/test_names.py
@@ -153,6 +153,7 @@ def test_generate_returns_module_with_valid_field_names():
         _foo: String!
         _Bar: String!
         ____baz_: String!
+        _: String!
     }
     """
 
@@ -167,4 +168,4 @@ def test_generate_returns_module_with_valid_field_names():
     )  # Round trip because invalid identifiers get picked up in parse
     class_def = get_class_def(parsed)
     field_names = get_assignment_target_names(class_def)
-    assert field_names == {"in_", "from_", "and_", "foo", "bar", "baz_"}
+    assert field_names == {"in_", "from_", "and_", "foo", "bar", "baz_", "underscore_"}

--- a/tests/client_generators/result_types_generator/schema.py
+++ b/tests/client_generators/result_types_generator/schema.py
@@ -32,6 +32,7 @@ type CustomType {
   _field4: String!
   _Field5: String!
   scalarField: SCALARA
+  _: String!
 }
 
 type CustomType1 {

--- a/tests/client_generators/result_types_generator/test_names.py
+++ b/tests/client_generators/result_types_generator/test_names.py
@@ -117,6 +117,7 @@ def test_generate_returns_module_with_valid_field_names():
             in: id
             _field4
             _Field5
+            _
         }
     }
     """
@@ -136,4 +137,4 @@ def test_generate_returns_module_with_valid_field_names():
     )  # Round trip because invalid identifiers get picked up in parse
     class_def = get_class_def(parsed, name_filter="CustomQueryCamelCaseQuery")
     field_names = get_assignment_target_names(class_def)
-    assert field_names == {"in_", "field4", "field5"}
+    assert field_names == {"in_", "field4", "field5", "underscore_"}


### PR DESCRIPTION
Without this fix, codegen fails with a parse error if the schema contains any fields named just `_`.