### PR TITLE
Add __typename to all models generated from abstract types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Changed `include_comments` option to accept enum value, changed default to `"stable"`, deprecated boolean support. Added `get_file_comment` plugin hook.
 - Changed `str_to_snake_case` utility to correctly handle capitalized words.
 - Digits in Python names are now preceded by an underscore (breaking change).
+- Fixed parsing of unions and interfaces to always add `__typename` to generated result models.
 
 
 ## 0.9.0 (2023-09-11)

--- a/tests/client_generators/result_types_generator/schema.py
+++ b/tests/client_generators/result_types_generator/schema.py
@@ -14,6 +14,7 @@ type Query {
   query4: UnionType!
   camelCaseQuery: CustomType!
   interfaceQuery: InterfaceI!
+  singleMemberQuery: SingleMemberUnion!
 }
 
 type Mutation {
@@ -57,6 +58,8 @@ enum CustomEnum {
 }
 
 union UnionType = CustomType1 | CustomType2
+
+union SingleMemberUnion = CustomType1
 
 scalar SCALARA
 

--- a/tests/main/clients/inline_fragments/expected_client/client.py
+++ b/tests/main/clients/inline_fragments/expected_client/client.py
@@ -68,6 +68,7 @@ class Client(AsyncBaseClient):
             """
             query InterfaceC {
               queryI {
+                __typename
                 id
               }
             }

--- a/tests/main/clients/inline_fragments/expected_client/interface_c.py
+++ b/tests/main/clients/inline_fragments/expected_client/interface_c.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from pydantic import Field
 
 from .base_model import BaseModel
@@ -8,6 +10,9 @@ class InterfaceC(BaseModel):
 
 
 class InterfaceCQueryI(BaseModel):
+    typename__: Literal["Interface", "TypeA", "TypeB", "TypeC"] = Field(
+        alias="__typename"
+    )
     id: str
 
 

--- a/tests/main/clients/shorter_results/expected_client/shorter_results_fragments.py
+++ b/tests/main/clients/shorter_results/expected_client/shorter_results_fragments.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Literal
 
 from pydantic import Field
 
@@ -20,6 +20,7 @@ class ListAnimalsFragment(BaseModel):
 
 
 class ListAnimalsFragmentListAnimals(BaseModel):
+    typename__: Literal["Animal", "Cat", "Dog"] = Field(alias="__typename")
     name: str
 
 


### PR DESCRIPTION
This pr:
- changes `ResultTypesGenerator` to add `__typename` field to models generated from:
    - unions with only one member
    - interfaces which were queries without any inline fragments
- refactors `parse_operation_field_type` by extracting logic for every type to separate function
- resoves #209