### PR TITLE
Added missing dependency to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
   "black",
   "isort",
   "autoflake",
+  "websockets~=11.0.3",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
When running mypy against the generated client in a fresh environment, the following warnings are raised:

```
graphql_client\async_base_client.py:19: error: Cannot find implementation or library stub for module named "websockets.client"  [import]
graphql_client\async_base_client.py:19: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
graphql_client\async_base_client.py:20: error: Cannot find implementation or library stub for module named "websockets.typing"  [import]
```

I have added the missing dependency to the `pyproject.toml`, have tested locally and this error then disappears when included.