### PR TITLE
Set to None if nullable directive used on nullable field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## UNRELEASED
+
+- Fixed generating results for nullable fields with nullable directives.
+
+
 ## 0.9.0 (2023-09-11)
 
 - Fixed generating operation string for nested inline fragments.

--- a/ariadne_codegen/client_generators/result_fields.py
+++ b/ariadne_codegen/client_generators/result_fields.py
@@ -79,11 +79,12 @@ def parse_operation_field(
             cast(AnnotationSlice, annotation.slice)
         )
 
-    if not (is_nullable(annotation)) and directives:
+    if directives:
         nullable_directives = [INCLUDE_DIRECTIVE_NAME, SKIP_DIRECTIVE_NAME]
         directives_names = [d.name.value for d in directives]
         if any(n in nullable_directives for n in directives_names):
-            annotation = generate_nullable_annotation(annotation)
+            if not is_nullable(annotation):
+                annotation = generate_nullable_annotation(annotation)
             default_value = generate_constant(None)
     return annotation, default_value, field_types_names
 

--- a/tests/client_generators/result_types_generator/schema.py
+++ b/tests/client_generators/result_types_generator/schema.py
@@ -48,6 +48,7 @@ type CustomType2 {
 type CustomType3 {
   field1: CustomType1!
   field2: CustomType1!
+  field3: CustomType1
 }
 
 enum CustomEnum {

--- a/tests/client_generators/result_types_generator/test_directives.py
+++ b/tests/client_generators/result_types_generator/test_directives.py
@@ -176,14 +176,26 @@ def test_generator_returns_module_with_handled_skip_and_include_directives(direc
             field2 {{
                 fielda
             }}
+            field3 @{directive}{{
+                fielda
+            }}
         }}
     }}
     """
-    expected_field_def = ast.AnnAssign(
+    expected_field_def_1 = ast.AnnAssign(
         target=ast.Name(id="field1"),
         annotation=ast.Subscript(
             value=ast.Name(id=OPTIONAL),
             slice=ast.Name(id='"CustomQueryQuery3Field1"'),
+        ),
+        value=ast.Constant(value=None),
+        simple=1,
+    )
+    expected_field_def_2 = ast.AnnAssign(
+        target=ast.Name(id="field3"),
+        annotation=ast.Subscript(
+            value=ast.Name(id=OPTIONAL),
+            slice=ast.Name(id='"CustomQueryQuery3Field3"'),
         ),
         value=ast.Constant(value=None),
         simple=1,
@@ -200,5 +212,5 @@ def test_generator_returns_module_with_handled_skip_and_include_directives(direc
 
     class_def = get_class_def(module, 1)
     assert class_def.name == "CustomQueryQuery3"
-    field_def = class_def.body[0]
-    assert compare_ast(field_def, expected_field_def)
+    assert compare_ast(class_def.body[0], expected_field_def_1)
+    assert compare_ast(class_def.body[2], expected_field_def_2)


### PR DESCRIPTION
The None should always be set on fields decorated by nullable directives.

Resolves #217 