### PR TITLE
Allow saving remote schema to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ One of the following 2 parameters is required, in case of providing both of them
 Optional settings:
 
 - `remote_schema_headers` - extra headers that are passed along with introspection query, eg. `{"Authorization" = "Bearer: token"}`. To include an environment variable in a header value, prefix the variable with `$`, eg. `{"Authorization" = "$AUTH_TOKEN"}`
+- `remote_schema_output_path` - (optional) path where the downloaded schema should be written to
 - `remote_schema_verify_ssl` (defaults to `true`) - a flag that specifies wheter to verify ssl while introspecting remote schema
 - `target_package_name` (defaults to `"graphql_client"`) - name of generated package
 - `target_package_path` (defaults to cwd) - path where to generate package

--- a/ariadne_codegen/main.py
+++ b/ariadne_codegen/main.py
@@ -1,7 +1,8 @@
 import sys
+from pathlib import Path
 
 import click
-from graphql import assert_valid_schema
+from graphql import assert_valid_schema, print_schema
 
 from .client_generators.package import PackageGenerator
 from .config import get_client_settings, get_config_dict, get_graphql_schema_settings
@@ -50,6 +51,10 @@ def client(config_dict):
             verify_ssl=settings.remote_schema_verify_ssl,
         )
         schema_source = settings.remote_schema_url
+
+        if settings.remote_schema_output_path:
+            schema_output_file = Path(settings.remote_schema_output_path)
+            schema_output_file.write_text(print_schema(schema), encoding="utf-8")
 
     plugin_manager = PluginManager(
         schema=schema,

--- a/ariadne_codegen/settings.py
+++ b/ariadne_codegen/settings.py
@@ -24,6 +24,7 @@ class BaseSettings:
     schema_path: Optional[str] = None
     remote_schema_url: Optional[str] = None
     remote_schema_headers: dict = field(default_factory=dict)
+    remote_schema_output_path: Optional[str] = None
     remote_schema_verify_ssl: bool = True
     plugins: List[str] = field(default_factory=list)
 

--- a/tests/main/clients/remote_schema/expected_schema.graphql
+++ b/tests/main/clients/remote_schema/expected_schema.graphql
@@ -1,0 +1,3 @@
+type Query {
+  testQuery: Int
+}

--- a/tests/main/clients/remote_schema/pyproject.toml
+++ b/tests/main/clients/remote_schema/pyproject.toml
@@ -5,3 +5,4 @@ include_comments = false
 
 remote_schema_url = "http://test/graphql/"
 remote_schema_headers = { "header1" = "value1", "header2" = "value2" }
+remote_schema_output_path = "schema.graphql"

--- a/tests/main/test_main.py
+++ b/tests/main/test_main.py
@@ -241,6 +241,15 @@ def test_main_uses_remote_schema_url_and_remote_schema_headers(
     result = CliRunner().invoke(main, catch_exceptions=False)
 
     assert result.exit_code == 0
+
+    downloaded_schema_file: Path = project_dir / "schema.graphql"
+    assert downloaded_schema_file.is_file()
+    expected_schema = CLIENTS_PATH.joinpath(
+        "remote_schema", "expected_schema.graphql"
+    ).read_bytes()
+    downloaded_schema = downloaded_schema_file.read_bytes()
+    assert downloaded_schema == expected_schema
+
     package_path = project_dir / package_name
     assert package_path.is_dir()
     assert_the_same_files_in_directories(package_path, expected_package_path)


### PR DESCRIPTION
Add extra option `remote_schema_output_path`. If set, save the downloaded remote schema to file in SDL format.

Related to #211.