### PR TITLE
Fixed generating of default values for input fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added default representation for a field name consisting only of underscores.
 - Changed generated client and models to use pydantic v2.
 - Changed custom scalars implementation to utilize pydantic's `BeforeValidator` and `PlainSerializer`. Added `scalars_module_name` option. Replaced `generate_scalars_parse_dict` and `generate_scalars_serialize_dict` with `generate_scalar_annotation` and `generate_scalar_imports` plugin hooks.
+- Fixed generating default values of input types from remote schemas.
 
 
 ## 0.7.1 (2023-06-06)

--- a/ariadne_codegen/client_generators/input_types.py
+++ b/ariadne_codegen/client_generators/input_types.py
@@ -135,7 +135,7 @@ class InputTypesGenerator:
                 target=name,
                 annotation=annotation,
                 value=parse_input_field_default_value(
-                    node=field.ast_node, field_type=field_type
+                    node=field.ast_node, annotation=annotation, field_type=field_type
                 ),
                 lineno=lineno,
             )

--- a/tests/client_generators/test_input_fields.py
+++ b/tests/client_generators/test_input_fields.py
@@ -418,4 +418,32 @@ def test_parse_input_const_value_node_given_object_returns_correct_method_call(
 def test_parse_input_field_default_value_returns_none_constant_for_optional_field():
     node = parse("input TestInput { fieldA: String }").definitions[0].fields[0]
 
-    assert compare_ast(parse_input_field_default_value(node, ""), ast.Constant(None))
+    assert compare_ast(
+        parse_input_field_default_value(
+            node,
+            ast.Subscript(value=ast.Name(id=OPTIONAL), slice=ast.Name(id="str")),
+            "",
+        ),
+        ast.Constant(None),
+    )
+
+
+def test_parse_input_field_default_value_returns_none_constant_without_node():
+    assert compare_ast(
+        parse_input_field_default_value(
+            None,
+            ast.Subscript(value=ast.Name(id=OPTIONAL), slice=ast.Name(id="str")),
+            "",
+        ),
+        ast.Constant(None),
+    )
+
+
+def test_parse_input_field_default_value_returns_none_for_non_nullable_node():
+    node = parse("input TestInput { fieldA: String! }").definitions[0].fields[0]
+
+    assert parse_input_field_default_value(node, ast.Name(id="str"), "") is None
+
+
+def test_parse_input_field_default_value_returns_none_for_non_optional_annotation():
+    assert parse_input_field_default_value(None, ast.Name(id="str"), "") is None


### PR DESCRIPTION
This pr fixes generating of input fields default value for cases with no ast node (eg. parsing remote schema)

fixes #192 