### PR TITLE
Rename invalid response error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added `include_all_enums` config flag to generate only enums used in supplied operations.
 - Added `operationName` to payload sent by generated client's methods.
 - Fixed base clients to pass `mypy --strict` without installed optional dependencies.
+- Renamed `GraphQlClientInvalidResponseError` to `GraphQLClientInvalidResponseError` (breaking change).
 
 
 ## 0.10.0 (2023-11-15)

--- a/EXAMPLE.md
+++ b/EXAMPLE.md
@@ -520,7 +520,7 @@ from .exceptions import (
     GraphQLClientGraphQLError,
     GraphQLClientGraphQLMultiError,
     GraphQLClientHttpError,
-    GraphQlClientInvalidResponseError,
+    GraphQLClientInvalidResponseError,
 )
 from .fragments import BasicUser, UserPersonalData
 from .get_users_counter import GetUsersCounter
@@ -547,7 +547,7 @@ __all__ = [
     "GraphQLClientGraphQLError",
     "GraphQLClientGraphQLMultiError",
     "GraphQLClientHttpError",
-    "GraphQlClientInvalidResponseError",
+    "GraphQLClientInvalidResponseError",
     "ListAllUsers",
     "ListAllUsersUsers",
     "ListAllUsersUsersLocation",

--- a/ariadne_codegen/client_generators/constants.py
+++ b/ariadne_codegen/client_generators/constants.py
@@ -91,7 +91,7 @@ DEFAULT_BASE_CLIENT_OPEN_TELEMETRY_NAME = "BaseClientOpenTelemetry"
 GRAPHQL_CLIENT_EXCEPTIONS_NAMES = [
     "GraphQLClientError",
     "GraphQLClientHttpError",
-    "GraphQlClientInvalidResponseError",
+    "GraphQLClientInvalidResponseError",
     "GraphQLClientGraphQLError",
     "GraphQLClientGraphQLMultiError",
 ]

--- a/ariadne_codegen/client_generators/dependencies/async_base_client.py
+++ b/ariadne_codegen/client_generators/dependencies/async_base_client.py
@@ -12,7 +12,7 @@ from .exceptions import (
     GraphQLClientGraphQLMultiError,
     GraphQLClientHttpError,
     GraphQLClientInvalidMessageFormat,
-    GraphQlClientInvalidResponseError,
+    GraphQLClientInvalidResponseError,
 )
 
 try:
@@ -125,10 +125,10 @@ class AsyncBaseClient:
         try:
             response_json = response.json()
         except ValueError as exc:
-            raise GraphQlClientInvalidResponseError(response=response) from exc
+            raise GraphQLClientInvalidResponseError(response=response) from exc
 
         if (not isinstance(response_json, dict)) or ("data" not in response_json):
-            raise GraphQlClientInvalidResponseError(response=response)
+            raise GraphQLClientInvalidResponseError(response=response)
 
         data = response_json["data"]
         errors = response_json.get("errors")

--- a/ariadne_codegen/client_generators/dependencies/async_base_client_open_telemetry.py
+++ b/ariadne_codegen/client_generators/dependencies/async_base_client_open_telemetry.py
@@ -23,7 +23,7 @@ from .exceptions import (
     GraphQLClientGraphQLMultiError,
     GraphQLClientHttpError,
     GraphQLClientInvalidMessageFormat,
-    GraphQlClientInvalidResponseError,
+    GraphQLClientInvalidResponseError,
 )
 
 try:
@@ -164,10 +164,10 @@ class AsyncBaseClientOpenTelemetry:
         try:
             response_json = response.json()
         except ValueError as exc:
-            raise GraphQlClientInvalidResponseError(response=response) from exc
+            raise GraphQLClientInvalidResponseError(response=response) from exc
 
         if (not isinstance(response_json, dict)) or ("data" not in response_json):
-            raise GraphQlClientInvalidResponseError(response=response)
+            raise GraphQLClientInvalidResponseError(response=response)
 
         data = response_json["data"]
         errors = response_json.get("errors")

--- a/ariadne_codegen/client_generators/dependencies/base_client.py
+++ b/ariadne_codegen/client_generators/dependencies/base_client.py
@@ -9,7 +9,7 @@ from .base_model import UNSET, Upload
 from .exceptions import (
     GraphQLClientGraphQLMultiError,
     GraphQLClientHttpError,
-    GraphQlClientInvalidResponseError,
+    GraphQLClientInvalidResponseError,
 )
 
 Self = TypeVar("Self", bound="BaseClient")
@@ -73,10 +73,10 @@ class BaseClient:
         try:
             response_json = response.json()
         except ValueError as exc:
-            raise GraphQlClientInvalidResponseError(response=response) from exc
+            raise GraphQLClientInvalidResponseError(response=response) from exc
 
         if (not isinstance(response_json, dict)) or ("data" not in response_json):
-            raise GraphQlClientInvalidResponseError(response=response)
+            raise GraphQLClientInvalidResponseError(response=response)
 
         data = response_json["data"]
         errors = response_json.get("errors")

--- a/ariadne_codegen/client_generators/dependencies/base_client_open_telemetry.py
+++ b/ariadne_codegen/client_generators/dependencies/base_client_open_telemetry.py
@@ -9,7 +9,7 @@ from .base_model import UNSET, Upload
 from .exceptions import (
     GraphQLClientGraphQLMultiError,
     GraphQLClientHttpError,
-    GraphQlClientInvalidResponseError,
+    GraphQLClientInvalidResponseError,
 )
 
 try:
@@ -96,10 +96,10 @@ class BaseClientOpenTelemetry:
         try:
             response_json = response.json()
         except ValueError as exc:
-            raise GraphQlClientInvalidResponseError(response=response) from exc
+            raise GraphQLClientInvalidResponseError(response=response) from exc
 
         if (not isinstance(response_json, dict)) or ("data" not in response_json):
-            raise GraphQlClientInvalidResponseError(response=response)
+            raise GraphQLClientInvalidResponseError(response=response)
 
         data = response_json["data"]
         errors = response_json.get("errors")

--- a/ariadne_codegen/client_generators/dependencies/exceptions.py
+++ b/ariadne_codegen/client_generators/dependencies/exceptions.py
@@ -16,7 +16,7 @@ class GraphQLClientHttpError(GraphQLClientError):
         return f"HTTP status code: {self.status_code}"
 
 
-class GraphQlClientInvalidResponseError(GraphQLClientError):
+class GraphQLClientInvalidResponseError(GraphQLClientError):
     def __init__(self, response: httpx.Response) -> None:
         self.response = response
 

--- a/tests/client_generators/dependencies/test_async_base_client.py
+++ b/tests/client_generators/dependencies/test_async_base_client.py
@@ -12,7 +12,7 @@ from ariadne_codegen.client_generators.dependencies.base_model import UNSET, Bas
 from ariadne_codegen.client_generators.dependencies.exceptions import (
     GraphQLClientGraphQLMultiError,
     GraphQLClientHttpError,
-    GraphQlClientInvalidResponseError,
+    GraphQLClientInvalidResponseError,
 )
 
 from ...utils import decode_multipart_request
@@ -513,7 +513,7 @@ def test_get_data_raises_graphql_client_invalid_response_error(
     client = AsyncBaseClient(url="base_url", http_client=mocker.MagicMock())
     response = httpx.Response(status_code=200, content=json.dumps(response_content))
 
-    with pytest.raises(GraphQlClientInvalidResponseError) as exc:
+    with pytest.raises(GraphQLClientInvalidResponseError) as exc:
         client.get_data(response)
         assert exc.response == response
 

--- a/tests/client_generators/dependencies/test_async_base_client_open_telemetry.py
+++ b/tests/client_generators/dependencies/test_async_base_client_open_telemetry.py
@@ -13,7 +13,7 @@ from ariadne_codegen.client_generators.dependencies.base_model import UNSET, Bas
 from ariadne_codegen.client_generators.dependencies.exceptions import (
     GraphQLClientGraphQLMultiError,
     GraphQLClientHttpError,
-    GraphQlClientInvalidResponseError,
+    GraphQLClientInvalidResponseError,
 )
 
 from ...utils import decode_multipart_request
@@ -530,7 +530,7 @@ def test_get_data_raises_graphql_client_invalid_response_error(
     )
     response = httpx.Response(status_code=200, content=json.dumps(response_content))
 
-    with pytest.raises(GraphQlClientInvalidResponseError) as exc:
+    with pytest.raises(GraphQLClientInvalidResponseError) as exc:
         client.get_data(response)
         assert exc.response == response
 

--- a/tests/client_generators/dependencies/test_base_client.py
+++ b/tests/client_generators/dependencies/test_base_client.py
@@ -10,7 +10,7 @@ from ariadne_codegen.client_generators.dependencies.base_model import UNSET, Bas
 from ariadne_codegen.client_generators.dependencies.exceptions import (
     GraphQLClientGraphQLMultiError,
     GraphQLClientHttpError,
-    GraphQlClientInvalidResponseError,
+    GraphQLClientInvalidResponseError,
 )
 
 from ...utils import decode_multipart_request
@@ -486,7 +486,7 @@ def test_get_data_raises_graphql_client_invalid_response_error(
     client = BaseClient(url="base_url", http_client=mocker.MagicMock())
     response = httpx.Response(status_code=200, content=json.dumps(response_content))
 
-    with pytest.raises(GraphQlClientInvalidResponseError) as exc:
+    with pytest.raises(GraphQLClientInvalidResponseError) as exc:
         client.get_data(response)
         assert exc.response == response
 

--- a/tests/client_generators/dependencies/test_base_client_open_telemetry.py
+++ b/tests/client_generators/dependencies/test_base_client_open_telemetry.py
@@ -13,7 +13,7 @@ from ariadne_codegen.client_generators.dependencies.base_model import UNSET, Bas
 from ariadne_codegen.client_generators.dependencies.exceptions import (
     GraphQLClientGraphQLMultiError,
     GraphQLClientHttpError,
-    GraphQlClientInvalidResponseError,
+    GraphQLClientInvalidResponseError,
 )
 
 from ...utils import decode_multipart_request
@@ -499,7 +499,7 @@ def test_get_data_raises_graphql_client_invalid_response_error(
     client = BaseClientOpenTelemetry(url="base_url", http_client=mocker.MagicMock())
     response = httpx.Response(status_code=200, content=json.dumps(response_content))
 
-    with pytest.raises(GraphQlClientInvalidResponseError) as exc:
+    with pytest.raises(GraphQLClientInvalidResponseError) as exc:
         client.get_data(response)
         assert exc.response == response
 

--- a/tests/client_generators/package_generator/test_generated_files.py
+++ b/tests/client_generators/package_generator/test_generated_files.py
@@ -106,7 +106,7 @@ def test_generate_creates_files_with_correct_imports(
                 "GraphQLClientGraphQLError",
                 "GraphQLClientGraphQLMultiError",
                 "GraphQLClientHttpError",
-                "GraphQlClientInvalidResponseError",
+                "GraphQLClientInvalidResponseError",
                 "Upload",
             ]
         """

--- a/tests/main/clients/custom_config_file/expected_client/__init__.py
+++ b/tests/main/clients/custom_config_file/expected_client/__init__.py
@@ -6,7 +6,7 @@ from .exceptions import (
     GraphQLClientGraphQLError,
     GraphQLClientGraphQLMultiError,
     GraphQLClientHttpError,
-    GraphQlClientInvalidResponseError,
+    GraphQLClientInvalidResponseError,
 )
 from .test import Test
 
@@ -18,7 +18,7 @@ __all__ = [
     "GraphQLClientGraphQLError",
     "GraphQLClientGraphQLMultiError",
     "GraphQLClientHttpError",
-    "GraphQlClientInvalidResponseError",
+    "GraphQLClientInvalidResponseError",
     "Test",
     "Upload",
 ]

--- a/tests/main/clients/custom_config_file/expected_client/async_base_client.py
+++ b/tests/main/clients/custom_config_file/expected_client/async_base_client.py
@@ -12,7 +12,7 @@ from .exceptions import (
     GraphQLClientGraphQLMultiError,
     GraphQLClientHttpError,
     GraphQLClientInvalidMessageFormat,
-    GraphQlClientInvalidResponseError,
+    GraphQLClientInvalidResponseError,
 )
 
 try:
@@ -125,10 +125,10 @@ class AsyncBaseClient:
         try:
             response_json = response.json()
         except ValueError as exc:
-            raise GraphQlClientInvalidResponseError(response=response) from exc
+            raise GraphQLClientInvalidResponseError(response=response) from exc
 
         if (not isinstance(response_json, dict)) or ("data" not in response_json):
-            raise GraphQlClientInvalidResponseError(response=response)
+            raise GraphQLClientInvalidResponseError(response=response)
 
         data = response_json["data"]
         errors = response_json.get("errors")

--- a/tests/main/clients/custom_config_file/expected_client/exceptions.py
+++ b/tests/main/clients/custom_config_file/expected_client/exceptions.py
@@ -16,7 +16,7 @@ class GraphQLClientHttpError(GraphQLClientError):
         return f"HTTP status code: {self.status_code}"
 
 
-class GraphQlClientInvalidResponseError(GraphQLClientError):
+class GraphQLClientInvalidResponseError(GraphQLClientError):
     def __init__(self, response: httpx.Response) -> None:
         self.response = response
 

--- a/tests/main/clients/custom_files_names/expected_client/__init__.py
+++ b/tests/main/clients/custom_files_names/expected_client/__init__.py
@@ -8,7 +8,7 @@ from .exceptions import (
     GraphQLClientGraphQLError,
     GraphQLClientGraphQLMultiError,
     GraphQLClientHttpError,
-    GraphQlClientInvalidResponseError,
+    GraphQLClientInvalidResponseError,
 )
 from .get_query_a import GetQueryA, GetQueryAQueryA
 
@@ -22,7 +22,7 @@ __all__ = [
     "GraphQLClientGraphQLError",
     "GraphQLClientGraphQLMultiError",
     "GraphQLClientHttpError",
-    "GraphQlClientInvalidResponseError",
+    "GraphQLClientInvalidResponseError",
     "Upload",
     "enumA",
     "inputA",

--- a/tests/main/clients/custom_files_names/expected_client/async_base_client.py
+++ b/tests/main/clients/custom_files_names/expected_client/async_base_client.py
@@ -12,7 +12,7 @@ from .exceptions import (
     GraphQLClientGraphQLMultiError,
     GraphQLClientHttpError,
     GraphQLClientInvalidMessageFormat,
-    GraphQlClientInvalidResponseError,
+    GraphQLClientInvalidResponseError,
 )
 
 try:
@@ -125,10 +125,10 @@ class AsyncBaseClient:
         try:
             response_json = response.json()
         except ValueError as exc:
-            raise GraphQlClientInvalidResponseError(response=response) from exc
+            raise GraphQLClientInvalidResponseError(response=response) from exc
 
         if (not isinstance(response_json, dict)) or ("data" not in response_json):
-            raise GraphQlClientInvalidResponseError(response=response)
+            raise GraphQLClientInvalidResponseError(response=response)
 
         data = response_json["data"]
         errors = response_json.get("errors")

--- a/tests/main/clients/custom_files_names/expected_client/exceptions.py
+++ b/tests/main/clients/custom_files_names/expected_client/exceptions.py
@@ -16,7 +16,7 @@ class GraphQLClientHttpError(GraphQLClientError):
         return f"HTTP status code: {self.status_code}"
 
 
-class GraphQlClientInvalidResponseError(GraphQLClientError):
+class GraphQLClientInvalidResponseError(GraphQLClientError):
     def __init__(self, response: httpx.Response) -> None:
         self.response = response
 

--- a/tests/main/clients/custom_scalars/expected_client/__init__.py
+++ b/tests/main/clients/custom_scalars/expected_client/__init__.py
@@ -6,7 +6,7 @@ from .exceptions import (
     GraphQLClientGraphQLError,
     GraphQLClientGraphQLMultiError,
     GraphQLClientHttpError,
-    GraphQlClientInvalidResponseError,
+    GraphQLClientInvalidResponseError,
 )
 from .get_a import GetA, GetATestQuery
 from .input_types import TestInput
@@ -21,7 +21,7 @@ __all__ = [
     "GraphQLClientGraphQLError",
     "GraphQLClientGraphQLMultiError",
     "GraphQLClientHttpError",
-    "GraphQlClientInvalidResponseError",
+    "GraphQLClientInvalidResponseError",
     "TestInput",
     "Upload",
 ]

--- a/tests/main/clients/custom_scalars/expected_client/async_base_client.py
+++ b/tests/main/clients/custom_scalars/expected_client/async_base_client.py
@@ -12,7 +12,7 @@ from .exceptions import (
     GraphQLClientGraphQLMultiError,
     GraphQLClientHttpError,
     GraphQLClientInvalidMessageFormat,
-    GraphQlClientInvalidResponseError,
+    GraphQLClientInvalidResponseError,
 )
 
 try:
@@ -125,10 +125,10 @@ class AsyncBaseClient:
         try:
             response_json = response.json()
         except ValueError as exc:
-            raise GraphQlClientInvalidResponseError(response=response) from exc
+            raise GraphQLClientInvalidResponseError(response=response) from exc
 
         if (not isinstance(response_json, dict)) or ("data" not in response_json):
-            raise GraphQlClientInvalidResponseError(response=response)
+            raise GraphQLClientInvalidResponseError(response=response)
 
         data = response_json["data"]
         errors = response_json.get("errors")

--- a/tests/main/clients/custom_scalars/expected_client/exceptions.py
+++ b/tests/main/clients/custom_scalars/expected_client/exceptions.py
@@ -16,7 +16,7 @@ class GraphQLClientHttpError(GraphQLClientError):
         return f"HTTP status code: {self.status_code}"
 
 
-class GraphQlClientInvalidResponseError(GraphQLClientError):
+class GraphQLClientInvalidResponseError(GraphQLClientError):
     def __init__(self, response: httpx.Response) -> None:
         self.response = response
 

--- a/tests/main/clients/example/expected_client/__init__.py
+++ b/tests/main/clients/example/expected_client/__init__.py
@@ -8,7 +8,7 @@ from .exceptions import (
     GraphQLClientGraphQLError,
     GraphQLClientGraphQLMultiError,
     GraphQLClientHttpError,
-    GraphQlClientInvalidResponseError,
+    GraphQLClientInvalidResponseError,
 )
 from .fragments import BasicUser, UserPersonalData
 from .get_users_counter import GetUsersCounter
@@ -35,7 +35,7 @@ __all__ = [
     "GraphQLClientGraphQLError",
     "GraphQLClientGraphQLMultiError",
     "GraphQLClientHttpError",
-    "GraphQlClientInvalidResponseError",
+    "GraphQLClientInvalidResponseError",
     "ListAllUsers",
     "ListAllUsersUsers",
     "ListAllUsersUsersLocation",

--- a/tests/main/clients/example/expected_client/async_base_client.py
+++ b/tests/main/clients/example/expected_client/async_base_client.py
@@ -12,7 +12,7 @@ from .exceptions import (
     GraphQLClientGraphQLMultiError,
     GraphQLClientHttpError,
     GraphQLClientInvalidMessageFormat,
-    GraphQlClientInvalidResponseError,
+    GraphQLClientInvalidResponseError,
 )
 
 try:
@@ -125,10 +125,10 @@ class AsyncBaseClient:
         try:
             response_json = response.json()
         except ValueError as exc:
-            raise GraphQlClientInvalidResponseError(response=response) from exc
+            raise GraphQLClientInvalidResponseError(response=response) from exc
 
         if (not isinstance(response_json, dict)) or ("data" not in response_json):
-            raise GraphQlClientInvalidResponseError(response=response)
+            raise GraphQLClientInvalidResponseError(response=response)
 
         data = response_json["data"]
         errors = response_json.get("errors")

--- a/tests/main/clients/example/expected_client/exceptions.py
+++ b/tests/main/clients/example/expected_client/exceptions.py
@@ -16,7 +16,7 @@ class GraphQLClientHttpError(GraphQLClientError):
         return f"HTTP status code: {self.status_code}"
 
 
-class GraphQlClientInvalidResponseError(GraphQLClientError):
+class GraphQLClientInvalidResponseError(GraphQLClientError):
     def __init__(self, response: httpx.Response) -> None:
         self.response = response
 

--- a/tests/main/clients/extended_models/expected_client/__init__.py
+++ b/tests/main/clients/extended_models/expected_client/__init__.py
@@ -6,7 +6,7 @@ from .exceptions import (
     GraphQLClientGraphQLError,
     GraphQLClientGraphQLMultiError,
     GraphQLClientHttpError,
-    GraphQlClientInvalidResponseError,
+    GraphQLClientInvalidResponseError,
 )
 from .fragments import FragmentA, FragmentB, GetQueryAFragment, GetQueryAFragmentQueryA
 from .fragments_with_mixins import (
@@ -38,6 +38,6 @@ __all__ = [
     "GraphQLClientGraphQLError",
     "GraphQLClientGraphQLMultiError",
     "GraphQLClientHttpError",
-    "GraphQlClientInvalidResponseError",
+    "GraphQLClientInvalidResponseError",
     "Upload",
 ]

--- a/tests/main/clients/extended_models/expected_client/async_base_client.py
+++ b/tests/main/clients/extended_models/expected_client/async_base_client.py
@@ -12,7 +12,7 @@ from .exceptions import (
     GraphQLClientGraphQLMultiError,
     GraphQLClientHttpError,
     GraphQLClientInvalidMessageFormat,
-    GraphQlClientInvalidResponseError,
+    GraphQLClientInvalidResponseError,
 )
 
 try:
@@ -125,10 +125,10 @@ class AsyncBaseClient:
         try:
             response_json = response.json()
         except ValueError as exc:
-            raise GraphQlClientInvalidResponseError(response=response) from exc
+            raise GraphQLClientInvalidResponseError(response=response) from exc
 
         if (not isinstance(response_json, dict)) or ("data" not in response_json):
-            raise GraphQlClientInvalidResponseError(response=response)
+            raise GraphQLClientInvalidResponseError(response=response)
 
         data = response_json["data"]
         errors = response_json.get("errors")

--- a/tests/main/clients/extended_models/expected_client/exceptions.py
+++ b/tests/main/clients/extended_models/expected_client/exceptions.py
@@ -16,7 +16,7 @@ class GraphQLClientHttpError(GraphQLClientError):
         return f"HTTP status code: {self.status_code}"
 
 
-class GraphQlClientInvalidResponseError(GraphQLClientError):
+class GraphQLClientInvalidResponseError(GraphQLClientError):
     def __init__(self, response: httpx.Response) -> None:
         self.response = response
 

--- a/tests/main/clients/fragments_on_abstract_types/expected_client/__init__.py
+++ b/tests/main/clients/fragments_on_abstract_types/expected_client/__init__.py
@@ -6,7 +6,7 @@ from .exceptions import (
     GraphQLClientGraphQLError,
     GraphQLClientGraphQLMultiError,
     GraphQLClientHttpError,
-    GraphQlClientInvalidResponseError,
+    GraphQLClientInvalidResponseError,
 )
 from .fragments import FragmentA, FragmentB
 from .query_with_fragment_on_sub_interface import (
@@ -36,7 +36,7 @@ __all__ = [
     "GraphQLClientGraphQLError",
     "GraphQLClientGraphQLMultiError",
     "GraphQLClientHttpError",
-    "GraphQlClientInvalidResponseError",
+    "GraphQLClientInvalidResponseError",
     "QueryWithFragmentOnSubInterface",
     "QueryWithFragmentOnSubInterfaceQueryInterfaceBaseInterface",
     "QueryWithFragmentOnSubInterfaceQueryInterfaceInterfaceA",

--- a/tests/main/clients/fragments_on_abstract_types/expected_client/async_base_client.py
+++ b/tests/main/clients/fragments_on_abstract_types/expected_client/async_base_client.py
@@ -12,7 +12,7 @@ from .exceptions import (
     GraphQLClientGraphQLMultiError,
     GraphQLClientHttpError,
     GraphQLClientInvalidMessageFormat,
-    GraphQlClientInvalidResponseError,
+    GraphQLClientInvalidResponseError,
 )
 
 try:
@@ -125,10 +125,10 @@ class AsyncBaseClient:
         try:
             response_json = response.json()
         except ValueError as exc:
-            raise GraphQlClientInvalidResponseError(response=response) from exc
+            raise GraphQLClientInvalidResponseError(response=response) from exc
 
         if (not isinstance(response_json, dict)) or ("data" not in response_json):
-            raise GraphQlClientInvalidResponseError(response=response)
+            raise GraphQLClientInvalidResponseError(response=response)
 
         data = response_json["data"]
         errors = response_json.get("errors")

--- a/tests/main/clients/fragments_on_abstract_types/expected_client/exceptions.py
+++ b/tests/main/clients/fragments_on_abstract_types/expected_client/exceptions.py
@@ -16,7 +16,7 @@ class GraphQLClientHttpError(GraphQLClientError):
         return f"HTTP status code: {self.status_code}"
 
 
-class GraphQlClientInvalidResponseError(GraphQLClientError):
+class GraphQLClientInvalidResponseError(GraphQLClientError):
     def __init__(self, response: httpx.Response) -> None:
         self.response = response
 

--- a/tests/main/clients/inline_fragments/expected_client/__init__.py
+++ b/tests/main/clients/inline_fragments/expected_client/__init__.py
@@ -6,7 +6,7 @@ from .exceptions import (
     GraphQLClientGraphQLError,
     GraphQLClientGraphQLMultiError,
     GraphQLClientHttpError,
-    GraphQlClientInvalidResponseError,
+    GraphQLClientInvalidResponseError,
 )
 from .fragments import (
     FragmentOnQueryWithInterface,
@@ -75,7 +75,7 @@ __all__ = [
     "GraphQLClientGraphQLError",
     "GraphQLClientGraphQLMultiError",
     "GraphQLClientHttpError",
-    "GraphQlClientInvalidResponseError",
+    "GraphQLClientInvalidResponseError",
     "InterfaceA",
     "InterfaceAQueryIInterface",
     "InterfaceAQueryITypeA",

--- a/tests/main/clients/inline_fragments/expected_client/async_base_client.py
+++ b/tests/main/clients/inline_fragments/expected_client/async_base_client.py
@@ -12,7 +12,7 @@ from .exceptions import (
     GraphQLClientGraphQLMultiError,
     GraphQLClientHttpError,
     GraphQLClientInvalidMessageFormat,
-    GraphQlClientInvalidResponseError,
+    GraphQLClientInvalidResponseError,
 )
 
 try:
@@ -125,10 +125,10 @@ class AsyncBaseClient:
         try:
             response_json = response.json()
         except ValueError as exc:
-            raise GraphQlClientInvalidResponseError(response=response) from exc
+            raise GraphQLClientInvalidResponseError(response=response) from exc
 
         if (not isinstance(response_json, dict)) or ("data" not in response_json):
-            raise GraphQlClientInvalidResponseError(response=response)
+            raise GraphQLClientInvalidResponseError(response=response)
 
         data = response_json["data"]
         errors = response_json.get("errors")

--- a/tests/main/clients/inline_fragments/expected_client/exceptions.py
+++ b/tests/main/clients/inline_fragments/expected_client/exceptions.py
@@ -16,7 +16,7 @@ class GraphQLClientHttpError(GraphQLClientError):
         return f"HTTP status code: {self.status_code}"
 
 
-class GraphQlClientInvalidResponseError(GraphQLClientError):
+class GraphQLClientInvalidResponseError(GraphQLClientError):
     def __init__(self, response: httpx.Response) -> None:
         self.response = response
 

--- a/tests/main/clients/multiple_fragments/expected_client/__init__.py
+++ b/tests/main/clients/multiple_fragments/expected_client/__init__.py
@@ -9,7 +9,7 @@ from .exceptions import (
     GraphQLClientGraphQLError,
     GraphQLClientGraphQLMultiError,
     GraphQLClientHttpError,
-    GraphQlClientInvalidResponseError,
+    GraphQLClientInvalidResponseError,
 )
 from .fragments import (
     CompleteA,
@@ -41,7 +41,7 @@ __all__ = [
     "GraphQLClientGraphQLError",
     "GraphQLClientGraphQLMultiError",
     "GraphQLClientHttpError",
-    "GraphQlClientInvalidResponseError",
+    "GraphQLClientInvalidResponseError",
     "MinimalA",
     "MinimalAFieldB",
     "MinimalB",

--- a/tests/main/clients/multiple_fragments/expected_client/async_base_client.py
+++ b/tests/main/clients/multiple_fragments/expected_client/async_base_client.py
@@ -12,7 +12,7 @@ from .exceptions import (
     GraphQLClientGraphQLMultiError,
     GraphQLClientHttpError,
     GraphQLClientInvalidMessageFormat,
-    GraphQlClientInvalidResponseError,
+    GraphQLClientInvalidResponseError,
 )
 
 try:
@@ -125,10 +125,10 @@ class AsyncBaseClient:
         try:
             response_json = response.json()
         except ValueError as exc:
-            raise GraphQlClientInvalidResponseError(response=response) from exc
+            raise GraphQLClientInvalidResponseError(response=response) from exc
 
         if (not isinstance(response_json, dict)) or ("data" not in response_json):
-            raise GraphQlClientInvalidResponseError(response=response)
+            raise GraphQLClientInvalidResponseError(response=response)
 
         data = response_json["data"]
         errors = response_json.get("errors")

--- a/tests/main/clients/multiple_fragments/expected_client/exceptions.py
+++ b/tests/main/clients/multiple_fragments/expected_client/exceptions.py
@@ -16,7 +16,7 @@ class GraphQLClientHttpError(GraphQLClientError):
         return f"HTTP status code: {self.status_code}"
 
 
-class GraphQlClientInvalidResponseError(GraphQLClientError):
+class GraphQLClientInvalidResponseError(GraphQLClientError):
     def __init__(self, response: httpx.Response) -> None:
         self.response = response
 

--- a/tests/main/clients/only_used_inputs_and_enums/expected_client/__init__.py
+++ b/tests/main/clients/only_used_inputs_and_enums/expected_client/__init__.py
@@ -7,7 +7,7 @@ from .exceptions import (
     GraphQLClientGraphQLError,
     GraphQLClientGraphQLMultiError,
     GraphQLClientHttpError,
-    GraphQlClientInvalidResponseError,
+    GraphQLClientInvalidResponseError,
 )
 from .fragments import FragmentG, FragmentGG
 from .get_a import GetA
@@ -43,7 +43,7 @@ __all__ = [
     "GraphQLClientGraphQLError",
     "GraphQLClientGraphQLMultiError",
     "GraphQLClientHttpError",
-    "GraphQlClientInvalidResponseError",
+    "GraphQLClientInvalidResponseError",
     "InputA",
     "InputAA",
     "InputAAA",

--- a/tests/main/clients/only_used_inputs_and_enums/expected_client/async_base_client.py
+++ b/tests/main/clients/only_used_inputs_and_enums/expected_client/async_base_client.py
@@ -12,7 +12,7 @@ from .exceptions import (
     GraphQLClientGraphQLMultiError,
     GraphQLClientHttpError,
     GraphQLClientInvalidMessageFormat,
-    GraphQlClientInvalidResponseError,
+    GraphQLClientInvalidResponseError,
 )
 
 try:
@@ -125,10 +125,10 @@ class AsyncBaseClient:
         try:
             response_json = response.json()
         except ValueError as exc:
-            raise GraphQlClientInvalidResponseError(response=response) from exc
+            raise GraphQLClientInvalidResponseError(response=response) from exc
 
         if (not isinstance(response_json, dict)) or ("data" not in response_json):
-            raise GraphQlClientInvalidResponseError(response=response)
+            raise GraphQLClientInvalidResponseError(response=response)
 
         data = response_json["data"]
         errors = response_json.get("errors")

--- a/tests/main/clients/only_used_inputs_and_enums/expected_client/exceptions.py
+++ b/tests/main/clients/only_used_inputs_and_enums/expected_client/exceptions.py
@@ -16,7 +16,7 @@ class GraphQLClientHttpError(GraphQLClientError):
         return f"HTTP status code: {self.status_code}"
 
 
-class GraphQlClientInvalidResponseError(GraphQLClientError):
+class GraphQLClientInvalidResponseError(GraphQLClientError):
     def __init__(self, response: httpx.Response) -> None:
         self.response = response
 

--- a/tests/main/clients/operations/expected_client/__init__.py
+++ b/tests/main/clients/operations/expected_client/__init__.py
@@ -17,7 +17,7 @@ from .exceptions import (
     GraphQLClientGraphQLError,
     GraphQLClientGraphQLMultiError,
     GraphQLClientHttpError,
-    GraphQlClientInvalidResponseError,
+    GraphQLClientInvalidResponseError,
 )
 from .fragments import FragmentB, FragmentY
 from .get_a import GetA, GetAA, GetAAValueB
@@ -57,6 +57,6 @@ __all__ = [
     "GraphQLClientGraphQLError",
     "GraphQLClientGraphQLMultiError",
     "GraphQLClientHttpError",
-    "GraphQlClientInvalidResponseError",
+    "GraphQLClientInvalidResponseError",
     "Upload",
 ]

--- a/tests/main/clients/operations/expected_client/async_base_client.py
+++ b/tests/main/clients/operations/expected_client/async_base_client.py
@@ -12,7 +12,7 @@ from .exceptions import (
     GraphQLClientGraphQLMultiError,
     GraphQLClientHttpError,
     GraphQLClientInvalidMessageFormat,
-    GraphQlClientInvalidResponseError,
+    GraphQLClientInvalidResponseError,
 )
 
 try:
@@ -125,10 +125,10 @@ class AsyncBaseClient:
         try:
             response_json = response.json()
         except ValueError as exc:
-            raise GraphQlClientInvalidResponseError(response=response) from exc
+            raise GraphQLClientInvalidResponseError(response=response) from exc
 
         if (not isinstance(response_json, dict)) or ("data" not in response_json):
-            raise GraphQlClientInvalidResponseError(response=response)
+            raise GraphQLClientInvalidResponseError(response=response)
 
         data = response_json["data"]
         errors = response_json.get("errors")

--- a/tests/main/clients/operations/expected_client/exceptions.py
+++ b/tests/main/clients/operations/expected_client/exceptions.py
@@ -16,7 +16,7 @@ class GraphQLClientHttpError(GraphQLClientError):
         return f"HTTP status code: {self.status_code}"
 
 
-class GraphQlClientInvalidResponseError(GraphQLClientError):
+class GraphQLClientInvalidResponseError(GraphQLClientError):
     def __init__(self, response: httpx.Response) -> None:
         self.response = response
 

--- a/tests/main/clients/remote_schema/expected_client/__init__.py
+++ b/tests/main/clients/remote_schema/expected_client/__init__.py
@@ -6,7 +6,7 @@ from .exceptions import (
     GraphQLClientGraphQLError,
     GraphQLClientGraphQLMultiError,
     GraphQLClientHttpError,
-    GraphQlClientInvalidResponseError,
+    GraphQLClientInvalidResponseError,
 )
 from .test import Test
 
@@ -18,7 +18,7 @@ __all__ = [
     "GraphQLClientGraphQLError",
     "GraphQLClientGraphQLMultiError",
     "GraphQLClientHttpError",
-    "GraphQlClientInvalidResponseError",
+    "GraphQLClientInvalidResponseError",
     "Test",
     "Upload",
 ]

--- a/tests/main/clients/remote_schema/expected_client/async_base_client.py
+++ b/tests/main/clients/remote_schema/expected_client/async_base_client.py
@@ -12,7 +12,7 @@ from .exceptions import (
     GraphQLClientGraphQLMultiError,
     GraphQLClientHttpError,
     GraphQLClientInvalidMessageFormat,
-    GraphQlClientInvalidResponseError,
+    GraphQLClientInvalidResponseError,
 )
 
 try:
@@ -125,10 +125,10 @@ class AsyncBaseClient:
         try:
             response_json = response.json()
         except ValueError as exc:
-            raise GraphQlClientInvalidResponseError(response=response) from exc
+            raise GraphQLClientInvalidResponseError(response=response) from exc
 
         if (not isinstance(response_json, dict)) or ("data" not in response_json):
-            raise GraphQlClientInvalidResponseError(response=response)
+            raise GraphQLClientInvalidResponseError(response=response)
 
         data = response_json["data"]
         errors = response_json.get("errors")

--- a/tests/main/clients/remote_schema/expected_client/exceptions.py
+++ b/tests/main/clients/remote_schema/expected_client/exceptions.py
@@ -16,7 +16,7 @@ class GraphQLClientHttpError(GraphQLClientError):
         return f"HTTP status code: {self.status_code}"
 
 
-class GraphQlClientInvalidResponseError(GraphQLClientError):
+class GraphQLClientInvalidResponseError(GraphQLClientError):
     def __init__(self, response: httpx.Response) -> None:
         self.response = response
 

--- a/tests/main/clients/shorter_results/expected_client/__init__.py
+++ b/tests/main/clients/shorter_results/expected_client/__init__.py
@@ -6,7 +6,7 @@ from .exceptions import (
     GraphQLClientGraphQLError,
     GraphQLClientGraphQLMultiError,
     GraphQLClientHttpError,
-    GraphQlClientInvalidResponseError,
+    GraphQLClientInvalidResponseError,
 )
 from .get_animal_by_name import (
     GetAnimalByName,
@@ -57,7 +57,7 @@ __all__ = [
     "GraphQLClientGraphQLError",
     "GraphQLClientGraphQLMultiError",
     "GraphQLClientHttpError",
-    "GraphQlClientInvalidResponseError",
+    "GraphQLClientInvalidResponseError",
     "ListAnimals",
     "ListAnimalsFragment",
     "ListAnimalsFragmentListAnimals",

--- a/tests/main/clients/shorter_results/expected_client/async_base_client.py
+++ b/tests/main/clients/shorter_results/expected_client/async_base_client.py
@@ -12,7 +12,7 @@ from .exceptions import (
     GraphQLClientGraphQLMultiError,
     GraphQLClientHttpError,
     GraphQLClientInvalidMessageFormat,
-    GraphQlClientInvalidResponseError,
+    GraphQLClientInvalidResponseError,
 )
 
 try:
@@ -125,10 +125,10 @@ class AsyncBaseClient:
         try:
             response_json = response.json()
         except ValueError as exc:
-            raise GraphQlClientInvalidResponseError(response=response) from exc
+            raise GraphQLClientInvalidResponseError(response=response) from exc
 
         if (not isinstance(response_json, dict)) or ("data" not in response_json):
-            raise GraphQlClientInvalidResponseError(response=response)
+            raise GraphQLClientInvalidResponseError(response=response)
 
         data = response_json["data"]
         errors = response_json.get("errors")

--- a/tests/main/clients/shorter_results/expected_client/exceptions.py
+++ b/tests/main/clients/shorter_results/expected_client/exceptions.py
@@ -16,7 +16,7 @@ class GraphQLClientHttpError(GraphQLClientError):
         return f"HTTP status code: {self.status_code}"
 
 
-class GraphQlClientInvalidResponseError(GraphQLClientError):
+class GraphQLClientInvalidResponseError(GraphQLClientError):
     def __init__(self, response: httpx.Response) -> None:
         self.response = response
 


### PR DESCRIPTION
This pr renames `GraphQlClientInvalidResponseError` to `GraphQLClientInvalidResponseError` (with capitalized `L`, as rest of exceptions in [`exceptions.py`](https://github.com/mirumee/ariadne-codegen/blob/main/ariadne_codegen/client_generators/dependencies/exceptions.py))

resolve #238 