### PR TITLE
Fix generating result types with nullable directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed generating operation string for nested inline fragments.
 - Removed scalars module. Changed generated models and client to use annotated types for custom scalars. Removed `scalars_module_name` option. Removed `generate_scalars_module`, `generate_scalars_cod`, `generate_scalar_annotation` and `generate_scalar_imports` plugin hooks.
 - Removed pydantic warnings for fields with `model_` prefix.
+- Fixed generating result types with nullable directives.
 
 
 ## 0.8.0 (2023-08-22)

--- a/ariadne_codegen/client_generators/result_fields.py
+++ b/ariadne_codegen/client_generators/result_fields.py
@@ -61,10 +61,11 @@ def parse_operation_field(
     typename_values: Optional[List[str]] = None,
     custom_scalars: Optional[Dict[str, ScalarData]] = None,
     fragments_definitions: Optional[Dict[str, FragmentDefinitionNode]] = None,
-) -> Tuple[Annotation, List[FieldNames]]:
+) -> Tuple[Annotation, Optional[ast.expr], List[FieldNames]]:
     if field.name and field.name.value == TYPENAME_FIELD_NAME and typename_values:
-        return generate_typename_annotation(typename_values), []
+        return generate_typename_annotation(typename_values), None, []
 
+    default_value: Optional[ast.expr] = None
     annotation, field_types_names = parse_operation_field_type(
         schema=schema,
         field=field,
@@ -83,7 +84,8 @@ def parse_operation_field(
         directives_names = [d.name.value for d in directives]
         if any(n in nullable_directives for n in directives_names):
             annotation = generate_nullable_annotation(annotation)
-    return annotation, field_types_names
+            default_value = generate_constant(None)
+    return annotation, default_value, field_types_names
 
 
 def generate_typename_annotation(typename_values: List[str]) -> ast.Subscript:

--- a/ariadne_codegen/client_generators/result_types.py
+++ b/ariadne_codegen/client_generators/result_types.py
@@ -246,7 +246,7 @@ class ResultTypesGenerator:
             field_name = self._get_field_name(field)
             name = self._process_field_name(field_name, field=field)
             field_definition = self._get_field_from_schema(type_name, field.name.value)
-            annotation, field_types_names = parse_operation_field(
+            annotation, default_value, field_types_names = parse_operation_field(
                 schema=self.schema,
                 field=field,
                 type_=cast(CodegenResultFieldType, field_definition.type),
@@ -261,6 +261,7 @@ class ResultTypesGenerator:
                 target=name,
                 annotation=annotation,
                 lineno=lineno,
+                value=default_value,
             )
             field_implementation = self._process_field_implementation(
                 field_implementation, field_schema_name=field_name, field=field

--- a/tests/client_generators/result_types_generator/test_directives.py
+++ b/tests/client_generators/result_types_generator/test_directives.py
@@ -185,6 +185,7 @@ def test_generator_returns_module_with_handled_skip_and_include_directives(direc
             value=ast.Name(id=OPTIONAL),
             slice=ast.Name(id='"CustomQueryQuery3Field1"'),
         ),
+        value=ast.Constant(value=None),
         simple=1,
     )
     generator = ResultTypesGenerator(

--- a/tests/client_generators/test_result_fields.py
+++ b/tests/client_generators/test_result_fields.py
@@ -76,7 +76,7 @@ from ..utils import compare_ast
 def test_parse_operation_field_returns_optional_annotation_if_given_nullable_directive(
     directive, type_, expected_annotation
 ):
-    annotation, _ = parse_operation_field(
+    annotation, _, _ = parse_operation_field(
         schema=GraphQLSchema(),
         field=FieldNode(),
         type_=type_,
@@ -92,7 +92,7 @@ def test_parse_operation_field_returns_typename_annotation_with_multiple_values(
         slice=ast.Tuple(elts=[ast.Name(id='"TypeA"'), ast.Name(id='"TypeB"')]),
     )
 
-    annotation, _ = parse_operation_field(
+    annotation, _, _ = parse_operation_field(
         schema=GraphQLSchema(),
         field=FieldNode(name=NameNode(value=TYPENAME_FIELD_NAME)),
         type_=GraphQLNonNull(GraphQLScalarType("String")),
@@ -107,7 +107,7 @@ def test_parse_operation_field_returns_typename_annotation_with_single_value():
         value=ast.Name(id=LITERAL), slice=ast.Name(id='"TypeA"')
     )
 
-    annotation, _ = parse_operation_field(
+    annotation, _, _ = parse_operation_field(
         schema=GraphQLSchema(),
         field=FieldNode(name=NameNode(value=TYPENAME_FIELD_NAME)),
         type_=GraphQLNonNull(GraphQLScalarType("String")),
@@ -145,7 +145,7 @@ def test_parse_operation_field_returns_annotation_with_annotated_nested_unions()
         ),
     )
 
-    annotation, _ = parse_operation_field(
+    annotation, _, _ = parse_operation_field(
         schema=GraphQLSchema(),
         field=FieldNode(name=NameNode(value="unionField")),
         type_=GraphQLUnionType(


### PR DESCRIPTION
Assign `None` as default value for optional fields created due to nullable directives. It's necessary to do so explicitly cause otherwise `pydantic` will complain about missing field (it's a regression introduced due to migration to pydantic v2).

Resolves #204.