### PR TITLE
Process schema hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed `ShorterResultsPlugin` that generated faulty code for discriminated unions.
 - Changed generator to ignore unused fragments which should be unpacked in queries.
 - Changed type hints for parse and serialize methods of scalars to `typing.Any`.
+- Added `process_schema` plugin hook.
 
 
 ## 0.6.0 (2023-04-18)

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -304,6 +304,15 @@ def generate_fragments_module(
 
 Hook executed on generation of fragments module. Module has classes representing all fragments from provided queries. Later this module will be saved as `{fragments_module_name}.py`, `fragments_module_name` is taken from config.
 
+### process_schema
+
+```py
+def process_schema(self, schema: GraphQLSchema) -> GraphQLSchema:
+```
+
+Hook executed on creating `GraphQLSchema` object from path or url provided in settings. During parsing `assume_valid` is set to `True`. Then this hook is called, and only after that `graphql.assert_valid_schema` is used to validate schema.
+To ensure all plugins have current version of schema, result of this hook is propagated to all plugins, updating their `schema` field. 
+
 
 ## Example
 

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -304,6 +304,7 @@ def generate_fragments_module(
 
 Hook executed on generation of fragments module. Module has classes representing all fragments from provided queries. Later this module will be saved as `{fragments_module_name}.py`, `fragments_module_name` is taken from config.
 
+
 ### process_schema
 
 ```py

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Instead of generating client, you can generate file with a copy of GraphQL schem
 ariadne-codegen graphqlschema
 ```
 
-`graphqlschema` mode reads configuration from the same place as [`client`](#configuration) but uses only `schema_path`, `remote_schema_url`, `remote_schema_headers` and `remote_schema_verify_ssl` options with addition to some extra options specific to it:
+`graphqlschema` mode reads configuration from the same place as [`client`](#configuration) but uses only `schema_path`, `remote_schema_url`, `remote_schema_headers`, `remote_schema_verify_ssl` and `plugins` options with addition to some extra options specific to it:
 
 - `target_file_path` (defaults to `"schema.py"`) - destination path for generated file
 - `schema_variable_name` (defaults to `"schema"`) - name for schema variable, must be valid python identifier

--- a/ariadne_codegen/main.py
+++ b/ariadne_codegen/main.py
@@ -1,6 +1,7 @@
 import sys
 
 import click
+from graphql import assert_valid_schema
 
 from .client_generators.package import PackageGenerator
 from .config import get_client_settings, get_config_dict, get_graphql_schema_settings
@@ -47,6 +48,7 @@ def client(config_dict):
             verify_ssl=settings.remote_schema_verify_ssl,
         )
         schema_source = settings.remote_schema_url
+    assert_valid_schema(schema)
 
     definitions = get_graphql_queries(settings.queries_path)
     queries = filter_operations_definitions(definitions)
@@ -98,6 +100,7 @@ def graphql_schema(config_dict):
             verify_ssl=settings.remote_schema_verify_ssl,
         )
     )
+    assert_valid_schema(schema)
 
     generate_graphql_schema_file(
         schema=schema,

--- a/ariadne_codegen/plugins/base.py
+++ b/ariadne_codegen/plugins/base.py
@@ -158,3 +158,6 @@ class Plugin:
         fragments_definitions: Dict[str, FragmentDefinitionNode],
     ) -> ast.Module:
         return module
+
+    def process_schema(self, schema: GraphQLSchema) -> GraphQLSchema:
+        return schema

--- a/ariadne_codegen/plugins/manager.py
+++ b/ariadne_codegen/plugins/manager.py
@@ -202,3 +202,13 @@ class PluginManager:
             module,
             fragments_definitions=fragments_definitions,
         )
+
+    def process_schema(self, schema: GraphQLSchema) -> GraphQLSchema:
+        processed_schema = schema
+        for plugin in self.plugins:
+            processed_schema = plugin.process_schema(processed_schema)
+
+            for plugin in self.plugins:
+                plugin.schema = processed_schema
+
+        return processed_schema

--- a/ariadne_codegen/schema.py
+++ b/ariadne_codegen/schema.py
@@ -9,7 +9,6 @@ from graphql import (
     GraphQLSyntaxError,
     IntrospectionQuery,
     OperationDefinitionNode,
-    assert_valid_schema,
     build_ast_schema,
     build_client_schema,
     get_introspection_query,

--- a/ariadne_codegen/schema.py
+++ b/ariadne_codegen/schema.py
@@ -44,7 +44,8 @@ def get_graphql_schema_from_url(
     url: str, headers: Optional[Dict[str, str]] = None, verify_ssl: bool = True
 ) -> GraphQLSchema:
     return build_client_schema(
-        introspect_remote_schema(url=url, headers=headers, verify_ssl=verify_ssl)
+        introspect_remote_schema(url=url, headers=headers, verify_ssl=verify_ssl),
+        assume_valid=True,
     )
 
 
@@ -90,8 +91,7 @@ def get_graphql_schema_from_path(schema_path: str) -> GraphQLSchema:
     """Get graphql schema build from provided path."""
     schema_str = load_graphql_files_from_path(Path(schema_path))
     graphql_ast = parse(schema_str)
-    schema: GraphQLSchema = build_ast_schema(graphql_ast)
-    assert_valid_schema(schema)
+    schema: GraphQLSchema = build_ast_schema(graphql_ast, assume_valid=True)
     return schema
 
 

--- a/ariadne_codegen/settings.py
+++ b/ariadne_codegen/settings.py
@@ -25,6 +25,7 @@ class BaseSettings:
     remote_schema_url: Optional[str] = None
     remote_schema_headers: dict = field(default_factory=dict)
     remote_schema_verify_ssl: bool = True
+    plugins: List[str] = field(default_factory=list)
 
     def __post_init__(self):
         if not self.schema_path and not self.remote_schema_url:
@@ -54,7 +55,6 @@ class ClientSettings(BaseSettings):
     convert_to_snake_case: bool = True
     async_client: bool = True
     files_to_include: List[str] = field(default_factory=list)
-    plugins: List[str] = field(default_factory=list)
     scalars: Dict[str, ScalarData] = field(default_factory=dict)
 
     def __post_init__(self):
@@ -156,6 +156,12 @@ class GraphQLSchemaSettings(BaseSettings):
 
     @property
     def used_settings_message(self):
+        plugins_list = ",".join(self.plugins)
+        plugins_msg = (
+            f"Plugins to use: {plugins_list}"
+            if self.plugins
+            else "No plugin is being used."
+        )
         return dedent(
             f"""\
             Selected strategy: {Strategy.GRAPHQL_SCHEMA}
@@ -163,6 +169,7 @@ class GraphQLSchemaSettings(BaseSettings):
             Saving graphql schema to: {self.target_file_path}.
             Using {self.schema_variable_name} as variable name for schema.
             Using {self.type_map_variable_name} as variable name for type map.
+            {plugins_msg}
             """
         )
 

--- a/tests/plugins/test_manager.py
+++ b/tests/plugins/test_manager.py
@@ -342,3 +342,39 @@ def test_generate_fragments_module_calls_plugins_generate_fragments_module(
     plugin1, plugin2 = plugin_manager_with_mocked_plugins.plugins
     assert plugin1.generate_fragments_module.called
     assert plugin2.generate_fragments_module.called
+
+
+def test_process_schema_calls_plugins_process_schema(
+    plugin_manager_with_mocked_plugins,
+):
+    plugin_manager_with_mocked_plugins.process_schema(GraphQLSchema())
+
+    plugin1, plugin2 = plugin_manager_with_mocked_plugins.plugins
+    assert plugin1.process_schema.called
+    assert plugin2.process_schema.called
+
+
+def test_process_schema_updates_plugins_schema_field():
+    class SchemaPugin(Plugin):
+        def process_schema(self, schema: GraphQLSchema) -> GraphQLSchema:
+            return GraphQLSchema()
+
+    class DumbPlugin(Plugin):
+        pass
+
+    org_schema = GraphQLSchema()
+    manager = PluginManager(
+        schema=org_schema,
+        plugins_types=[DumbPlugin, SchemaPugin, DumbPlugin],
+    )
+
+    dumb_plugin1, schema_plugin, dump_plugin2 = manager.plugins
+    assert dumb_plugin1.schema is org_schema
+    assert dump_plugin2.schema is org_schema
+    assert schema_plugin.schema is org_schema
+
+    manager.process_schema(org_schema)
+
+    assert dumb_plugin1.schema is not org_schema
+    assert dump_plugin2.schema is not org_schema
+    assert schema_plugin.schema is not org_schema


### PR DESCRIPTION
This pr:
- Adds `process_schema` plugin hook
- Changes flow of parsing schema: we parse schema allowing invalid ones(`assume_valid=True`), then `process_schema` hook is called, only then we validate processed schema.
- Adds `plugins` setting to `graphqlschema` strategy.

Resolves #149 Utilizing `process_schema` plugin will be able to inject apollo federation directives definitions into schema.