### PR TITLE
Fragments defined on subtype of field's type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added validation of defined operations against the schema.
 - Removed `mixin` directive from fragment string included in operation string sent to server.
 - Added support for `mixin` directive on fragments definitions.
+- Added support for fragments defined on subtype of field's type.
 
 
 ## 0.7.1 (2023-06-06)

--- a/ariadne_codegen/client_generators/result_types.py
+++ b/ariadne_codegen/client_generators/result_types.py
@@ -11,6 +11,7 @@ from graphql import (
     GraphQLAbstractType,
     GraphQLEnumType,
     GraphQLField,
+    GraphQLNamedType,
     GraphQLNonNull,
     GraphQLObjectType,
     GraphQLScalarType,
@@ -335,7 +336,7 @@ class ResultTypesGenerator:
     def _unpack_fragment(
         self,
         fragment_def: FragmentDefinitionNode,
-        root_type_def: Optional[str] = None,
+        root_type_def: Optional[GraphQLNamedType] = None,
     ) -> bool:
         if fragment_def.name and isinstance(
             self.schema.type_map.get(fragment_def.type_condition.name.value),

--- a/tests/client_generators/test_result_fields.py
+++ b/tests/client_generators/test_result_fields.py
@@ -14,6 +14,7 @@ from graphql import (
     GraphQLNonNull,
     GraphQLObjectType,
     GraphQLScalarType,
+    GraphQLSchema,
     GraphQLUnionType,
     InlineFragmentNode,
     NamedTypeNode,
@@ -76,6 +77,7 @@ def test_parse_operation_field_returns_optional_annotation_if_given_nullable_dir
     directive, type_, expected_annotation
 ):
     annotation, _ = parse_operation_field(
+        schema=GraphQLSchema(),
         field=FieldNode(),
         type_=type_,
         directives=(DirectiveNode(name=NameNode(value=directive), arguments=()),),
@@ -91,6 +93,7 @@ def test_parse_operation_field_returns_typename_annotation_with_multiple_values(
     )
 
     annotation, _ = parse_operation_field(
+        schema=GraphQLSchema(),
         field=FieldNode(name=NameNode(value=TYPENAME_FIELD_NAME)),
         type_=GraphQLNonNull(GraphQLScalarType("String")),
         typename_values=["TypeB", "TypeA"],
@@ -105,6 +108,7 @@ def test_parse_operation_field_returns_typename_annotation_with_single_value():
     )
 
     annotation, _ = parse_operation_field(
+        schema=GraphQLSchema(),
         field=FieldNode(name=NameNode(value=TYPENAME_FIELD_NAME)),
         type_=GraphQLNonNull(GraphQLScalarType("String")),
         typename_values=["TypeA"],
@@ -142,6 +146,7 @@ def test_parse_operation_field_returns_annotation_with_annotated_nested_unions()
     )
 
     annotation, _ = parse_operation_field(
+        schema=GraphQLSchema(),
         field=FieldNode(name=NameNode(value="unionField")),
         type_=GraphQLUnionType(
             "UnionType",
@@ -194,7 +199,9 @@ def test_parse_operation_field_returns_annotation_with_annotated_nested_unions()
 def test_parse_operation_field_type_returns_annotation_for_scalar(
     type_, expected_annotation
 ):
-    annotation, names = parse_operation_field_type(field=FieldNode(), type_=type_)
+    annotation, names = parse_operation_field_type(
+        schema=GraphQLSchema(), field=FieldNode(), type_=type_
+    )
 
     assert compare_ast(annotation, expected_annotation)
     assert names == []
@@ -220,6 +227,7 @@ def test_parse_operation_field_type_returns_annotation_for_custom_scalar(
     type_, expected_annotation
 ):
     annotation, names = parse_operation_field_type(
+        schema=GraphQLSchema(),
         field=FieldNode(),
         type_=type_,
         custom_scalars={"SCALARXYZ": ScalarData(type_="ScalarXYZ")},
@@ -266,7 +274,7 @@ def test_parse_operation_field_type_returns_annotation_for_objects_and_interface
     type_, class_name, expected_annotation, expected_names
 ):
     annotation, names = parse_operation_field_type(
-        field=FieldNode(), type_=type_, class_name=class_name
+        schema=GraphQLSchema(), field=FieldNode(), type_=type_, class_name=class_name
     )
 
     assert compare_ast(annotation, expected_annotation)
@@ -294,6 +302,7 @@ def test_parse_operation_field_type_returns_union_for_interface_with_inline_frag
     ]
 
     annotation, names = parse_operation_field_type(
+        schema=GraphQLSchema(),
         field=FieldNode(
             selection_set=SelectionSetNode(
                 selections=(
@@ -350,6 +359,7 @@ def test_parse_operation_field_type_returns_union_inline_fragments_in_fragment()
     )
 
     annotation, names = parse_operation_field_type(
+        schema=GraphQLSchema(),
         field=FieldNode(
             selection_set=SelectionSetNode(
                 selections=(FragmentSpreadNode(name=NameNode(value="TestFragment")),)
@@ -384,7 +394,9 @@ def test_parse_operation_field_type_returns_union_inline_fragments_in_fragment()
 def test_parse_operation_field_type_returns_annotation_for_enums(
     type_, expected_annotation, expected_names
 ):
-    annotation, names = parse_operation_field_type(field=FieldNode(), type_=type_)
+    annotation, names = parse_operation_field_type(
+        schema=GraphQLSchema(), field=FieldNode(), type_=type_
+    )
 
     assert compare_ast(annotation, expected_annotation)
     assert names == expected_names
@@ -415,7 +427,10 @@ def test_parse_operation_field_type_returns_annotation_and_names_for_union():
     ]
 
     annotation, names = parse_operation_field_type(
-        field=FieldNode(), type_=type_, class_name="TestQueryField"
+        schema=GraphQLSchema(),
+        field=FieldNode(),
+        type_=type_,
+        class_name="TestQueryField",
     )
 
     assert compare_ast(annotation, expected_annotation)
@@ -469,7 +484,10 @@ def test_parse_operation_field_type_returns_annotation_for_list(
     type_, expected_annotation
 ):
     annotation, names = parse_operation_field_type(
-        field=FieldNode(), type_=type_, class_name="TestQueryField"
+        schema=GraphQLSchema(),
+        field=FieldNode(),
+        type_=type_,
+        class_name="TestQueryField",
     )
 
     assert compare_ast(annotation, expected_annotation)

--- a/tests/main/clients/fragments_on_abstract_types/expected_client/__init__.py
+++ b/tests/main/clients/fragments_on_abstract_types/expected_client/__init__.py
@@ -1,0 +1,51 @@
+from .async_base_client import AsyncBaseClient
+from .base_model import BaseModel, Upload
+from .client import Client
+from .exceptions import (
+    GraphQLClientError,
+    GraphQLClientGraphQLError,
+    GraphQLClientGraphQLMultiError,
+    GraphQLClientHttpError,
+    GraphQlClientInvalidResponseError,
+)
+from .fragments import FragmentA, FragmentB
+from .query_with_fragment_on_sub_interface import (
+    QueryWithFragmentOnSubInterface,
+    QueryWithFragmentOnSubInterfaceQueryInterfaceBaseInterface,
+    QueryWithFragmentOnSubInterfaceQueryInterfaceInterfaceA,
+)
+from .query_with_fragment_on_sub_interface_with_inline_fragment import (
+    QueryWithFragmentOnSubInterfaceWithInlineFragment,
+    QueryWithFragmentOnSubInterfaceWithInlineFragmentQueryInterfaceBaseInterface,
+    QueryWithFragmentOnSubInterfaceWithInlineFragmentQueryInterfaceInterfaceA,
+    QueryWithFragmentOnSubInterfaceWithInlineFragmentQueryInterfaceTypeA,
+)
+from .query_with_fragment_on_union_member import (
+    QueryWithFragmentOnUnionMember,
+    QueryWithFragmentOnUnionMemberQueryUnionTypeA,
+    QueryWithFragmentOnUnionMemberQueryUnionTypeB,
+)
+
+__all__ = [
+    "AsyncBaseClient",
+    "BaseModel",
+    "Client",
+    "FragmentA",
+    "FragmentB",
+    "GraphQLClientError",
+    "GraphQLClientGraphQLError",
+    "GraphQLClientGraphQLMultiError",
+    "GraphQLClientHttpError",
+    "GraphQlClientInvalidResponseError",
+    "QueryWithFragmentOnSubInterface",
+    "QueryWithFragmentOnSubInterfaceQueryInterfaceBaseInterface",
+    "QueryWithFragmentOnSubInterfaceQueryInterfaceInterfaceA",
+    "QueryWithFragmentOnSubInterfaceWithInlineFragment",
+    "QueryWithFragmentOnSubInterfaceWithInlineFragmentQueryInterfaceBaseInterface",
+    "QueryWithFragmentOnSubInterfaceWithInlineFragmentQueryInterfaceInterfaceA",
+    "QueryWithFragmentOnSubInterfaceWithInlineFragmentQueryInterfaceTypeA",
+    "QueryWithFragmentOnUnionMember",
+    "QueryWithFragmentOnUnionMemberQueryUnionTypeA",
+    "QueryWithFragmentOnUnionMemberQueryUnionTypeB",
+    "Upload",
+]

--- a/tests/main/clients/fragments_on_abstract_types/expected_client/async_base_client.py
+++ b/tests/main/clients/fragments_on_abstract_types/expected_client/async_base_client.py
@@ -1,0 +1,290 @@
+import enum
+import json
+from typing import IO, Any, AsyncIterator, Dict, List, Optional, Tuple, TypeVar, cast
+from uuid import uuid4
+
+import httpx
+from pydantic import BaseModel
+from pydantic.json import pydantic_encoder
+
+from .base_model import UNSET, Upload
+from .exceptions import (
+    GraphQLClientGraphQLMultiError,
+    GraphQLClientHttpError,
+    GraphQLClientInvalidMessageFormat,
+    GraphQlClientInvalidResponseError,
+)
+
+try:
+    from websockets.client import WebSocketClientProtocol
+    from websockets.client import connect as ws_connect
+    from websockets.typing import Data, Origin, Subprotocol
+except ImportError:
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager  # type: ignore
+    async def ws_connect(*args, **kwargs):  # pylint: disable=unused-argument
+        raise NotImplementedError("Subscriptions require 'websockets' package.")
+        yield  # pylint: disable=unreachable
+
+    WebSocketClientProtocol = Any  # type: ignore
+    Data = Any  # type: ignore
+    Origin = Any  # type: ignore
+    Subprotocol = Any  # type: ignore
+
+
+Self = TypeVar("Self", bound="AsyncBaseClient")
+
+GRAPHQL_TRANSPORT_WS = "graphql-transport-ws"
+
+
+class GraphQLTransportWSMessageType(str, enum.Enum):
+    CONNECTION_INIT = "connection_init"
+    CONNECTION_ACK = "connection_ack"
+    PING = "ping"
+    PONG = "pong"
+    SUBSCRIBE = "subscribe"
+    NEXT = "next"
+    ERROR = "error"
+    COMPLETE = "complete"
+
+
+class AsyncBaseClient:
+    def __init__(
+        self,
+        url: str = "",
+        headers: Optional[Dict[str, str]] = None,
+        http_client: Optional[httpx.AsyncClient] = None,
+        ws_url: str = "",
+        ws_headers: Optional[Dict[str, Any]] = None,
+        ws_origin: Optional[str] = None,
+        ws_connection_init_payload: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.url = url
+        self.headers = headers
+        self.http_client = (
+            http_client if http_client else httpx.AsyncClient(headers=headers)
+        )
+        self.ws_url = ws_url
+        self.ws_headers = ws_headers or {}
+        self.ws_origin = Origin(ws_origin) if ws_origin else None
+        self.ws_connection_init_payload = ws_connection_init_payload
+
+    async def __aenter__(self: Self) -> Self:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: object,
+        exc_val: object,
+        exc_tb: object,
+    ) -> None:
+        await self.http_client.aclose()
+
+    async def execute(
+        self, query: str, variables: Optional[Dict[str, Any]] = None
+    ) -> httpx.Response:
+        processed_variables, files, files_map = self._process_variables(variables)
+        payload: Dict[str, Any] = {"query": query, "variables": processed_variables}
+
+        if files and files_map:
+            return await self._execute_multipart(
+                payload=payload,
+                files=files,
+                files_map=files_map,
+            )
+
+        return await self._execute_json(payload=payload)
+
+    def get_data(self, response: httpx.Response) -> Dict[str, Any]:
+        if not response.is_success:
+            raise GraphQLClientHttpError(
+                status_code=response.status_code, response=response
+            )
+
+        try:
+            response_json = response.json()
+        except ValueError as exc:
+            raise GraphQlClientInvalidResponseError(response=response) from exc
+
+        if (not isinstance(response_json, dict)) or ("data" not in response_json):
+            raise GraphQlClientInvalidResponseError(response=response)
+
+        data = response_json["data"]
+        errors = response_json.get("errors")
+
+        if errors:
+            raise GraphQLClientGraphQLMultiError.from_errors_dicts(
+                errors_dicts=errors, data=data
+            )
+
+        return cast(dict[str, Any], data)
+
+    async def execute_ws(
+        self, query: str, variables: Optional[Dict[str, Any]] = None
+    ) -> AsyncIterator[Dict[str, Any]]:
+        operation_id = str(uuid4())
+        async with ws_connect(
+            self.ws_url,
+            subprotocols=[Subprotocol(GRAPHQL_TRANSPORT_WS)],
+            origin=self.ws_origin,
+            extra_headers=self.ws_headers,
+        ) as websocket:
+            await self._send_connection_init(websocket)
+            await self._send_subscribe(
+                websocket,
+                operation_id=operation_id,
+                query=query,
+                variables=variables,
+            )
+
+            async for message in websocket:
+                data = await self._handle_ws_message(message, websocket)
+                if data:
+                    yield data
+
+    def _process_variables(
+        self, variables: Optional[Dict[str, Any]]
+    ) -> Tuple[
+        Dict[str, Any], Dict[str, Tuple[str, IO[bytes], str]], Dict[str, List[str]]
+    ]:
+        if not variables:
+            return {}, {}, {}
+
+        serializable_variables = self._convert_dict_to_json_serializable(variables)
+        return self._get_files_from_variables(serializable_variables)
+
+    def _convert_dict_to_json_serializable(
+        self, dict_: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        return {
+            key: self._convert_value(value)
+            for key, value in dict_.items()
+            if value is not UNSET
+        }
+
+    def _convert_value(self, value: Any) -> Any:
+        if isinstance(value, BaseModel):
+            return value.dict(by_alias=True, exclude_unset=True)
+        if isinstance(value, list):
+            return [self._convert_value(item) for item in value]
+        return value
+
+    def _get_files_from_variables(
+        self, variables: Dict[str, Any]
+    ) -> Tuple[
+        Dict[str, Any], Dict[str, Tuple[str, IO[bytes], str]], Dict[str, List[str]]
+    ]:
+        files_map: Dict[str, List[str]] = {}
+        files_list: List[Upload] = []
+
+        def separate_files(path: str, obj: Any) -> Any:
+            if isinstance(obj, list):
+                nulled_list = []
+                for index, value in enumerate(obj):
+                    value = separate_files(f"{path}.{index}", value)
+                    nulled_list.append(value)
+                return nulled_list
+
+            if isinstance(obj, dict):
+                nulled_dict = {}
+                for key, value in obj.items():
+                    value = separate_files(f"{path}.{key}", value)
+                    nulled_dict[key] = value
+                return nulled_dict
+
+            if isinstance(obj, Upload):
+                if obj in files_list:
+                    file_index = files_list.index(obj)
+                    files_map[str(file_index)].append(path)
+                else:
+                    file_index = len(files_list)
+                    files_list.append(obj)
+                    files_map[str(file_index)] = [path]
+                return None
+
+            return obj
+
+        nulled_variables = separate_files("variables", variables)
+        files: Dict[str, Tuple[str, IO[bytes], str]] = {
+            str(i): (file_.filename, cast(IO[bytes], file_.content), file_.content_type)
+            for i, file_ in enumerate(files_list)
+        }
+        return nulled_variables, files, files_map
+
+    async def _execute_multipart(
+        self,
+        payload: Dict[str, Any],
+        files: Dict[str, Tuple[str, IO[bytes], str]],
+        files_map: Dict[str, List[str]],
+    ) -> httpx.Response:
+        data = {
+            "operations": json.dumps(payload, default=pydantic_encoder),
+            "map": json.dumps(files_map, default=pydantic_encoder),
+        }
+
+        return await self.http_client.post(url=self.url, data=data, files=files)
+
+    async def _execute_json(self, payload: Dict[str, Any]) -> httpx.Response:
+        content = json.dumps(payload, default=pydantic_encoder)
+        return await self.http_client.post(
+            url=self.url, content=content, headers={"Content-Type": "application/json"}
+        )
+
+    async def _send_connection_init(self, websocket: WebSocketClientProtocol) -> None:
+        payload: Dict[str, Any] = {
+            "type": GraphQLTransportWSMessageType.CONNECTION_INIT.value
+        }
+        if self.ws_connection_init_payload:
+            payload["payload"] = self.ws_connection_init_payload
+        await websocket.send(json.dumps(payload))
+
+    async def _send_subscribe(
+        self,
+        websocket: WebSocketClientProtocol,
+        operation_id: str,
+        query: str,
+        variables: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        payload: Dict[str, Any] = {
+            "id": operation_id,
+            "type": GraphQLTransportWSMessageType.SUBSCRIBE.value,
+            "payload": {"query": query},
+        }
+        if variables:
+            payload["payload"]["variables"] = self._convert_dict_to_json_serializable(
+                variables
+            )
+        await websocket.send(json.dumps(payload))
+
+    async def _handle_ws_message(
+        self, message: Data, websocket: WebSocketClientProtocol
+    ) -> Optional[Dict[str, Any]]:
+        try:
+            message_dict = json.loads(message)
+        except json.JSONDecodeError as exc:
+            raise GraphQLClientInvalidMessageFormat(message=message) from exc
+
+        type_ = message_dict.get("type")
+        payload = message_dict.get("payload", {})
+
+        if not type_ or type_ not in {t.value for t in GraphQLTransportWSMessageType}:
+            raise GraphQLClientInvalidMessageFormat(message=message)
+
+        if type_ == GraphQLTransportWSMessageType.NEXT:
+            if "data" not in payload:
+                raise GraphQLClientInvalidMessageFormat(message=message)
+            return cast(Dict[str, Any], payload["data"])
+
+        if type_ == GraphQLTransportWSMessageType.COMPLETE:
+            await websocket.close()
+        elif type_ == GraphQLTransportWSMessageType.PING:
+            await websocket.send(
+                json.dumps({"type": GraphQLTransportWSMessageType.PONG.value})
+            )
+        elif type_ == GraphQLTransportWSMessageType.ERROR:
+            raise GraphQLClientGraphQLMultiError.from_errors_dicts(
+                errors_dicts=payload, data=message_dict
+            )
+
+        return None

--- a/tests/main/clients/fragments_on_abstract_types/expected_client/base_model.py
+++ b/tests/main/clients/fragments_on_abstract_types/expected_client/base_model.py
@@ -1,0 +1,68 @@
+from io import IOBase
+from typing import Any, Dict, Type, Union, get_args, get_origin
+
+from pydantic import BaseModel as PydanticBaseModel
+from pydantic import ConfigDict
+from pydantic.class_validators import validator
+from pydantic.dataclasses import dataclass
+from pydantic.fields import ModelField
+
+from .scalars import SCALARS_PARSE_FUNCTIONS, SCALARS_SERIALIZE_FUNCTIONS
+
+
+class UnsetType:
+    def __bool__(self) -> bool:
+        return False
+
+
+UNSET = UnsetType()
+
+
+class BaseModel(PydanticBaseModel):
+    class Config:
+        allow_population_by_field_name = True
+        validate_assignment = True
+        arbitrary_types_allowed = True
+
+    # pylint: disable=no-self-argument
+    @validator("*", pre=True)
+    def parse_custom_scalars(cls, value: Any, field: ModelField) -> Any:
+        return cls._parse_custom_scalar_value(value, field.annotation)
+
+    @classmethod
+    def _parse_custom_scalar_value(cls, value: Any, type_: Type[Any]) -> Any:
+        origin = get_origin(type_)
+        args = get_args(type_)
+        if origin is list and isinstance(value, list):
+            return [cls._parse_custom_scalar_value(item, args[0]) for item in value]
+
+        if origin is Union and type(None) in args:
+            sub_type: Any = list(filter(None, args))[0]
+            return cls._parse_custom_scalar_value(value, sub_type)
+
+        decode = SCALARS_PARSE_FUNCTIONS.get(type_)
+        if value and decode and callable(decode):
+            return decode(value)
+
+        return value
+
+    def dict(self, **kwargs: Any) -> Dict[str, Any]:
+        dict_ = super().dict(**kwargs)
+        return {key: self._serialize_value(value) for key, value in dict_.items()}
+
+    def _serialize_value(self, value: Any) -> Any:
+        serialize = SCALARS_SERIALIZE_FUNCTIONS.get(type(value))
+        if serialize and callable(serialize):
+            return serialize(value)
+
+        if isinstance(value, list):
+            return [self._serialize_value(item) for item in value]
+
+        return value
+
+
+@dataclass(config=ConfigDict(arbitrary_types_allowed=True))
+class Upload:
+    filename: str
+    content: IOBase
+    content_type: str

--- a/tests/main/clients/fragments_on_abstract_types/expected_client/client.py
+++ b/tests/main/clients/fragments_on_abstract_types/expected_client/client.py
@@ -1,0 +1,84 @@
+from .async_base_client import AsyncBaseClient
+from .query_with_fragment_on_sub_interface import QueryWithFragmentOnSubInterface
+from .query_with_fragment_on_sub_interface_with_inline_fragment import (
+    QueryWithFragmentOnSubInterfaceWithInlineFragment,
+)
+from .query_with_fragment_on_union_member import QueryWithFragmentOnUnionMember
+
+
+def gql(q: str) -> str:
+    return q
+
+
+class Client(AsyncBaseClient):
+    async def query_with_fragment_on_sub_interface(
+        self,
+    ) -> QueryWithFragmentOnSubInterface:
+        query = gql(
+            """
+            query queryWithFragmentOnSubInterface {
+              queryInterface {
+                __typename
+                ...fragmentA
+              }
+            }
+
+            fragment fragmentA on InterfaceA {
+              id
+              valueA
+            }
+            """
+        )
+        variables: dict[str, object] = {}
+        response = await self.execute(query=query, variables=variables)
+        data = self.get_data(response)
+        return QueryWithFragmentOnSubInterface.parse_obj(data)
+
+    async def query_with_fragment_on_sub_interface_with_inline_fragment(
+        self,
+    ) -> QueryWithFragmentOnSubInterfaceWithInlineFragment:
+        query = gql(
+            """
+            query queryWithFragmentOnSubInterfaceWithInlineFragment {
+              queryInterface {
+                __typename
+                ...fragmentAWithInlineFragment
+              }
+            }
+
+            fragment fragmentAWithInlineFragment on InterfaceA {
+              id
+              valueA
+              ... on TypeA {
+                another
+              }
+            }
+            """
+        )
+        variables: dict[str, object] = {}
+        response = await self.execute(query=query, variables=variables)
+        data = self.get_data(response)
+        return QueryWithFragmentOnSubInterfaceWithInlineFragment.parse_obj(data)
+
+    async def query_with_fragment_on_union_member(
+        self,
+    ) -> QueryWithFragmentOnUnionMember:
+        query = gql(
+            """
+            query queryWithFragmentOnUnionMember {
+              queryUnion {
+                __typename
+                ...fragmentB
+              }
+            }
+
+            fragment fragmentB on TypeB {
+              id
+              valueB
+            }
+            """
+        )
+        variables: dict[str, object] = {}
+        response = await self.execute(query=query, variables=variables)
+        data = self.get_data(response)
+        return QueryWithFragmentOnUnionMember.parse_obj(data)

--- a/tests/main/clients/fragments_on_abstract_types/expected_client/exceptions.py
+++ b/tests/main/clients/fragments_on_abstract_types/expected_client/exceptions.py
@@ -1,0 +1,79 @@
+from typing import Any, Dict, List, Optional, Union
+
+import httpx
+
+
+class GraphQLClientError(Exception):
+    """Base exception."""
+
+
+class GraphQLClientHttpError(GraphQLClientError):
+    def __init__(self, status_code: int, response: httpx.Response) -> None:
+        self.status_code = status_code
+        self.response = response
+
+    def __str__(self) -> str:
+        return f"HTTP status code: {self.status_code}"
+
+
+class GraphQlClientInvalidResponseError(GraphQLClientError):
+    def __init__(self, response: httpx.Response) -> None:
+        self.response = response
+
+    def __str__(self) -> str:
+        return "Invalid response format."
+
+
+class GraphQLClientGraphQLError(GraphQLClientError):
+    def __init__(
+        self,
+        message: str,
+        locations: Optional[List[Dict[str, int]]] = None,
+        path: Optional[List[str]] = None,
+        extensions: Optional[Dict[str, object]] = None,
+        orginal: Optional[Dict[str, object]] = None,
+    ):
+        self.message = message
+        self.locations = locations
+        self.path = path
+        self.extensions = extensions
+        self.orginal = orginal
+
+    def __str__(self) -> str:
+        return self.message
+
+    @classmethod
+    def from_dict(cls, error: dict[str, Any]) -> "GraphQLClientGraphQLError":
+        return cls(
+            message=error["message"],
+            locations=error.get("locations"),
+            path=error.get("path"),
+            extensions=error.get("extensions"),
+            orginal=error,
+        )
+
+
+class GraphQLClientGraphQLMultiError(GraphQLClientError):
+    def __init__(self, errors: List[GraphQLClientGraphQLError], data: dict[str, Any]):
+        self.errors = errors
+        self.data = data
+
+    def __str__(self) -> str:
+        return "; ".join(str(e) for e in self.errors)
+
+    @classmethod
+    def from_errors_dicts(
+        cls, errors_dicts: List[dict[str, Any]], data: dict[str, Any]
+    ) -> "GraphQLClientGraphQLMultiError":
+        return cls(
+            errors=[GraphQLClientGraphQLError.from_dict(e) for e in errors_dicts],
+            data=data,
+        )
+
+
+class GraphQLClientInvalidMessageFormat(GraphQLClientError):
+    def __init__(self, message: Union[str, bytes]) -> None:
+        self.message = message
+
+    def __str__(self) -> str:
+        return "Invalid message format."

--- a/tests/main/clients/fragments_on_abstract_types/expected_client/fragments.py
+++ b/tests/main/clients/fragments_on_abstract_types/expected_client/fragments.py
@@ -1,0 +1,17 @@
+from pydantic import Field
+
+from .base_model import BaseModel
+
+
+class FragmentA(BaseModel):
+    id: str
+    value_a: str = Field(alias="valueA")
+
+
+class FragmentB(BaseModel):
+    id: str
+    value_b: str = Field(alias="valueB")
+
+
+FragmentA.update_forward_refs()
+FragmentB.update_forward_refs()

--- a/tests/main/clients/fragments_on_abstract_types/expected_client/query_with_fragment_on_sub_interface.py
+++ b/tests/main/clients/fragments_on_abstract_types/expected_client/query_with_fragment_on_sub_interface.py
@@ -1,0 +1,26 @@
+from typing import Literal, Union
+
+from pydantic import Field
+
+from .base_model import BaseModel
+from .fragments import FragmentA
+
+
+class QueryWithFragmentOnSubInterface(BaseModel):
+    query_interface: Union[
+        "QueryWithFragmentOnSubInterfaceQueryInterfaceBaseInterface",
+        "QueryWithFragmentOnSubInterfaceQueryInterfaceInterfaceA",
+    ] = Field(alias="queryInterface", discriminator="typename__")
+
+
+class QueryWithFragmentOnSubInterfaceQueryInterfaceBaseInterface(BaseModel):
+    typename__: Literal["BaseInterface", "TypeA"] = Field(alias="__typename")
+
+
+class QueryWithFragmentOnSubInterfaceQueryInterfaceInterfaceA(FragmentA):
+    typename__: Literal["InterfaceA"] = Field(alias="__typename")
+
+
+QueryWithFragmentOnSubInterface.update_forward_refs()
+QueryWithFragmentOnSubInterfaceQueryInterfaceBaseInterface.update_forward_refs()
+QueryWithFragmentOnSubInterfaceQueryInterfaceInterfaceA.update_forward_refs()

--- a/tests/main/clients/fragments_on_abstract_types/expected_client/query_with_fragment_on_sub_interface_with_inline_fragment.py
+++ b/tests/main/clients/fragments_on_abstract_types/expected_client/query_with_fragment_on_sub_interface_with_inline_fragment.py
@@ -1,0 +1,40 @@
+from typing import Literal, Union
+
+from pydantic import Field
+
+from .base_model import BaseModel
+
+
+class QueryWithFragmentOnSubInterfaceWithInlineFragment(BaseModel):
+    query_interface: Union[
+        "QueryWithFragmentOnSubInterfaceWithInlineFragmentQueryInterfaceBaseInterface",
+        "QueryWithFragmentOnSubInterfaceWithInlineFragmentQueryInterfaceInterfaceA",
+        "QueryWithFragmentOnSubInterfaceWithInlineFragmentQueryInterfaceTypeA",
+    ] = Field(alias="queryInterface", discriminator="typename__")
+
+
+class QueryWithFragmentOnSubInterfaceWithInlineFragmentQueryInterfaceBaseInterface(
+    BaseModel
+):
+    typename__: Literal["BaseInterface"] = Field(alias="__typename")
+
+
+class QueryWithFragmentOnSubInterfaceWithInlineFragmentQueryInterfaceInterfaceA(
+    BaseModel
+):
+    typename__: Literal["InterfaceA"] = Field(alias="__typename")
+    id: str
+    value_a: str = Field(alias="valueA")
+
+
+class QueryWithFragmentOnSubInterfaceWithInlineFragmentQueryInterfaceTypeA(BaseModel):
+    typename__: Literal["TypeA"] = Field(alias="__typename")
+    id: str
+    value_a: str = Field(alias="valueA")
+    another: str
+
+
+QueryWithFragmentOnSubInterfaceWithInlineFragment.update_forward_refs()
+QueryWithFragmentOnSubInterfaceWithInlineFragmentQueryInterfaceBaseInterface.update_forward_refs()
+QueryWithFragmentOnSubInterfaceWithInlineFragmentQueryInterfaceInterfaceA.update_forward_refs()
+QueryWithFragmentOnSubInterfaceWithInlineFragmentQueryInterfaceTypeA.update_forward_refs()

--- a/tests/main/clients/fragments_on_abstract_types/expected_client/query_with_fragment_on_union_member.py
+++ b/tests/main/clients/fragments_on_abstract_types/expected_client/query_with_fragment_on_union_member.py
@@ -1,0 +1,26 @@
+from typing import Literal, Union
+
+from pydantic import Field
+
+from .base_model import BaseModel
+from .fragments import FragmentB
+
+
+class QueryWithFragmentOnUnionMember(BaseModel):
+    query_union: Union[
+        "QueryWithFragmentOnUnionMemberQueryUnionTypeA",
+        "QueryWithFragmentOnUnionMemberQueryUnionTypeB",
+    ] = Field(alias="queryUnion", discriminator="typename__")
+
+
+class QueryWithFragmentOnUnionMemberQueryUnionTypeA(BaseModel):
+    typename__: Literal["TypeA"] = Field(alias="__typename")
+
+
+class QueryWithFragmentOnUnionMemberQueryUnionTypeB(FragmentB):
+    typename__: Literal["TypeB"] = Field(alias="__typename")
+
+
+QueryWithFragmentOnUnionMember.update_forward_refs()
+QueryWithFragmentOnUnionMemberQueryUnionTypeA.update_forward_refs()
+QueryWithFragmentOnUnionMemberQueryUnionTypeB.update_forward_refs()

--- a/tests/main/clients/fragments_on_abstract_types/expected_client/scalars.py
+++ b/tests/main/clients/fragments_on_abstract_types/expected_client/scalars.py
@@ -1,0 +1,4 @@
+from typing import Any, Callable, Dict
+
+SCALARS_PARSE_FUNCTIONS: Dict[Any, Callable[[Any], Any]] = {}
+SCALARS_SERIALIZE_FUNCTIONS: Dict[Any, Callable[[Any], Any]] = {}

--- a/tests/main/clients/fragments_on_abstract_types/pyproject.toml
+++ b/tests/main/clients/fragments_on_abstract_types/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.ariadne-codegen]
+schema_path = "schema.graphql"
+queries_path = "queries.graphql"
+include_comments = false
+target_package_name = "fragments_on_abstract_types_client"

--- a/tests/main/clients/fragments_on_abstract_types/queries.graphql
+++ b/tests/main/clients/fragments_on_abstract_types/queries.graphql
@@ -1,0 +1,36 @@
+query queryWithFragmentOnSubInterface {
+  queryInterface {
+    ...fragmentA
+  }
+}
+
+fragment fragmentA on InterfaceA {
+  id
+  valueA
+}
+
+query queryWithFragmentOnSubInterfaceWithInlineFragment {
+  queryInterface {
+    ...fragmentAWithInlineFragment
+  }
+}
+
+fragment fragmentAWithInlineFragment on InterfaceA {
+  id
+  valueA
+  ... on TypeA {
+    another
+  }
+}
+
+query queryWithFragmentOnUnionMember {
+    queryUnion {
+        ...fragmentB
+    }
+}
+
+
+fragment fragmentB on TypeB {
+    id
+    valueB
+}

--- a/tests/main/clients/fragments_on_abstract_types/schema.graphql
+++ b/tests/main/clients/fragments_on_abstract_types/schema.graphql
@@ -1,0 +1,26 @@
+type Query {
+  queryInterface: BaseInterface!
+  queryUnion: UnionAB!
+}
+
+interface BaseInterface {
+  id: ID!
+}
+
+interface InterfaceA implements BaseInterface {
+  id: ID!
+  valueA: String!
+}
+
+type TypeA implements InterfaceA & BaseInterface {
+  id: ID!
+  valueA: String!
+  another: String!
+}
+
+type TypeB {
+  id: ID!
+  valueB: String!
+}
+
+union UnionAB = TypeA | TypeB

--- a/tests/main/test_main.py
+++ b/tests/main/test_main.py
@@ -153,6 +153,17 @@ def test_main_shows_version():
             "shorter_results",
             CLIENTS_PATH / "shorter_results" / "expected_client",
         ),
+        (
+            (
+                CLIENTS_PATH / "fragments_on_abstract_types" / "pyproject.toml",
+                (
+                    CLIENTS_PATH / "fragments_on_abstract_types" / "queries.graphql",
+                    CLIENTS_PATH / "fragments_on_abstract_types" / "schema.graphql",
+                ),
+            ),
+            "fragments_on_abstract_types_client",
+            CLIENTS_PATH / "fragments_on_abstract_types" / "expected_client",
+        ),
     ],
     indirect=["project_dir"],
 )


### PR DESCRIPTION
This pr adds support for fragments defined on subtype of field's union or interface.
We generate such field as union of 2 classes:
1. Represents type on which fragment was defined - this class inherits from fragment model
2. Rest possible implementations of root union/interface.

If fragment has inline fragment, then we treat it as our "regular" union and generated classes don't inherit from fragment model.


resolves #175 