### PR TITLE
Remove `Annotated` from return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Changed generated unions to use pydantic's discriminated unions feature.
 - Replaced HTTPX's `json=` serializer for query payloads with pydantic's `pydantic_encoder`.
 - Removed `mixin` directive from operation string sent to server.
+- Fixed `ShorterResultsPlugin` that generated faulty code for discriminated unions.
 
 
 ## 0.6.0 (2023-04-18)

--- a/ariadne_codegen/contrib/shorter_results.py
+++ b/ariadne_codegen/contrib/shorter_results.py
@@ -361,17 +361,43 @@ def _update_node(node: ast.expr) -> tuple[ast.expr, List[str]]:
         return node, [node.id]
 
     if isinstance(node, ast.Subscript):
-        node.slice, node_ids = _update_node(node.slice)
+        child_node, node_ids = _update_node(node.slice)
+
+        # We don't want to keep annotations in the return type so if the node is
+        # an annotated subscript (which may come from something like interface
+        # discriminators), remove them.
+        if isinstance(node.value, ast.Name) and node.value.id == "Annotated":
+            return child_node, node_ids
+
+        node.slice = child_node
 
         return node, node_ids
 
     if isinstance(node, ast.Tuple):
+        # If the tuple is a two element tuple with the first element as a
+        # subscript and the second as a call expression calling `Field` it comes
+        # from a discriminator annotation which isn't needed as the return type.
+        # Just return the first node and its elements and drop the call
+        # expression.
+        if len(node.elts) == 2:
+            first_node, second_node = node.elts
+            if (
+                isinstance(first_node, ast.Subscript)
+                and isinstance(second_node, ast.Call)
+                and isinstance(second_node.func, ast.Name)
+                and second_node.func.id == "Field"
+            ):
+                return _update_node(first_node)
+
         all_node_ids = []
         for i, elt in enumerate(node.elts):
             node.elts[i], node_ids = _update_node(elt)
             all_node_ids.extend(node_ids)
 
         return node, all_node_ids
+
+    if isinstance(node, ast.expr):
+        return node, []
 
     return ast.expr(), []
 

--- a/tests/main/clients/shorter_results/expected_client/__init__.py
+++ b/tests/main/clients/shorter_results/expected_client/__init__.py
@@ -19,6 +19,12 @@ from .get_animal_by_name import (
 from .get_animal_fragment import GetAnimalFragment
 from .get_animal_fragment_with_extra import GetAnimalFragmentWithExtra
 from .get_authenticated_user import GetAuthenticatedUser, GetAuthenticatedUserMe
+from .list_animals import (
+    ListAnimals,
+    ListAnimalsListAnimalsAnimal,
+    ListAnimalsListAnimalsCat,
+    ListAnimalsListAnimalsDog,
+)
 from .list_strings_1 import ListStrings1
 from .list_strings_2 import ListStrings2
 from .list_strings_3 import ListStrings3
@@ -45,6 +51,10 @@ __all__ = [
     "GraphQLClientGraphQLMultiError",
     "GraphQLClientHttpError",
     "GraphQlClientInvalidResponseError",
+    "ListAnimals",
+    "ListAnimalsListAnimalsAnimal",
+    "ListAnimalsListAnimalsCat",
+    "ListAnimalsListAnimalsDog",
     "ListStrings1",
     "ListStrings2",
     "ListStrings3",

--- a/tests/main/clients/shorter_results/expected_client/client.py
+++ b/tests/main/clients/shorter_results/expected_client/client.py
@@ -12,6 +12,12 @@ from .get_animal_by_name import (
 from .get_animal_fragment import GetAnimalFragment
 from .get_animal_fragment_with_extra import GetAnimalFragmentWithExtra
 from .get_authenticated_user import GetAuthenticatedUser, GetAuthenticatedUserMe
+from .list_animals import (
+    ListAnimals,
+    ListAnimalsListAnimalsAnimal,
+    ListAnimalsListAnimalsCat,
+    ListAnimalsListAnimalsDog,
+)
 from .list_strings_1 import ListStrings1
 from .list_strings_2 import ListStrings2
 from .list_strings_3 import ListStrings3
@@ -135,6 +141,36 @@ class Client(AsyncBaseClient):
         response = await self.execute(query=query, variables=variables)
         data = self.get_data(response)
         return GetAnimalByName.parse_obj(data).animal_by_name
+
+    async def list_animals(
+        self,
+    ) -> List[
+        Union[
+            ListAnimalsListAnimalsAnimal,
+            ListAnimalsListAnimalsCat,
+            ListAnimalsListAnimalsDog,
+        ]
+    ]:
+        query = gql(
+            """
+            query ListAnimals {
+              listAnimals {
+                __typename
+                name
+                ... on Cat {
+                  kittens
+                }
+                ... on Dog {
+                  puppies
+                }
+              }
+            }
+            """
+        )
+        variables: dict[str, object] = {}
+        response = await self.execute(query=query, variables=variables)
+        data = self.get_data(response)
+        return ListAnimals.parse_obj(data).list_animals
 
     async def get_animal_fragment(self) -> str:
         query = gql(

--- a/tests/main/clients/shorter_results/expected_client/list_animals.py
+++ b/tests/main/clients/shorter_results/expected_client/list_animals.py
@@ -1,0 +1,41 @@
+from typing import Annotated, List, Literal, Union
+
+from pydantic import Field
+
+from .base_model import BaseModel
+
+
+class ListAnimals(BaseModel):
+    list_animals: List[
+        Annotated[
+            Union[
+                "ListAnimalsListAnimalsAnimal",
+                "ListAnimalsListAnimalsCat",
+                "ListAnimalsListAnimalsDog",
+            ],
+            Field(discriminator="typename__"),
+        ]
+    ] = Field(alias="listAnimals")
+
+
+class ListAnimalsListAnimalsAnimal(BaseModel):
+    typename__: Literal["Animal"] = Field(alias="__typename")
+    name: str
+
+
+class ListAnimalsListAnimalsCat(BaseModel):
+    typename__: Literal["Cat"] = Field(alias="__typename")
+    name: str
+    kittens: int
+
+
+class ListAnimalsListAnimalsDog(BaseModel):
+    typename__: Literal["Dog"] = Field(alias="__typename")
+    name: str
+    puppies: int
+
+
+ListAnimals.update_forward_refs()
+ListAnimalsListAnimalsAnimal.update_forward_refs()
+ListAnimalsListAnimalsCat.update_forward_refs()
+ListAnimalsListAnimalsDog.update_forward_refs()

--- a/tests/main/clients/shorter_results/queries.graphql
+++ b/tests/main/clients/shorter_results/queries.graphql
@@ -39,6 +39,18 @@ query GetAnimalByName {
   }
 }
 
+query ListAnimals {
+  listAnimals {
+    name
+    ... on Cat {
+      kittens
+    }
+    ... on Dog {
+      puppies
+    }
+  }
+}
+
 query GetAnimalFragment {
   ...AnimalFragment
 }

--- a/tests/main/clients/shorter_results/schema.graphql
+++ b/tests/main/clients/shorter_results/schema.graphql
@@ -33,6 +33,7 @@ type Query {
 
   me: User!
 
+  listAnimals: [Animal!]!
   animalByName(name: String!): Animal!
 
   justAScalar: MyScalar!


### PR DESCRIPTION
After landing #157 the field on the classes is now annotated with a field call. When using the shorter results plugin we grab the whole field (type and annotation) and use that as return type from the client.

Since we don't have support to add the `ast.Call`, the generated client generates invalid code.

This PR will, instead of adding support for more expressions, filter out `ast.Tuple` types which consists of an `ast.Subscript` followed by an `ast.Call` where the called method is `Field`.

---
Current faulty generated code used as return type:

```python
List[
  Annotated[
    Union[
      ListAnimalsListAnimalsAnimal,
      ListAnimalsListAnimalsCat,
      ListAnimalsListAnimalsDog,
    ],
  ]
]
```

Actual fix by this PR:

```python
List[
  Union[
    ListAnimalsListAnimalsAnimal,
    ListAnimalsListAnimalsCat,
    ListAnimalsListAnimalsDog,
  ],
]
```

Potential fix by adding support for `ast.Call`:

```python
List[
  Annotated[
    Union[
      ListAnimalsListAnimalsAnimal,
      ListAnimalsListAnimalsCat,
      ListAnimalsListAnimalsDog,
    ],
    Field(discriminator="typename__"),
  ]
]
```
