### PR TITLE
Ignore unused fragments which should be unpacked in queries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Replaced HTTPX's `json=` serializer for query payloads with pydantic's `pydantic_encoder`.
 - Removed `mixin` directive from operation string sent to server.
 - Fixed `ShorterResultsPlugin` that generated faulty code for discriminated unions.
+- Changed generator to ignore unused fragments which should be unpacked in queries.
 
 
 ## 0.6.0 (2023-04-18)

--- a/tests/client_generators/result_types_generator/test_parsing_fragments.py
+++ b/tests/client_generators/result_types_generator/test_parsing_fragments.py
@@ -120,3 +120,56 @@ def test_get_classes_returns_types_generated_from_fragment_which_uses_other_frag
     assert set(generator.get_generated_public_names()) == {
         c.name for c in expected_class_defs
     }
+
+
+def test_get_classes_returns_empty_list_for_fragment_on_union():
+    fragment_str = """
+        fragment TestFragment on UnionType {
+            ... on CustomType1 {
+                fielda
+            }
+            ... on CustomType2 {
+                fieldb
+            }
+        }
+    """
+    fragment_definition = cast(
+        FragmentDefinitionNode, parse(fragment_str).definitions[0]
+    )
+    generator = ResultTypesGenerator(
+        schema=build_schema(SCHEMA_STR),
+        operation_definition=fragment_definition,
+        enums_module_name="enums",
+        fragments_definitions={"TestFragment": fragment_definition},
+    )
+
+    generated_class_defs = generator.get_classes()
+
+    assert not generated_class_defs
+
+
+def test_get_classes_returns_empty_list_for_fragment_with_inline_fragments():
+    fragment_str = """
+        fragment TestFragment on InterfaceI {
+            id
+            ... on TypeA {
+                fieldA
+            }
+            ... on TypeB {
+                fieldB
+            }
+        }
+    """
+    fragment_definition = cast(
+        FragmentDefinitionNode, parse(fragment_str).definitions[0]
+    )
+    generator = ResultTypesGenerator(
+        schema=build_schema(SCHEMA_STR),
+        operation_definition=fragment_definition,
+        enums_module_name="enums",
+        fragments_definitions={"TestFragment": fragment_definition},
+    )
+
+    generated_class_defs = generator.get_classes()
+
+    assert not generated_class_defs

--- a/tests/main/clients/inline_fragments/expected_client/__init__.py
+++ b/tests/main/clients/inline_fragments/expected_client/__init__.py
@@ -17,6 +17,7 @@ from .fragments import (
     FragmentOnQueryWithUnionQueryUTypeA,
     FragmentOnQueryWithUnionQueryUTypeB,
     FragmentOnQueryWithUnionQueryUTypeC,
+    UnusedFragmentOnTypeA,
 )
 from .interface_a import (
     InterfaceA,
@@ -127,4 +128,5 @@ __all__ = [
     "UnionWithTypenameQueryUTypeA",
     "UnionWithTypenameQueryUTypeB",
     "UnionWithTypenameQueryUTypeC",
+    "UnusedFragmentOnTypeA",
 ]

--- a/tests/main/clients/inline_fragments/expected_client/fragments.py
+++ b/tests/main/clients/inline_fragments/expected_client/fragments.py
@@ -55,6 +55,11 @@ class FragmentOnQueryWithUnionQueryUTypeC(BaseModel):
     id: str
 
 
+class UnusedFragmentOnTypeA(BaseModel):
+    id: str
+    field_a: str = Field(alias="fieldA")
+
+
 FragmentOnQueryWithInterface.update_forward_refs()
 FragmentOnQueryWithInterfaceQueryIInterface.update_forward_refs()
 FragmentOnQueryWithInterfaceQueryITypeA.update_forward_refs()
@@ -63,3 +68,4 @@ FragmentOnQueryWithUnion.update_forward_refs()
 FragmentOnQueryWithUnionQueryUTypeA.update_forward_refs()
 FragmentOnQueryWithUnionQueryUTypeB.update_forward_refs()
 FragmentOnQueryWithUnionQueryUTypeC.update_forward_refs()
+UnusedFragmentOnTypeA.update_forward_refs()

--- a/tests/main/clients/inline_fragments/queries.graphql
+++ b/tests/main/clients/inline_fragments/queries.graphql
@@ -90,7 +90,6 @@ query UnionWithTypename {
   }
 }
 
-
 query queryWithFragmentOnInterface {
   queryI {
     ...fragmentOnInterface
@@ -153,4 +152,33 @@ fragment FragmentOnQueryWithUnion on Query {
       fieldB
     }
   }
+}
+
+fragment unusedFragmentOnInterface on Interface {
+  id
+  ... on TypeA {
+    fieldA
+  }
+  ... on TypeB {
+    fieldB
+  }
+}
+
+fragment unusedFragmentOnUnion on Union {
+  id
+  ... on TypeA {
+    fieldA
+  }
+  ... on TypeB {
+    fieldB
+  }
+}
+
+fragment unusedFragmentOnUnionWithoutInlineFragments on Union {
+  id
+}
+
+fragment unusedFragmentOnTypeA on TypeA {
+  id
+  fieldA
 }


### PR DESCRIPTION
This pr makes that unused fragment, which should be unpacked in queries, are now ignored. If unused fragment represents union then we don't generate models for it. If fragment is on "regular" type then we include it in `fragments.py`.

resolves #161 