### PR TITLE
Serialize variables using pydantic_encoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Added `ShorterResultsPlugin` to standard plugins.
 - Fixed handling of inline fragments inside other fragments.
 - Changed generated unions to use pydantic's discriminated unions feature.
-- Used pydantic's `pydantic_encoder` to serialize `variables` dict.
+- Replaced HTTPX's `json=` serializer for query payloads with pydantic's `pydantic_encoder`.
 
 
 ## 0.6.0 (2023-04-18)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added `ShorterResultsPlugin` to standard plugins.
 - Fixed handling of inline fragments inside other fragments.
 - Changed generated unions to use pydantic's discriminated unions feature.
+- Used pydantic's `pydantic_encoder` to serialize `variables` dict.
 
 
 ## 0.6.0 (2023-04-18)

--- a/ariadne_codegen/client_generators/dependencies/async_base_client.py
+++ b/ariadne_codegen/client_generators/dependencies/async_base_client.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 
 import httpx
 from pydantic import BaseModel
+from pydantic.json import pydantic_encoder
 
 from .base_model import UNSET
 from .exceptions import (
@@ -86,7 +87,8 @@ class AsyncBaseClient:
         payload: Dict[str, Any] = {"query": query}
         if variables:
             payload["variables"] = self._convert_dict_to_json_serializable(variables)
-        return await self.http_client.post(url=self.url, json=payload)
+        content = json.dumps(payload, default=pydantic_encoder)
+        return await self.http_client.post(url=self.url, content=content)
 
     def get_data(self, response: httpx.Response) -> Dict[str, Any]:
         if not response.is_success:

--- a/ariadne_codegen/client_generators/dependencies/base_client.py
+++ b/ariadne_codegen/client_generators/dependencies/base_client.py
@@ -1,7 +1,9 @@
+import json
 from typing import Any, Dict, Optional, TypeVar, cast
 
 import httpx
 from pydantic import BaseModel
+from pydantic.json import pydantic_encoder
 
 from .base_model import UNSET
 from .exceptions import (
@@ -42,7 +44,8 @@ class BaseClient:
         payload: Dict[str, Any] = {"query": query}
         if variables:
             payload["variables"] = self._convert_dict_to_json_serializable(variables)
-        return self.http_client.post(url=self.url, json=payload)
+        content = json.dumps(payload, default=pydantic_encoder)
+        return self.http_client.post(url=self.url, content=content)
 
     def get_data(self, response: httpx.Response) -> dict[str, Any]:
         if not response.is_success:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dev = [
   "types-toml",
   "pytest-mock",
   "pytest-asyncio",
+  "pytest-httpx",
   "freezegun",
 ]
 subscriptions = ["websockets~=11.0"]

--- a/tests/client_generators/dependencies/test_async_base_client.py
+++ b/tests/client_generators/dependencies/test_async_base_client.py
@@ -17,9 +17,10 @@ from ariadne_codegen.client_generators.dependencies.exceptions import (
 
 
 @pytest.mark.asyncio
-async def test_execute_sends_post_to_correct_url_with_correct_payload(mocker):
-    fake_client = mocker.AsyncMock()
-    client = AsyncBaseClient(url="base_url/endpoint", http_client=fake_client)
+async def test_execute_sends_post_to_correct_url_with_correct_payload(httpx_mock):
+    httpx_mock.add_response()
+
+    client = AsyncBaseClient(url="http://base_url/endpoint")
     query_str = """
     query Abc($v: String!) {
         abc(v: $v) {
@@ -30,23 +31,22 @@ async def test_execute_sends_post_to_correct_url_with_correct_payload(mocker):
 
     await client.execute(query_str, {"v": "Xyz"})
 
-    assert fake_client.post.called
-    assert len(fake_client.post.mock_calls) == 1
-    call_kwargs = fake_client.post.mock_calls[0].kwargs
-    assert call_kwargs["url"] == "base_url/endpoint"
-    assert call_kwargs["json"] == {"query": query_str, "variables": {"v": "Xyz"}}
+    request = httpx_mock.get_request()
+    assert request.url == "http://base_url/endpoint"
+    content = json.loads(request.content)
+    assert content == {"query": query_str, "variables": {"v": "Xyz"}}
 
 
 @pytest.mark.asyncio
-async def test_execute_parses_pydantic_variables_before_sending(mocker):
+async def test_execute_parses_pydantic_variables_before_sending(httpx_mock):
     class TestModel1(BaseModel):
         a: int
 
     class TestModel2(BaseModel):
         nested: TestModel1
 
-    fake_client = mocker.AsyncMock()
-    client = AsyncBaseClient(url="base_url", http_client=fake_client)
+    httpx_mock.add_response()
+    client = AsyncBaseClient(url="http://base_url")
     query_str = """
     query Abc($v1: TestModel1!, $v2: TestModel2) {
         abc(v1: $v1, v2: $v2){
@@ -59,23 +59,21 @@ async def test_execute_parses_pydantic_variables_before_sending(mocker):
         query_str, {"v1": TestModel1(a=5), "v2": TestModel2(nested=TestModel1(a=10))}
     )
 
-    assert fake_client.post.called
-    assert len(fake_client.post.mock_calls) == 1
-    call_kwargs = fake_client.post.mock_calls[0].kwargs
-    assert call_kwargs["url"] == "base_url"
-    assert call_kwargs["json"] == {
+    request = httpx_mock.get_request()
+    content = json.loads(request.content)
+    assert content == {
         "query": query_str,
         "variables": {"v1": {"a": 5}, "v2": {"nested": {"a": 10}}},
     }
 
 
 @pytest.mark.asyncio
-async def test_execute_correctly_parses_top_level_list_variables(mocker):
+async def test_execute_correctly_parses_top_level_list_variables(httpx_mock):
     class TestModel1(BaseModel):
         a: int
 
-    fake_client = mocker.AsyncMock()
-    client = AsyncBaseClient(url="base_url", http_client=fake_client)
+    httpx_mock.add_response()
+    client = AsyncBaseClient(url="http://base_url")
     query_str = """
     query Abc($v1: [[TestModel1!]!]!) {
         abc(v1: $v1){
@@ -91,23 +89,19 @@ async def test_execute_correctly_parses_top_level_list_variables(mocker):
         },
     )
 
-    assert fake_client.post.called
-    assert len(fake_client.post.mock_calls) == 1
-    call_kwargs = fake_client.post.mock_calls[0].kwargs
-    assert call_kwargs["url"] == "base_url"
-    assert call_kwargs["json"] == {
+    request = httpx_mock.get_request()
+    content = json.loads(request.content)
+    assert content == {
         "query": query_str,
         "variables": {"v1": [[{"a": 1}, {"a": 2}]]},
     }
-    assert not any(
-        isinstance(x, BaseModel) for x in call_kwargs["json"]["variables"]["v1"][0]
-    )
+    assert not any(isinstance(x, BaseModel) for x in content["variables"]["v1"][0])
 
 
 @pytest.mark.asyncio
-async def test_execute_sends_payload_without_unset_arguments(mocker):
-    fake_client = mocker.AsyncMock()
-    client = AsyncBaseClient(url="url", http_client=fake_client)
+async def test_execute_sends_payload_without_unset_arguments(httpx_mock):
+    httpx_mock.add_response()
+    client = AsyncBaseClient(url="http://base_url")
     query_str = """
     query Abc($arg1: TestInputA, $arg2: String, $arg3: Float, $arg4: Int!) {
         abc(arg1: $arg1, arg2: $arg2, arg3: $arg3, arg4: $arg4){
@@ -120,17 +114,16 @@ async def test_execute_sends_payload_without_unset_arguments(mocker):
         query_str, {"arg1": UNSET, "arg2": UNSET, "arg3": None, "arg4": 2}
     )
 
-    assert fake_client.post.called
-    assert len(fake_client.post.mock_calls) == 1
-    call_kwargs = fake_client.post.mock_calls[0].kwargs
-    assert call_kwargs["json"] == {
+    request = httpx_mock.get_request()
+    content = json.loads(request.content)
+    assert content == {
         "query": query_str,
         "variables": {"arg3": None, "arg4": 2},
     }
 
 
 @pytest.mark.asyncio
-async def test_execute_sends_payload_without_unset_input_fields(mocker):
+async def test_execute_sends_payload_without_unset_input_fields(httpx_mock):
     class TestInputB(BaseModel):
         required_b: str
         optional_b: Optional[str]
@@ -142,8 +135,8 @@ async def test_execute_sends_payload_without_unset_input_fields(mocker):
         input_b2: Optional[TestInputB]
         input_b3: Optional[TestInputB]
 
-    fake_client = mocker.AsyncMock()
-    client = AsyncBaseClient(url="url", http_client=fake_client)
+    httpx_mock.add_response()
+    client = AsyncBaseClient(url="http://base_url")
     query_str = """
     query Abc($arg: TestInputB) {
         abc(arg: $arg){
@@ -161,10 +154,9 @@ async def test_execute_sends_payload_without_unset_input_fields(mocker):
         },
     )
 
-    assert fake_client.post.called
-    assert len(fake_client.post.mock_calls) == 1
-    call_kwargs = fake_client.post.mock_calls[0].kwargs
-    assert call_kwargs["json"] == {
+    request = httpx_mock.get_request()
+    content = json.loads(request.content)
+    assert content == {
         "query": query_str,
         "variables": {
             "arg": {

--- a/tests/client_generators/dependencies/test_async_base_client.py
+++ b/tests/client_generators/dependencies/test_async_base_client.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime
 from typing import Optional
 
 import httpx
@@ -166,6 +167,22 @@ async def test_execute_sends_payload_without_unset_input_fields(httpx_mock):
             }
         },
     }
+
+
+@pytest.mark.asyncio
+async def test_execute_sends_payload_with_serialized_datetime_without_exception(
+    httpx_mock,
+):
+    httpx_mock.add_response()
+    client = AsyncBaseClient(url="http://base_url")
+    query_str = "query Abc($arg: DATETIME) { abc }"
+    arg_value = datetime(2023, 12, 31, 10, 15)
+
+    await client.execute(query_str, {"arg": arg_value})
+
+    request = httpx_mock.get_request()
+    content = json.loads(request.content)
+    assert content["variables"]["arg"] == arg_value.isoformat()
 
 
 @pytest.mark.parametrize(

--- a/tests/client_generators/dependencies/test_base_client.py
+++ b/tests/client_generators/dependencies/test_base_client.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime
 from typing import Optional
 
 import httpx
@@ -156,6 +157,19 @@ def test_execute_sends_payload_without_unset_input_fields(httpx_mock):
             }
         },
     }
+
+
+def test_execute_sends_payload_with_serialized_datetime_without_exception(httpx_mock):
+    httpx_mock.add_response()
+    client = BaseClient(url="http://base_url")
+    query_str = "query Abc($arg: DATETIME) { abc }"
+    arg_value = datetime(2023, 12, 31, 10, 15)
+
+    client.execute(query_str, {"arg": arg_value})
+
+    request = httpx_mock.get_request()
+    content = json.loads(request.content)
+    assert content["variables"]["arg"] == arg_value.isoformat()
 
 
 @pytest.mark.parametrize(

--- a/tests/client_generators/dependencies/test_base_client.py
+++ b/tests/client_generators/dependencies/test_base_client.py
@@ -14,9 +14,9 @@ from ariadne_codegen.client_generators.dependencies.exceptions import (
 )
 
 
-def test_execute_sends_post_to_correct_url_with_correct_payload(mocker):
-    fake_client = mocker.MagicMock()
-    client = BaseClient(url="base_url/endpoint", http_client=fake_client)
+def test_execute_sends_post_to_correct_url_with_correct_payload(httpx_mock):
+    httpx_mock.add_response()
+    client = BaseClient(url="http://base_url/endpoint")
     query_str = """
     query Abc($v: String!) {
         abc(v: $v) {
@@ -27,22 +27,21 @@ def test_execute_sends_post_to_correct_url_with_correct_payload(mocker):
 
     client.execute(query_str, {"v": "Xyz"})
 
-    assert fake_client.post.called
-    assert len(fake_client.post.mock_calls) == 1
-    call_kwargs = fake_client.post.mock_calls[0].kwargs
-    assert call_kwargs["url"] == "base_url/endpoint"
-    assert call_kwargs["json"] == {"query": query_str, "variables": {"v": "Xyz"}}
+    request = httpx_mock.get_request()
+    assert request.url == "http://base_url/endpoint"
+    content = json.loads(request.content)
+    assert content == {"query": query_str, "variables": {"v": "Xyz"}}
 
 
-def test_execute_parses_pydantic_variables_before_sending(mocker):
+def test_execute_parses_pydantic_variables_before_sending(httpx_mock):
     class TestModel1(BaseModel):
         a: int
 
     class TestModel2(BaseModel):
         nested: TestModel1
 
-    fake_client = mocker.MagicMock()
-    client = BaseClient(url="base_url", http_client=fake_client)
+    httpx_mock.add_response()
+    client = BaseClient(url="http://base_url")
     query_str = """
     query Abc($v1: TestModel1!, $v2: TestModel2) {
         abc(v1: $v1, v2: $v2){
@@ -55,22 +54,20 @@ def test_execute_parses_pydantic_variables_before_sending(mocker):
         query_str, {"v1": TestModel1(a=5), "v2": TestModel2(nested=TestModel1(a=10))}
     )
 
-    assert fake_client.post.called
-    assert len(fake_client.post.mock_calls) == 1
-    call_kwargs = fake_client.post.mock_calls[0].kwargs
-    assert call_kwargs["url"] == "base_url"
-    assert call_kwargs["json"] == {
+    request = httpx_mock.get_request()
+    content = json.loads(request.content)
+    assert content == {
         "query": query_str,
         "variables": {"v1": {"a": 5}, "v2": {"nested": {"a": 10}}},
     }
 
 
-def test_execute_correctly_parses_top_level_list_variables(mocker):
+def test_execute_correctly_parses_top_level_list_variables(httpx_mock):
     class TestModel1(BaseModel):
         a: int
 
-    fake_client = mocker.MagicMock()
-    client = BaseClient(url="base_url", http_client=fake_client)
+    httpx_mock.add_response()
+    client = BaseClient(url="http://base_url")
     query_str = """
     query Abc($v1: [[TestModel1!]!]!) {
         abc(v1: $v1){
@@ -86,22 +83,18 @@ def test_execute_correctly_parses_top_level_list_variables(mocker):
         },
     )
 
-    assert fake_client.post.called
-    assert len(fake_client.post.mock_calls) == 1
-    call_kwargs = fake_client.post.mock_calls[0].kwargs
-    assert call_kwargs["url"] == "base_url"
-    assert call_kwargs["json"] == {
+    request = httpx_mock.get_request()
+    content = json.loads(request.content)
+    assert content == {
         "query": query_str,
         "variables": {"v1": [[{"a": 1}, {"a": 2}]]},
     }
-    assert not any(
-        isinstance(x, BaseModel) for x in call_kwargs["json"]["variables"]["v1"][0]
-    )
+    assert not any(isinstance(x, BaseModel) for x in content["variables"]["v1"][0])
 
 
-def test_execute_sends_payload_without_unset_arguments(mocker):
-    fake_client = mocker.MagicMock()
-    client = BaseClient(url="url", http_client=fake_client)
+def test_execute_sends_payload_without_unset_arguments(httpx_mock):
+    httpx_mock.add_response()
+    client = BaseClient(url="http://base_url")
     query_str = """
     query Abc($arg1: TestInputA, $arg2: String, $arg3: Float, $arg4: Int!) {
         abc(arg1: $arg1, arg2: $arg2, arg3: $arg3, arg4: $arg4){
@@ -112,16 +105,15 @@ def test_execute_sends_payload_without_unset_arguments(mocker):
 
     client.execute(query_str, {"arg1": UNSET, "arg2": UNSET, "arg3": None, "arg4": 2})
 
-    assert fake_client.post.called
-    assert len(fake_client.post.mock_calls) == 1
-    call_kwargs = fake_client.post.mock_calls[0].kwargs
-    assert call_kwargs["json"] == {
+    request = httpx_mock.get_request()
+    content = json.loads(request.content)
+    assert content == {
         "query": query_str,
         "variables": {"arg3": None, "arg4": 2},
     }
 
 
-def test_execute_sends_payload_without_unset_input_fields(mocker):
+def test_execute_sends_payload_without_unset_input_fields(httpx_mock):
     class TestInputB(BaseModel):
         required_b: str
         optional_b: Optional[str]
@@ -133,8 +125,8 @@ def test_execute_sends_payload_without_unset_input_fields(mocker):
         input_b2: Optional[TestInputB]
         input_b3: Optional[TestInputB]
 
-    fake_client = mocker.MagicMock()
-    client = BaseClient(url="url", http_client=fake_client)
+    httpx_mock.add_response()
+    client = BaseClient(url="http://base_url")
     query_str = """
     query Abc($arg: TestInputB) {
         abc(arg: $arg){
@@ -152,10 +144,9 @@ def test_execute_sends_payload_without_unset_input_fields(mocker):
         },
     )
 
-    assert fake_client.post.called
-    assert len(fake_client.post.mock_calls) == 1
-    call_kwargs = fake_client.post.mock_calls[0].kwargs
-    assert call_kwargs["json"] == {
+    request = httpx_mock.get_request()
+    content = json.loads(request.content)
+    assert content == {
         "query": query_str,
         "variables": {
             "arg": {

--- a/tests/main/clients/custom_config_file/expected_client/async_base_client.py
+++ b/tests/main/clients/custom_config_file/expected_client/async_base_client.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 
 import httpx
 from pydantic import BaseModel
+from pydantic.json import pydantic_encoder
 
 from .base_model import UNSET
 from .exceptions import (
@@ -86,7 +87,8 @@ class AsyncBaseClient:
         payload: Dict[str, Any] = {"query": query}
         if variables:
             payload["variables"] = self._convert_dict_to_json_serializable(variables)
-        return await self.http_client.post(url=self.url, json=payload)
+        content = json.dumps(payload, default=pydantic_encoder)
+        return await self.http_client.post(url=self.url, content=content)
 
     def get_data(self, response: httpx.Response) -> Dict[str, Any]:
         if not response.is_success:

--- a/tests/main/clients/custom_files_names/expected_client/async_base_client.py
+++ b/tests/main/clients/custom_files_names/expected_client/async_base_client.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 
 import httpx
 from pydantic import BaseModel
+from pydantic.json import pydantic_encoder
 
 from .base_model import UNSET
 from .exceptions import (
@@ -86,7 +87,8 @@ class AsyncBaseClient:
         payload: Dict[str, Any] = {"query": query}
         if variables:
             payload["variables"] = self._convert_dict_to_json_serializable(variables)
-        return await self.http_client.post(url=self.url, json=payload)
+        content = json.dumps(payload, default=pydantic_encoder)
+        return await self.http_client.post(url=self.url, content=content)
 
     def get_data(self, response: httpx.Response) -> Dict[str, Any]:
         if not response.is_success:

--- a/tests/main/clients/custom_scalars/expected_client/async_base_client.py
+++ b/tests/main/clients/custom_scalars/expected_client/async_base_client.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 
 import httpx
 from pydantic import BaseModel
+from pydantic.json import pydantic_encoder
 
 from .base_model import UNSET
 from .exceptions import (
@@ -86,7 +87,8 @@ class AsyncBaseClient:
         payload: Dict[str, Any] = {"query": query}
         if variables:
             payload["variables"] = self._convert_dict_to_json_serializable(variables)
-        return await self.http_client.post(url=self.url, json=payload)
+        content = json.dumps(payload, default=pydantic_encoder)
+        return await self.http_client.post(url=self.url, content=content)
 
     def get_data(self, response: httpx.Response) -> Dict[str, Any]:
         if not response.is_success:

--- a/tests/main/clients/example/expected_client/async_base_client.py
+++ b/tests/main/clients/example/expected_client/async_base_client.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 
 import httpx
 from pydantic import BaseModel
+from pydantic.json import pydantic_encoder
 
 from .base_model import UNSET
 from .exceptions import (
@@ -86,7 +87,8 @@ class AsyncBaseClient:
         payload: Dict[str, Any] = {"query": query}
         if variables:
             payload["variables"] = self._convert_dict_to_json_serializable(variables)
-        return await self.http_client.post(url=self.url, json=payload)
+        content = json.dumps(payload, default=pydantic_encoder)
+        return await self.http_client.post(url=self.url, content=content)
 
     def get_data(self, response: httpx.Response) -> Dict[str, Any]:
         if not response.is_success:

--- a/tests/main/clients/extended_models/expected_client/async_base_client.py
+++ b/tests/main/clients/extended_models/expected_client/async_base_client.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 
 import httpx
 from pydantic import BaseModel
+from pydantic.json import pydantic_encoder
 
 from .base_model import UNSET
 from .exceptions import (
@@ -86,7 +87,8 @@ class AsyncBaseClient:
         payload: Dict[str, Any] = {"query": query}
         if variables:
             payload["variables"] = self._convert_dict_to_json_serializable(variables)
-        return await self.http_client.post(url=self.url, json=payload)
+        content = json.dumps(payload, default=pydantic_encoder)
+        return await self.http_client.post(url=self.url, content=content)
 
     def get_data(self, response: httpx.Response) -> Dict[str, Any]:
         if not response.is_success:

--- a/tests/main/clients/inline_fragments/expected_client/async_base_client.py
+++ b/tests/main/clients/inline_fragments/expected_client/async_base_client.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 
 import httpx
 from pydantic import BaseModel
+from pydantic.json import pydantic_encoder
 
 from .base_model import UNSET
 from .exceptions import (
@@ -86,7 +87,8 @@ class AsyncBaseClient:
         payload: Dict[str, Any] = {"query": query}
         if variables:
             payload["variables"] = self._convert_dict_to_json_serializable(variables)
-        return await self.http_client.post(url=self.url, json=payload)
+        content = json.dumps(payload, default=pydantic_encoder)
+        return await self.http_client.post(url=self.url, content=content)
 
     def get_data(self, response: httpx.Response) -> Dict[str, Any]:
         if not response.is_success:

--- a/tests/main/clients/multiple_fragments/expected_client/async_base_client.py
+++ b/tests/main/clients/multiple_fragments/expected_client/async_base_client.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 
 import httpx
 from pydantic import BaseModel
+from pydantic.json import pydantic_encoder
 
 from .base_model import UNSET
 from .exceptions import (
@@ -86,7 +87,8 @@ class AsyncBaseClient:
         payload: Dict[str, Any] = {"query": query}
         if variables:
             payload["variables"] = self._convert_dict_to_json_serializable(variables)
-        return await self.http_client.post(url=self.url, json=payload)
+        content = json.dumps(payload, default=pydantic_encoder)
+        return await self.http_client.post(url=self.url, content=content)
 
     def get_data(self, response: httpx.Response) -> Dict[str, Any]:
         if not response.is_success:

--- a/tests/main/clients/remote_schema/expected_client/async_base_client.py
+++ b/tests/main/clients/remote_schema/expected_client/async_base_client.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 
 import httpx
 from pydantic import BaseModel
+from pydantic.json import pydantic_encoder
 
 from .base_model import UNSET
 from .exceptions import (
@@ -86,7 +87,8 @@ class AsyncBaseClient:
         payload: Dict[str, Any] = {"query": query}
         if variables:
             payload["variables"] = self._convert_dict_to_json_serializable(variables)
-        return await self.http_client.post(url=self.url, json=payload)
+        content = json.dumps(payload, default=pydantic_encoder)
+        return await self.http_client.post(url=self.url, content=content)
 
     def get_data(self, response: httpx.Response) -> Dict[str, Any]:
         if not response.is_success:

--- a/tests/main/clients/shorter_results/expected_client/async_base_client.py
+++ b/tests/main/clients/shorter_results/expected_client/async_base_client.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 
 import httpx
 from pydantic import BaseModel
+from pydantic.json import pydantic_encoder
 
 from .base_model import UNSET
 from .exceptions import (
@@ -86,7 +87,8 @@ class AsyncBaseClient:
         payload: Dict[str, Any] = {"query": query}
         if variables:
             payload["variables"] = self._convert_dict_to_json_serializable(variables)
-        return await self.http_client.post(url=self.url, json=payload)
+        content = json.dumps(payload, default=pydantic_encoder)
+        return await self.http_client.post(url=self.url, content=content)
 
     def get_data(self, response: httpx.Response) -> Dict[str, Any]:
         if not response.is_success:


### PR DESCRIPTION
This pr:
- adds [pytest-httpxs](https://github.com/Colin-b/pytest_httpx) as dev dependency
- changes base clients to use pydantic's [pydantic_encoder](https://docs.pydantic.dev/latest/usage/dataclasses/#json-dumping) for serialization of sent payload, without this change we handle some types for result fields but not for arguments, eg. `datetime.datetime` when someone provides it as scalar type (without custom `parse`/`serialize`), then result field with type `datetime.datetime` works fine, but argument with the same type causes exception