### PR TITLE
Add operationName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Added `NoReimportsPlugin` that makes the `__init__.py` of generated client package empty.
 - Added `include_all_inputs` config flag to generate only inputs used in supplied operations.
 - Added `include_all_enums` config flag to generate only enums used in supplied operations.
-- Changed generated client's methods to add `operationName` to sent payload.
+- Added `operationName` to payload sent by generated client's methods.
 
 
 ## 0.10.0 (2023-11-15)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added `NoReimportsPlugin` that makes the `__init__.py` of generated client package empty.
 - Added `include_all_inputs` config flag to generate only inputs used in supplied operations.
 - Added `include_all_enums` config flag to generate only enums used in supplied operations.
+- Changed generated client's methods to add `operationName` to sent payload.
 
 
 ## 0.10.0 (2023-11-15)

--- a/EXAMPLE.md
+++ b/EXAMPLE.md
@@ -210,7 +210,9 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {"userData": user_data}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query, operation_name="CreateUser", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return CreateUser.model_validate(data)
 
@@ -231,7 +233,9 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query, operation_name="ListAllUsers", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return ListAllUsers.model_validate(data)
 
@@ -260,7 +264,12 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {"country": country}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query,
+            operation_name="ListUsersByCountry",
+            variables=variables,
+            **kwargs
+        )
         data = self.get_data(response)
         return ListUsersByCountry.model_validate(data)
 
@@ -273,7 +282,9 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        async for data in self.execute_ws(query=query, variables=variables, **kwargs):
+        async for data in self.execute_ws(
+            query=query, operation_name="GetUsersCounter", variables=variables, **kwargs
+        ):
             yield GetUsersCounter.model_validate(data)
 
     async def upload_file(self, file: Upload, **kwargs: Any) -> UploadFile:
@@ -285,7 +296,9 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {"file": file}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query, operation_name="uploadFile", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return UploadFile.model_validate(data)
 ```

--- a/ariadne_codegen/client_generators/client.py
+++ b/ariadne_codegen/client_generators/client.py
@@ -145,6 +145,7 @@ class ClientGenerator:
                 ast.FunctionDef, ast.AsyncFunctionDef
             ] = self._generate_subscription_method_def(
                 name=name,
+                operation_name=operation_name,
                 return_type=return_type,
                 arguments=arguments,
                 arguments_dict=arguments_dict,
@@ -191,6 +192,7 @@ class ClientGenerator:
     def _generate_subscription_method_def(
         self,
         name: str,
+        operation_name: str,
         return_type: str,
         arguments: ast.arguments,
         arguments_dict: ast.Dict,
@@ -205,7 +207,7 @@ class ClientGenerator:
             body=[
                 self._generate_operation_str_assign(operation_str, 1),
                 self._generate_variables_assign(arguments_dict, 2),
-                self._generate_async_generator_loop(return_type, 3),
+                self._generate_async_generator_loop(operation_name, return_type, 3),
             ],
         )
 
@@ -337,7 +339,7 @@ class ClientGenerator:
         )
 
     def _generate_async_generator_loop(
-        self, return_type: str, lineno: int = 1
+        self, operation_name: str, return_type: str, lineno: int = 1
     ) -> ast.AsyncFor:
         return generate_async_for(
             target=generate_name(self._data_variable),
@@ -346,6 +348,9 @@ class ClientGenerator:
                 keywords=[
                     generate_keyword(
                         value=generate_name(self._operation_str_variable), arg="query"
+                    ),
+                    generate_keyword(
+                        value=generate_constant(operation_name), arg="operation_name"
                     ),
                     generate_keyword(
                         value=generate_name(self._variables_dict_variable),

--- a/ariadne_codegen/client_generators/dependencies/async_base_client.py
+++ b/ariadne_codegen/client_generators/dependencies/async_base_client.py
@@ -134,7 +134,11 @@ class AsyncBaseClient:
         return cast(Dict[str, Any], data)
 
     async def execute_ws(
-        self, query: str, variables: Optional[Dict[str, Any]] = None, **kwargs: Any
+        self,
+        query: str,
+        operation_name: Optional[str] = None,
+        variables: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
     ) -> AsyncIterator[Dict[str, Any]]:
         headers = self.ws_headers.copy()
         headers.update(kwargs.get("extra_headers", {}))
@@ -154,6 +158,7 @@ class AsyncBaseClient:
                 websocket,
                 operation_id=operation_id,
                 query=query,
+                operation_name=operation_name,
                 variables=variables,
             )
 
@@ -295,12 +300,13 @@ class AsyncBaseClient:
         websocket: WebSocketClientProtocol,
         operation_id: str,
         query: str,
+        operation_name: Optional[str] = None,
         variables: Optional[Dict[str, Any]] = None,
     ) -> None:
         payload: Dict[str, Any] = {
             "id": operation_id,
             "type": GraphQLTransportWSMessageType.SUBSCRIBE.value,
-            "payload": {"query": query},
+            "payload": {"query": query, "operationName": operation_name},
         }
         if variables:
             payload["payload"]["variables"] = self._convert_dict_to_json_serializable(

--- a/ariadne_codegen/client_generators/dependencies/async_base_client_open_telemetry.py
+++ b/ariadne_codegen/client_generators/dependencies/async_base_client_open_telemetry.py
@@ -128,14 +128,23 @@ class AsyncBaseClientOpenTelemetry:
         await self.http_client.aclose()
 
     async def execute(
-        self, query: str, variables: Optional[Dict[str, Any]] = None, **kwargs: Any
+        self,
+        query: str,
+        operation_name: Optional[str] = None,
+        variables: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
     ) -> httpx.Response:
         if self.tracer:
             return await self._execute_with_telemetry(
-                query=query, variables=variables, **kwargs
+                query=query,
+                operation_name=operation_name,
+                variables=variables,
+                **kwargs,
             )
 
-        return await self._execute(query=query, variables=variables, **kwargs)
+        return await self._execute(
+            query=query, operation_name=operation_name, variables=variables, **kwargs
+        )
 
     def get_data(self, response: httpx.Response) -> Dict[str, Any]:
         if not response.is_success:
@@ -175,13 +184,18 @@ class AsyncBaseClientOpenTelemetry:
             yield message
 
     async def _execute(
-        self, query: str, variables: Optional[Dict[str, Any]] = None, **kwargs: Any
+        self,
+        query: str,
+        operation_name: Optional[str] = None,
+        variables: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
     ) -> httpx.Response:
         processed_variables, files, files_map = self._process_variables(variables)
 
         if files and files_map:
             return await self._execute_multipart(
                 query=query,
+                operation_name=operation_name,
                 variables=processed_variables,
                 files=files,
                 files_map=files_map,
@@ -189,7 +203,10 @@ class AsyncBaseClientOpenTelemetry:
             )
 
         return await self._execute_json(
-            query=query, variables=processed_variables, **kwargs
+            query=query,
+            operation_name=operation_name,
+            variables=processed_variables,
+            **kwargs,
         )
 
     def _process_variables(
@@ -264,6 +281,7 @@ class AsyncBaseClientOpenTelemetry:
     async def _execute_multipart(
         self,
         query: str,
+        operation_name: Optional[str],
         variables: Dict[str, Any],
         files: Dict[str, Tuple[str, IO[bytes], str]],
         files_map: Dict[str, List[str]],
@@ -271,7 +289,12 @@ class AsyncBaseClientOpenTelemetry:
     ) -> httpx.Response:
         data = {
             "operations": json.dumps(
-                {"query": query, "variables": variables}, default=to_jsonable_python
+                {
+                    "query": query,
+                    "operationName": operation_name,
+                    "variables": variables,
+                },
+                default=to_jsonable_python,
             ),
             "map": json.dumps(files_map, default=to_jsonable_python),
         }
@@ -281,7 +304,11 @@ class AsyncBaseClientOpenTelemetry:
         )
 
     async def _execute_json(
-        self, query: str, variables: Dict[str, Any], **kwargs: Any
+        self,
+        query: str,
+        operation_name: Optional[str],
+        variables: Dict[str, Any],
+        **kwargs: Any,
     ) -> httpx.Response:
         headers: Dict[str, str] = {"Content-Type": "application/json"}
         headers.update(kwargs.get("headers", {}))
@@ -292,7 +319,12 @@ class AsyncBaseClientOpenTelemetry:
         return await self.http_client.post(
             url=self.url,
             content=json.dumps(
-                {"query": query, "variables": variables}, default=to_jsonable_python
+                {
+                    "query": query,
+                    "operationName": operation_name,
+                    "variables": variables,
+                },
+                default=to_jsonable_python,
             ),
             **merged_kwargs,
         )
@@ -385,7 +417,11 @@ class AsyncBaseClientOpenTelemetry:
         return None
 
     async def _execute_with_telemetry(
-        self, query: str, variables: Optional[Dict[str, Any]] = None, **kwargs: Any
+        self,
+        query: str,
+        operation_name: Optional[str] = None,
+        variables: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
     ) -> httpx.Response:
         with self.tracer.start_as_current_span(  # type: ignore
             self.root_span_name, context=self.root_context
@@ -398,6 +434,7 @@ class AsyncBaseClientOpenTelemetry:
                 return await self._execute_multipart_with_telemetry(
                     root_span=root_span,
                     query=query,
+                    operation_name=operation_name,
                     variables=processed_variables,
                     files=files,
                     files_map=files_map,
@@ -407,6 +444,7 @@ class AsyncBaseClientOpenTelemetry:
             return await self._execute_json_with_telemetry(
                 root_span=root_span,
                 query=query,
+                operation_name=operation_name,
                 variables=processed_variables,
                 **kwargs,
             )
@@ -415,6 +453,7 @@ class AsyncBaseClientOpenTelemetry:
         self,
         root_span: Span,
         query: str,
+        operation_name: Optional[str],
         variables: Dict[str, Any],
         files: Dict[str, Tuple[str, IO[bytes], str]],
         files_map: Dict[str, List[str]],
@@ -429,10 +468,12 @@ class AsyncBaseClientOpenTelemetry:
             serialized_map = json.dumps(files_map, default=to_jsonable_python)
 
             span.set_attribute("query", query)
+            span.set_attribute("operationName", operation_name or "")
             span.set_attribute("variables", serialized_variables)
             span.set_attribute("map", serialized_map)
             return await self._execute_multipart(
                 query=query,
+                operation_name=operation_name,
                 variables=variables,
                 files=files,
                 files_map=files_map,
@@ -440,7 +481,12 @@ class AsyncBaseClientOpenTelemetry:
             )
 
     async def _execute_json_with_telemetry(
-        self, root_span: Span, query: str, variables: Dict[str, Any], **kwargs: Any
+        self,
+        root_span: Span,
+        query: str,
+        operation_name: Optional[str],
+        variables: Dict[str, Any],
+        **kwargs: Any,
     ) -> httpx.Response:
         with self.tracer.start_as_current_span(  # type: ignore
             "json request", context=set_span_in_context(root_span)
@@ -450,8 +496,14 @@ class AsyncBaseClientOpenTelemetry:
             serialized_variables = json.dumps(variables, default=to_jsonable_python)
 
             span.set_attribute("query", query)
+            span.set_attribute("operationName", operation_name or "")
             span.set_attribute("variables", serialized_variables)
-            return await self._execute_json(query=query, variables=variables, **kwargs)
+            return await self._execute_json(
+                query=query,
+                operation_name=operation_name,
+                variables=variables,
+                **kwargs,
+            )
 
     async def _execute_ws_with_telemetry(
         self, query: str, variables: Optional[Dict[str, Any]] = None, **kwargs: Any

--- a/tests/client_generators/dependencies/test_websockets.py
+++ b/tests/client_generators/dependencies/test_websockets.py
@@ -126,13 +126,19 @@ async def test_execute_ws_sends_correct_subscribe_data(mocked_websocket):
     query_str = "query testQuery($arg: String!) { test(arg: $arg) }"
     variables = {"arg": "test_value"}
 
-    async for _ in AsyncBaseClient().execute_ws(query=query_str, variables=variables):
+    async for _ in AsyncBaseClient().execute_ws(
+        query=query_str, operation_name="testQuery", variables=variables
+    ):
         pass
 
     _, subscribe_call = mocked_websocket.send.mock_calls
     sent_data = json.loads(subscribe_call.args[0])
     assert sent_data["type"] == "subscribe"
-    assert sent_data["payload"] == {"query": query_str, "variables": variables}
+    assert sent_data["payload"] == {
+        "query": query_str,
+        "operationName": "testQuery",
+        "variables": variables,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/client_generators/test_client_generator.py
+++ b/tests/client_generators/test_client_generator.py
@@ -277,6 +277,9 @@ def test_add_method_generates_correct_async_method_body(async_base_client_import
                     args=[],
                     keywords=[
                         ast.keyword(arg="query", value=ast.Name(id="query")),
+                        ast.keyword(
+                            arg="operation_name", value=ast.Constant(value="ListXyz")
+                        ),
                         ast.keyword(arg="variables", value=ast.Name(id="variables")),
                         ast.keyword(value=ast.Name(id=KWARGS_NAMES)),
                     ],
@@ -415,6 +418,9 @@ def test_add_method_generates_correct_method_body(base_client_import):
                 args=[],
                 keywords=[
                     ast.keyword(arg="query", value=ast.Name(id="query")),
+                    ast.keyword(
+                        arg="operation_name", value=ast.Constant(value="ListXyz")
+                    ),
                     ast.keyword(arg="variables", value=ast.Name(id="variables")),
                     ast.keyword(value=ast.Name(id=KWARGS_NAMES)),
                 ],

--- a/tests/client_generators/test_client_generator.py
+++ b/tests/client_generators/test_client_generator.py
@@ -511,6 +511,9 @@ def test_add_method_generates_async_generator_for_subscription_definition(
                     args=[],
                     keywords=[
                         ast.keyword(arg="query", value=ast.Name(id="query")),
+                        ast.keyword(
+                            arg="operation_name", value=ast.Constant(value="GetCounter")
+                        ),
                         ast.keyword(arg="variables", value=ast.Name(id="variables")),
                         ast.keyword(value=ast.Name(id=KWARGS_NAMES)),
                     ],

--- a/tests/main/clients/custom_base_client/custom_base_client.py
+++ b/tests/main/clients/custom_base_client/custom_base_client.py
@@ -2,7 +2,9 @@ from typing import Any  # this file needs to pass mypy --strict
 
 
 class CustomAsyncBaseClient:
-    async def execute(self, query: Any, variables: Any) -> Any:
+    async def execute(
+        self, query: Any, operation_name: Any, variables: Any, **kwargs: Any
+    ) -> Any:
         pass
 
     def get_data(self, response: Any) -> Any:

--- a/tests/main/clients/custom_base_client/expected_client/client.py
+++ b/tests/main/clients/custom_base_client/expected_client/client.py
@@ -21,6 +21,8 @@ class Client(CustomAsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {"dataA": data_a}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query, operation_name="getQueryA", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return GetQueryA.model_validate(data)

--- a/tests/main/clients/custom_base_client/expected_client/custom_base_client.py
+++ b/tests/main/clients/custom_base_client/expected_client/custom_base_client.py
@@ -2,7 +2,9 @@ from typing import Any  # this file needs to pass mypy --strict
 
 
 class CustomAsyncBaseClient:
-    async def execute(self, query: Any, variables: Any) -> Any:
+    async def execute(
+        self, query: Any, operation_name: Any, variables: Any, **kwargs: Any
+    ) -> Any:
         pass
 
     def get_data(self, response: Any) -> Any:

--- a/tests/main/clients/custom_config_file/expected_client/async_base_client.py
+++ b/tests/main/clients/custom_config_file/expected_client/async_base_client.py
@@ -134,7 +134,11 @@ class AsyncBaseClient:
         return cast(Dict[str, Any], data)
 
     async def execute_ws(
-        self, query: str, variables: Optional[Dict[str, Any]] = None, **kwargs: Any
+        self,
+        query: str,
+        operation_name: Optional[str] = None,
+        variables: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
     ) -> AsyncIterator[Dict[str, Any]]:
         headers = self.ws_headers.copy()
         headers.update(kwargs.get("extra_headers", {}))
@@ -154,6 +158,7 @@ class AsyncBaseClient:
                 websocket,
                 operation_id=operation_id,
                 query=query,
+                operation_name=operation_name,
                 variables=variables,
             )
 
@@ -295,12 +300,13 @@ class AsyncBaseClient:
         websocket: WebSocketClientProtocol,
         operation_id: str,
         query: str,
+        operation_name: Optional[str] = None,
         variables: Optional[Dict[str, Any]] = None,
     ) -> None:
         payload: Dict[str, Any] = {
             "id": operation_id,
             "type": GraphQLTransportWSMessageType.SUBSCRIBE.value,
-            "payload": {"query": query},
+            "payload": {"query": query, "operationName": operation_name},
         }
         if variables:
             payload["payload"]["variables"] = self._convert_dict_to_json_serializable(

--- a/tests/main/clients/custom_config_file/expected_client/client.py
+++ b/tests/main/clients/custom_config_file/expected_client/client.py
@@ -18,6 +18,8 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query, operation_name="test", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return Test.model_validate(data)

--- a/tests/main/clients/custom_files_names/expected_client/async_base_client.py
+++ b/tests/main/clients/custom_files_names/expected_client/async_base_client.py
@@ -134,7 +134,11 @@ class AsyncBaseClient:
         return cast(Dict[str, Any], data)
 
     async def execute_ws(
-        self, query: str, variables: Optional[Dict[str, Any]] = None, **kwargs: Any
+        self,
+        query: str,
+        operation_name: Optional[str] = None,
+        variables: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
     ) -> AsyncIterator[Dict[str, Any]]:
         headers = self.ws_headers.copy()
         headers.update(kwargs.get("extra_headers", {}))
@@ -154,6 +158,7 @@ class AsyncBaseClient:
                 websocket,
                 operation_id=operation_id,
                 query=query,
+                operation_name=operation_name,
                 variables=variables,
             )
 
@@ -295,12 +300,13 @@ class AsyncBaseClient:
         websocket: WebSocketClientProtocol,
         operation_id: str,
         query: str,
+        operation_name: Optional[str] = None,
         variables: Optional[Dict[str, Any]] = None,
     ) -> None:
         payload: Dict[str, Any] = {
             "id": operation_id,
             "type": GraphQLTransportWSMessageType.SUBSCRIBE.value,
-            "payload": {"query": query},
+            "payload": {"query": query, "operationName": operation_name},
         }
         if variables:
             payload["payload"]["variables"] = self._convert_dict_to_json_serializable(

--- a/tests/main/clients/custom_files_names/expected_client/custom_client.py
+++ b/tests/main/clients/custom_files_names/expected_client/custom_client.py
@@ -21,6 +21,8 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {"dataA": data_a}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query, operation_name="getQueryA", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return GetQueryA.model_validate(data)

--- a/tests/main/clients/custom_scalars/expected_client/async_base_client.py
+++ b/tests/main/clients/custom_scalars/expected_client/async_base_client.py
@@ -134,7 +134,11 @@ class AsyncBaseClient:
         return cast(Dict[str, Any], data)
 
     async def execute_ws(
-        self, query: str, variables: Optional[Dict[str, Any]] = None, **kwargs: Any
+        self,
+        query: str,
+        operation_name: Optional[str] = None,
+        variables: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
     ) -> AsyncIterator[Dict[str, Any]]:
         headers = self.ws_headers.copy()
         headers.update(kwargs.get("extra_headers", {}))
@@ -154,6 +158,7 @@ class AsyncBaseClient:
                 websocket,
                 operation_id=operation_id,
                 query=query,
+                operation_name=operation_name,
                 variables=variables,
             )
 
@@ -295,12 +300,13 @@ class AsyncBaseClient:
         websocket: WebSocketClientProtocol,
         operation_id: str,
         query: str,
+        operation_name: Optional[str] = None,
         variables: Optional[Dict[str, Any]] = None,
     ) -> None:
         payload: Dict[str, Any] = {
             "id": operation_id,
             "type": GraphQLTransportWSMessageType.SUBSCRIBE.value,
-            "payload": {"query": query},
+            "payload": {"query": query, "operationName": operation_name},
         }
         if variables:
             payload["payload"]["variables"] = self._convert_dict_to_json_serializable(

--- a/tests/main/clients/custom_scalars/expected_client/client.py
+++ b/tests/main/clients/custom_scalars/expected_client/client.py
@@ -40,6 +40,8 @@ class Client(AsyncBaseClient):
             "input": input,
             "other": other,
         }
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query, operation_name="getA", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return GetA.model_validate(data)

--- a/tests/main/clients/example/expected_client/async_base_client.py
+++ b/tests/main/clients/example/expected_client/async_base_client.py
@@ -134,7 +134,11 @@ class AsyncBaseClient:
         return cast(Dict[str, Any], data)
 
     async def execute_ws(
-        self, query: str, variables: Optional[Dict[str, Any]] = None, **kwargs: Any
+        self,
+        query: str,
+        operation_name: Optional[str] = None,
+        variables: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
     ) -> AsyncIterator[Dict[str, Any]]:
         headers = self.ws_headers.copy()
         headers.update(kwargs.get("extra_headers", {}))
@@ -154,6 +158,7 @@ class AsyncBaseClient:
                 websocket,
                 operation_id=operation_id,
                 query=query,
+                operation_name=operation_name,
                 variables=variables,
             )
 
@@ -295,12 +300,13 @@ class AsyncBaseClient:
         websocket: WebSocketClientProtocol,
         operation_id: str,
         query: str,
+        operation_name: Optional[str] = None,
         variables: Optional[Dict[str, Any]] = None,
     ) -> None:
         payload: Dict[str, Any] = {
             "id": operation_id,
             "type": GraphQLTransportWSMessageType.SUBSCRIBE.value,
-            "payload": {"query": query},
+            "payload": {"query": query, "operationName": operation_name},
         }
         if variables:
             payload["payload"]["variables"] = self._convert_dict_to_json_serializable(

--- a/tests/main/clients/example/expected_client/client.py
+++ b/tests/main/clients/example/expected_client/client.py
@@ -100,7 +100,9 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        async for data in self.execute_ws(query=query, variables=variables, **kwargs):
+        async for data in self.execute_ws(
+            query=query, operation_name="GetUsersCounter", variables=variables, **kwargs
+        ):
             yield GetUsersCounter.model_validate(data)
 
     async def upload_file(self, file: Upload, **kwargs: Any) -> UploadFile:

--- a/tests/main/clients/example/expected_client/client.py
+++ b/tests/main/clients/example/expected_client/client.py
@@ -28,7 +28,9 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {"userData": user_data}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query, operation_name="CreateUser", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return CreateUser.model_validate(data)
 
@@ -49,7 +51,9 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query, operation_name="ListAllUsers", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return ListAllUsers.model_validate(data)
 
@@ -78,7 +82,12 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {"country": country}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query,
+            operation_name="ListUsersByCountry",
+            variables=variables,
+            **kwargs
+        )
         data = self.get_data(response)
         return ListUsersByCountry.model_validate(data)
 
@@ -103,6 +112,8 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {"file": file}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query, operation_name="uploadFile", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return UploadFile.model_validate(data)

--- a/tests/main/clients/extended_models/expected_client/async_base_client.py
+++ b/tests/main/clients/extended_models/expected_client/async_base_client.py
@@ -134,7 +134,11 @@ class AsyncBaseClient:
         return cast(Dict[str, Any], data)
 
     async def execute_ws(
-        self, query: str, variables: Optional[Dict[str, Any]] = None, **kwargs: Any
+        self,
+        query: str,
+        operation_name: Optional[str] = None,
+        variables: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
     ) -> AsyncIterator[Dict[str, Any]]:
         headers = self.ws_headers.copy()
         headers.update(kwargs.get("extra_headers", {}))
@@ -154,6 +158,7 @@ class AsyncBaseClient:
                 websocket,
                 operation_id=operation_id,
                 query=query,
+                operation_name=operation_name,
                 variables=variables,
             )
 
@@ -295,12 +300,13 @@ class AsyncBaseClient:
         websocket: WebSocketClientProtocol,
         operation_id: str,
         query: str,
+        operation_name: Optional[str] = None,
         variables: Optional[Dict[str, Any]] = None,
     ) -> None:
         payload: Dict[str, Any] = {
             "id": operation_id,
             "type": GraphQLTransportWSMessageType.SUBSCRIBE.value,
-            "payload": {"query": query},
+            "payload": {"query": query, "operationName": operation_name},
         }
         if variables:
             payload["payload"]["variables"] = self._convert_dict_to_json_serializable(

--- a/tests/main/clients/extended_models/expected_client/client.py
+++ b/tests/main/clients/extended_models/expected_client/client.py
@@ -23,7 +23,9 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query, operation_name="getQueryA", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return GetQueryA.model_validate(data)
 
@@ -38,7 +40,9 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query, operation_name="getQueryB", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return GetQueryB.model_validate(data)
 
@@ -57,7 +61,12 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query,
+            operation_name="getQueryAWithFragment",
+            variables=variables,
+            **kwargs
+        )
         data = self.get_data(response)
         return GetQueryAWithFragment.model_validate(data)
 
@@ -83,6 +92,11 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query,
+            operation_name="fragmentsWithMixins",
+            variables=variables,
+            **kwargs
+        )
         data = self.get_data(response)
         return FragmentsWithMixins.model_validate(data)

--- a/tests/main/clients/fragments_on_abstract_types/expected_client/async_base_client.py
+++ b/tests/main/clients/fragments_on_abstract_types/expected_client/async_base_client.py
@@ -134,7 +134,11 @@ class AsyncBaseClient:
         return cast(Dict[str, Any], data)
 
     async def execute_ws(
-        self, query: str, variables: Optional[Dict[str, Any]] = None, **kwargs: Any
+        self,
+        query: str,
+        operation_name: Optional[str] = None,
+        variables: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
     ) -> AsyncIterator[Dict[str, Any]]:
         headers = self.ws_headers.copy()
         headers.update(kwargs.get("extra_headers", {}))
@@ -154,6 +158,7 @@ class AsyncBaseClient:
                 websocket,
                 operation_id=operation_id,
                 query=query,
+                operation_name=operation_name,
                 variables=variables,
             )
 
@@ -295,12 +300,13 @@ class AsyncBaseClient:
         websocket: WebSocketClientProtocol,
         operation_id: str,
         query: str,
+        operation_name: Optional[str] = None,
         variables: Optional[Dict[str, Any]] = None,
     ) -> None:
         payload: Dict[str, Any] = {
             "id": operation_id,
             "type": GraphQLTransportWSMessageType.SUBSCRIBE.value,
-            "payload": {"query": query},
+            "payload": {"query": query, "operationName": operation_name},
         }
         if variables:
             payload["payload"]["variables"] = self._convert_dict_to_json_serializable(

--- a/tests/main/clients/fragments_on_abstract_types/expected_client/client.py
+++ b/tests/main/clients/fragments_on_abstract_types/expected_client/client.py
@@ -32,7 +32,12 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query,
+            operation_name="queryWithFragmentOnSubInterface",
+            variables=variables,
+            **kwargs
+        )
         data = self.get_data(response)
         return QueryWithFragmentOnSubInterface.model_validate(data)
 
@@ -58,7 +63,12 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query,
+            operation_name="queryWithFragmentOnSubInterfaceWithInlineFragment",
+            variables=variables,
+            **kwargs
+        )
         data = self.get_data(response)
         return QueryWithFragmentOnSubInterfaceWithInlineFragment.model_validate(data)
 
@@ -81,6 +91,11 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query,
+            operation_name="queryWithFragmentOnUnionMember",
+            variables=variables,
+            **kwargs
+        )
         data = self.get_data(response)
         return QueryWithFragmentOnUnionMember.model_validate(data)

--- a/tests/main/clients/inline_fragments/expected_client/async_base_client.py
+++ b/tests/main/clients/inline_fragments/expected_client/async_base_client.py
@@ -134,7 +134,11 @@ class AsyncBaseClient:
         return cast(Dict[str, Any], data)
 
     async def execute_ws(
-        self, query: str, variables: Optional[Dict[str, Any]] = None, **kwargs: Any
+        self,
+        query: str,
+        operation_name: Optional[str] = None,
+        variables: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
     ) -> AsyncIterator[Dict[str, Any]]:
         headers = self.ws_headers.copy()
         headers.update(kwargs.get("extra_headers", {}))
@@ -154,6 +158,7 @@ class AsyncBaseClient:
                 websocket,
                 operation_id=operation_id,
                 query=query,
+                operation_name=operation_name,
                 variables=variables,
             )
 
@@ -295,12 +300,13 @@ class AsyncBaseClient:
         websocket: WebSocketClientProtocol,
         operation_id: str,
         query: str,
+        operation_name: Optional[str] = None,
         variables: Optional[Dict[str, Any]] = None,
     ) -> None:
         payload: Dict[str, Any] = {
             "id": operation_id,
             "type": GraphQLTransportWSMessageType.SUBSCRIBE.value,
-            "payload": {"query": query},
+            "payload": {"query": query, "operationName": operation_name},
         }
         if variables:
             payload["payload"]["variables"] = self._convert_dict_to_json_serializable(

--- a/tests/main/clients/inline_fragments/expected_client/client.py
+++ b/tests/main/clients/inline_fragments/expected_client/client.py
@@ -40,7 +40,9 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query, operation_name="InterfaceA", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return InterfaceA.model_validate(data)
 
@@ -59,7 +61,9 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query, operation_name="InterfaceB", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return InterfaceB.model_validate(data)
 
@@ -75,7 +79,9 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query, operation_name="InterfaceC", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return InterfaceC.model_validate(data)
 
@@ -97,7 +103,9 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query, operation_name="ListInterface", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return ListInterface.model_validate(data)
 
@@ -113,7 +121,12 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query,
+            operation_name="InterfaceWithTypename",
+            variables=variables,
+            **kwargs
+        )
         data = self.get_data(response)
         return InterfaceWithTypename.model_validate(data)
 
@@ -136,7 +149,9 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query, operation_name="UnionA", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return UnionA.model_validate(data)
 
@@ -155,7 +170,9 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query, operation_name="UnionB", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return UnionB.model_validate(data)
 
@@ -178,7 +195,9 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query, operation_name="ListUnion", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return ListUnion.model_validate(data)
 
@@ -206,7 +225,12 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query,
+            operation_name="queryWithFragmentOnInterface",
+            variables=variables,
+            **kwargs
+        )
         data = self.get_data(response)
         return QueryWithFragmentOnInterface.model_validate(data)
 
@@ -235,7 +259,12 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query,
+            operation_name="queryWithFragmentOnUnion",
+            variables=variables,
+            **kwargs
+        )
         data = self.get_data(response)
         return QueryWithFragmentOnUnion.model_validate(data)
 
@@ -262,7 +291,12 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query,
+            operation_name="queryWithFragmentOnQueryWithInterface",
+            variables=variables,
+            **kwargs
+        )
         data = self.get_data(response)
         return QueryWithFragmentOnQueryWithInterface.model_validate(data)
 
@@ -290,6 +324,11 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query,
+            operation_name="queryWithFragmentOnQueryWithUnion",
+            variables=variables,
+            **kwargs
+        )
         data = self.get_data(response)
         return QueryWithFragmentOnQueryWithUnion.model_validate(data)

--- a/tests/main/clients/multiple_fragments/expected_client/async_base_client.py
+++ b/tests/main/clients/multiple_fragments/expected_client/async_base_client.py
@@ -134,7 +134,11 @@ class AsyncBaseClient:
         return cast(Dict[str, Any], data)
 
     async def execute_ws(
-        self, query: str, variables: Optional[Dict[str, Any]] = None, **kwargs: Any
+        self,
+        query: str,
+        operation_name: Optional[str] = None,
+        variables: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
     ) -> AsyncIterator[Dict[str, Any]]:
         headers = self.ws_headers.copy()
         headers.update(kwargs.get("extra_headers", {}))
@@ -154,6 +158,7 @@ class AsyncBaseClient:
                 websocket,
                 operation_id=operation_id,
                 query=query,
+                operation_name=operation_name,
                 variables=variables,
             )
 
@@ -295,12 +300,13 @@ class AsyncBaseClient:
         websocket: WebSocketClientProtocol,
         operation_id: str,
         query: str,
+        operation_name: Optional[str] = None,
         variables: Optional[Dict[str, Any]] = None,
     ) -> None:
         payload: Dict[str, Any] = {
             "id": operation_id,
             "type": GraphQLTransportWSMessageType.SUBSCRIBE.value,
-            "payload": {"query": query},
+            "payload": {"query": query, "operationName": operation_name},
         }
         if variables:
             payload["payload"]["variables"] = self._convert_dict_to_json_serializable(

--- a/tests/main/clients/multiple_fragments/expected_client/client.py
+++ b/tests/main/clients/multiple_fragments/expected_client/client.py
@@ -34,7 +34,9 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query, operation_name="exampleQuery1", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return ExampleQuery1.model_validate(data)
 
@@ -62,7 +64,9 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query, operation_name="exampleQuery2", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return ExampleQuery2.model_validate(data)
 
@@ -86,6 +90,8 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query, operation_name="exampleQuery3", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return ExampleQuery3.model_validate(data)

--- a/tests/main/clients/only_used_inputs_and_enums/expected_client/async_base_client.py
+++ b/tests/main/clients/only_used_inputs_and_enums/expected_client/async_base_client.py
@@ -134,7 +134,11 @@ class AsyncBaseClient:
         return cast(Dict[str, Any], data)
 
     async def execute_ws(
-        self, query: str, variables: Optional[Dict[str, Any]] = None, **kwargs: Any
+        self,
+        query: str,
+        operation_name: Optional[str] = None,
+        variables: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
     ) -> AsyncIterator[Dict[str, Any]]:
         headers = self.ws_headers.copy()
         headers.update(kwargs.get("extra_headers", {}))
@@ -154,6 +158,7 @@ class AsyncBaseClient:
                 websocket,
                 operation_id=operation_id,
                 query=query,
+                operation_name=operation_name,
                 variables=variables,
             )
 
@@ -295,12 +300,13 @@ class AsyncBaseClient:
         websocket: WebSocketClientProtocol,
         operation_id: str,
         query: str,
+        operation_name: Optional[str] = None,
         variables: Optional[Dict[str, Any]] = None,
     ) -> None:
         payload: Dict[str, Any] = {
             "id": operation_id,
             "type": GraphQLTransportWSMessageType.SUBSCRIBE.value,
-            "payload": {"query": query},
+            "payload": {"query": query, "operationName": operation_name},
         }
         if variables:
             payload["payload"]["variables"] = self._convert_dict_to_json_serializable(

--- a/tests/main/clients/only_used_inputs_and_enums/expected_client/client.py
+++ b/tests/main/clients/only_used_inputs_and_enums/expected_client/client.py
@@ -26,7 +26,9 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {"argA": arg_a}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query, operation_name="getA", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return GetA.model_validate(data)
 
@@ -39,7 +41,9 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {"argA": arg_a}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query, operation_name="getA2", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return GetA2.model_validate(data)
 
@@ -52,7 +56,9 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {"argAA": arg_aa}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query, operation_name="getB", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return GetB.model_validate(data)
 
@@ -65,7 +71,9 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {"enumD": enum_d}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query, operation_name="getD", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return GetD.model_validate(data)
 
@@ -78,7 +86,9 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {"argE": arg_e}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query, operation_name="getE", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return GetE.model_validate(data)
 
@@ -93,7 +103,9 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query, operation_name="getF", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return GetF.model_validate(data)
 
@@ -112,6 +124,8 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query, operation_name="getG", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return GetG.model_validate(data)

--- a/tests/main/clients/operations/expected_client/async_base_client.py
+++ b/tests/main/clients/operations/expected_client/async_base_client.py
@@ -134,7 +134,11 @@ class AsyncBaseClient:
         return cast(Dict[str, Any], data)
 
     async def execute_ws(
-        self, query: str, variables: Optional[Dict[str, Any]] = None, **kwargs: Any
+        self,
+        query: str,
+        operation_name: Optional[str] = None,
+        variables: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
     ) -> AsyncIterator[Dict[str, Any]]:
         headers = self.ws_headers.copy()
         headers.update(kwargs.get("extra_headers", {}))
@@ -154,6 +158,7 @@ class AsyncBaseClient:
                 websocket,
                 operation_id=operation_id,
                 query=query,
+                operation_name=operation_name,
                 variables=variables,
             )
 
@@ -295,12 +300,13 @@ class AsyncBaseClient:
         websocket: WebSocketClientProtocol,
         operation_id: str,
         query: str,
+        operation_name: Optional[str] = None,
         variables: Optional[Dict[str, Any]] = None,
     ) -> None:
         payload: Dict[str, Any] = {
             "id": operation_id,
             "type": GraphQLTransportWSMessageType.SUBSCRIBE.value,
-            "payload": {"query": query},
+            "payload": {"query": query, "operationName": operation_name},
         }
         if variables:
             payload["payload"]["variables"] = self._convert_dict_to_json_serializable(

--- a/tests/main/clients/operations/expected_client/client.py
+++ b/tests/main/clients/operations/expected_client/client.py
@@ -44,7 +44,10 @@ class Client(AsyncBaseClient):
     async def c_subscription(self, **kwargs: Any) -> AsyncIterator[CSubscription]:
         variables: Dict[str, object] = {}
         async for data in self.execute_ws(
-            query=C_SUBSCRIPTION_GQL, variables=variables, **kwargs
+            query=C_SUBSCRIPTION_GQL,
+            operation_name="cSubscription",
+            variables=variables,
+            **kwargs
         ):
             yield CSubscription.model_validate(data)
 

--- a/tests/main/clients/operations/expected_client/client.py
+++ b/tests/main/clients/operations/expected_client/client.py
@@ -24,14 +24,19 @@ def gql(q: str) -> str:
 class Client(AsyncBaseClient):
     async def c_query(self, **kwargs: Any) -> CQuery:
         variables: Dict[str, object] = {}
-        response = await self.execute(query=C_QUERY_GQL, variables=variables, **kwargs)
+        response = await self.execute(
+            query=C_QUERY_GQL, operation_name="cQuery", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return CQuery.model_validate(data)
 
     async def c_mutation(self, **kwargs: Any) -> CMutation:
         variables: Dict[str, object] = {}
         response = await self.execute(
-            query=C_MUTATION_GQL, variables=variables, **kwargs
+            query=C_MUTATION_GQL,
+            operation_name="cMutation",
+            variables=variables,
+            **kwargs
         )
         data = self.get_data(response)
         return CMutation.model_validate(data)
@@ -45,20 +50,27 @@ class Client(AsyncBaseClient):
 
     async def get_a(self, **kwargs: Any) -> GetA:
         variables: Dict[str, object] = {}
-        response = await self.execute(query=GET_A_GQL, variables=variables, **kwargs)
+        response = await self.execute(
+            query=GET_A_GQL, operation_name="getA", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return GetA.model_validate(data)
 
     async def get_a_with_fragment(self, **kwargs: Any) -> GetAWithFragment:
         variables: Dict[str, object] = {}
         response = await self.execute(
-            query=GET_A_WITH_FRAGMENT_GQL, variables=variables, **kwargs
+            query=GET_A_WITH_FRAGMENT_GQL,
+            operation_name="getAWithFragment",
+            variables=variables,
+            **kwargs
         )
         data = self.get_data(response)
         return GetAWithFragment.model_validate(data)
 
     async def get_xyz(self, **kwargs: Any) -> GetXYZ:
         variables: Dict[str, object] = {}
-        response = await self.execute(query=GET_XYZ_GQL, variables=variables, **kwargs)
+        response = await self.execute(
+            query=GET_XYZ_GQL, operation_name="getXYZ", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return GetXYZ.model_validate(data)

--- a/tests/main/clients/remote_schema/expected_client/async_base_client.py
+++ b/tests/main/clients/remote_schema/expected_client/async_base_client.py
@@ -134,7 +134,11 @@ class AsyncBaseClient:
         return cast(Dict[str, Any], data)
 
     async def execute_ws(
-        self, query: str, variables: Optional[Dict[str, Any]] = None, **kwargs: Any
+        self,
+        query: str,
+        operation_name: Optional[str] = None,
+        variables: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
     ) -> AsyncIterator[Dict[str, Any]]:
         headers = self.ws_headers.copy()
         headers.update(kwargs.get("extra_headers", {}))
@@ -154,6 +158,7 @@ class AsyncBaseClient:
                 websocket,
                 operation_id=operation_id,
                 query=query,
+                operation_name=operation_name,
                 variables=variables,
             )
 
@@ -295,12 +300,13 @@ class AsyncBaseClient:
         websocket: WebSocketClientProtocol,
         operation_id: str,
         query: str,
+        operation_name: Optional[str] = None,
         variables: Optional[Dict[str, Any]] = None,
     ) -> None:
         payload: Dict[str, Any] = {
             "id": operation_id,
             "type": GraphQLTransportWSMessageType.SUBSCRIBE.value,
-            "payload": {"query": query},
+            "payload": {"query": query, "operationName": operation_name},
         }
         if variables:
             payload["payload"]["variables"] = self._convert_dict_to_json_serializable(

--- a/tests/main/clients/remote_schema/expected_client/client.py
+++ b/tests/main/clients/remote_schema/expected_client/client.py
@@ -18,6 +18,8 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query, operation_name="test", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return Test.model_validate(data)

--- a/tests/main/clients/shorter_results/expected_client/async_base_client.py
+++ b/tests/main/clients/shorter_results/expected_client/async_base_client.py
@@ -134,7 +134,11 @@ class AsyncBaseClient:
         return cast(Dict[str, Any], data)
 
     async def execute_ws(
-        self, query: str, variables: Optional[Dict[str, Any]] = None, **kwargs: Any
+        self,
+        query: str,
+        operation_name: Optional[str] = None,
+        variables: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
     ) -> AsyncIterator[Dict[str, Any]]:
         headers = self.ws_headers.copy()
         headers.update(kwargs.get("extra_headers", {}))
@@ -154,6 +158,7 @@ class AsyncBaseClient:
                 websocket,
                 operation_id=operation_id,
                 query=query,
+                operation_name=operation_name,
                 variables=variables,
             )
 
@@ -295,12 +300,13 @@ class AsyncBaseClient:
         websocket: WebSocketClientProtocol,
         operation_id: str,
         query: str,
+        operation_name: Optional[str] = None,
         variables: Optional[Dict[str, Any]] = None,
     ) -> None:
         payload: Dict[str, Any] = {
             "id": operation_id,
             "type": GraphQLTransportWSMessageType.SUBSCRIBE.value,
-            "payload": {"query": query},
+            "payload": {"query": query, "operationName": operation_name},
         }
         if variables:
             payload["payload"]["variables"] = self._convert_dict_to_json_serializable(

--- a/tests/main/clients/shorter_results/expected_client/client.py
+++ b/tests/main/clients/shorter_results/expected_client/client.py
@@ -266,7 +266,12 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        async for data in self.execute_ws(query=query, variables=variables, **kwargs):
+        async for data in self.execute_ws(
+            query=query,
+            operation_name="SubscribeStrings",
+            variables=variables,
+            **kwargs
+        ):
             yield SubscribeStrings.model_validate(data).optional_list_string
 
     async def unwrap_fragment(

--- a/tests/main/clients/shorter_results/expected_client/client.py
+++ b/tests/main/clients/shorter_results/expected_client/client.py
@@ -45,7 +45,12 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query,
+            operation_name="GetAuthenticatedUser",
+            variables=variables,
+            **kwargs
+        )
         data = self.get_data(response)
         return GetAuthenticatedUser.model_validate(data).me
 
@@ -58,7 +63,9 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query, operation_name="ListStrings_1", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return ListStrings1.model_validate(data).optional_list_optional_string
 
@@ -71,7 +78,9 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query, operation_name="ListStrings_2", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return ListStrings2.model_validate(data).optional_list_string
 
@@ -84,7 +93,9 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query, operation_name="ListStrings_3", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return ListStrings3.model_validate(data).list_optional_string
 
@@ -97,7 +108,9 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query, operation_name="ListStrings_4", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return ListStrings4.model_validate(data).list_string
 
@@ -114,7 +127,9 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query, operation_name="ListTypeA", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return ListTypeA.model_validate(data).list_optional_type_a
 
@@ -142,7 +157,9 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {"name": name}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query, operation_name="GetAnimalByName", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return GetAnimalByName.model_validate(data).animal_by_name
 
@@ -172,7 +189,9 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query, operation_name="ListAnimals", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return ListAnimals.model_validate(data).list_animals
 
@@ -194,7 +213,12 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query,
+            operation_name="GetAnimalFragmentWithExtra",
+            variables=variables,
+            **kwargs
+        )
         data = self.get_data(response)
         return GetAnimalFragmentWithExtra.model_validate(data)
 
@@ -207,7 +231,9 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query, operation_name="GetSimpleScalar", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return GetSimpleScalar.model_validate(data).just_simple_scalar
 
@@ -220,7 +246,12 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query,
+            operation_name="GetComplexScalar",
+            variables=variables,
+            **kwargs
+        )
         data = self.get_data(response)
         return GetComplexScalar.model_validate(data).just_complex_scalar
 
@@ -255,6 +286,8 @@ class Client(AsyncBaseClient):
             """
         )
         variables: Dict[str, object] = {}
-        response = await self.execute(query=query, variables=variables, **kwargs)
+        response = await self.execute(
+            query=query, operation_name="UnwrapFragment", variables=variables, **kwargs
+        )
         data = self.get_data(response)
         return UnwrapFragment.model_validate(data).query_unwrap_fragment


### PR DESCRIPTION
This pr adds `operationName` key to the payload sent to a server. We already require all parsed operations to have a name. In generated methods, it is passed as string literal, e.g:
```python
response = await self.execute(query=query, operation_name="CreateUser", variables=variables, **kwargs)
```

resolves #225 