### PR TITLE
Remove mixin from fragment str

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added support for `Upload` scalar. Added support for file uploads to `AsyncBaseClient` and `BaseClient`.
 - Added validation of defined operations against the schema.
+- Removed `mixin` directive from fragment string included in operation string sent to server
 
 
 ## 0.7.1 (2023-06-06)

--- a/tests/main/clients/extended_models/expected_client/__init__.py
+++ b/tests/main/clients/extended_models/expected_client/__init__.py
@@ -8,7 +8,9 @@ from .exceptions import (
     GraphQLClientHttpError,
     GraphQlClientInvalidResponseError,
 )
+from .fragments import GetQueryAFragment, GetQueryAFragmentQueryA
 from .get_query_a import GetQueryA, GetQueryAQueryA
+from .get_query_a_with_fragment import GetQueryAWithFragment
 from .get_query_b import GetQueryB, GetQueryBQueryB
 
 __all__ = [
@@ -16,7 +18,10 @@ __all__ = [
     "BaseModel",
     "Client",
     "GetQueryA",
+    "GetQueryAFragment",
+    "GetQueryAFragmentQueryA",
     "GetQueryAQueryA",
+    "GetQueryAWithFragment",
     "GetQueryB",
     "GetQueryBQueryB",
     "GraphQLClientError",

--- a/tests/main/clients/extended_models/expected_client/client.py
+++ b/tests/main/clients/extended_models/expected_client/client.py
@@ -1,5 +1,6 @@
 from .async_base_client import AsyncBaseClient
 from .get_query_a import GetQueryA
+from .get_query_a_with_fragment import GetQueryAWithFragment
 from .get_query_b import GetQueryB
 
 
@@ -37,3 +38,22 @@ class Client(AsyncBaseClient):
         response = await self.execute(query=query, variables=variables)
         data = self.get_data(response)
         return GetQueryB.parse_obj(data)
+
+    async def get_query_a_with_fragment(self) -> GetQueryAWithFragment:
+        query = gql(
+            """
+            query getQueryAWithFragment {
+              ...getQueryAFragment
+            }
+
+            fragment getQueryAFragment on Query {
+              queryA {
+                fieldA
+              }
+            }
+            """
+        )
+        variables: dict[str, object] = {}
+        response = await self.execute(query=query, variables=variables)
+        data = self.get_data(response)
+        return GetQueryAWithFragment.parse_obj(data)

--- a/tests/main/clients/extended_models/expected_client/fragments.py
+++ b/tests/main/clients/extended_models/expected_client/fragments.py
@@ -1,0 +1,17 @@
+from pydantic import Field
+
+from .base_model import BaseModel
+from .common_mixins import CommonMixin
+from .mixins_a import MixinA
+
+
+class GetQueryAFragment(BaseModel):
+    query_a: "GetQueryAFragmentQueryA" = Field(alias="queryA")
+
+
+class GetQueryAFragmentQueryA(BaseModel, MixinA, CommonMixin):
+    field_a: int = Field(alias="fieldA")
+
+
+GetQueryAFragment.update_forward_refs()
+GetQueryAFragmentQueryA.update_forward_refs()

--- a/tests/main/clients/extended_models/expected_client/get_query_a_with_fragment.py
+++ b/tests/main/clients/extended_models/expected_client/get_query_a_with_fragment.py
@@ -1,0 +1,8 @@
+from .fragments import GetQueryAFragment
+
+
+class GetQueryAWithFragment(GetQueryAFragment):
+    pass
+
+
+GetQueryAWithFragment.update_forward_refs()

--- a/tests/main/clients/extended_models/queries.graphql
+++ b/tests/main/clients/extended_models/queries.graphql
@@ -13,3 +13,15 @@ query getQueryB {
     fieldB
   }
 }
+
+query getQueryAWithFragment {
+  ...getQueryAFragment
+}
+
+fragment getQueryAFragment on Query {
+    queryA
+    @mixin(from: ".mixins_a", import: "MixinA")
+    @mixin(from: ".common_mixins", import: "CommonMixin") {
+    fieldA
+  }
+}


### PR DESCRIPTION
This pr removes `mixin` from fragments strings, which are added to operation string sent to server.
resolves #176 