### PR TITLE
Raise GraphQLClientGraphQLMultiError instead of GraphQLClientInvalidResponseError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added `operationName` to payload sent by generated client's methods.
 - Fixed base clients to pass `mypy --strict` without installed optional dependencies.
 - Renamed `GraphQlClientInvalidResponseError` to `GraphQLClientInvalidResponseError` (breaking change).
+- Changed base clients to raise `GraphQLClientGraphQLMultiError` for payloads with `errors` key but no `data` (breaking change).
 
 
 ## 0.10.0 (2023-11-15)

--- a/ariadne_codegen/client_generators/dependencies/async_base_client.py
+++ b/ariadne_codegen/client_generators/dependencies/async_base_client.py
@@ -127,10 +127,12 @@ class AsyncBaseClient:
         except ValueError as exc:
             raise GraphQLClientInvalidResponseError(response=response) from exc
 
-        if (not isinstance(response_json, dict)) or ("data" not in response_json):
+        if (not isinstance(response_json, dict)) or (
+            "data" not in response_json and "errors" not in response_json
+        ):
             raise GraphQLClientInvalidResponseError(response=response)
 
-        data = response_json["data"]
+        data = response_json.get("data")
         errors = response_json.get("errors")
 
         if errors:

--- a/ariadne_codegen/client_generators/dependencies/async_base_client_open_telemetry.py
+++ b/ariadne_codegen/client_generators/dependencies/async_base_client_open_telemetry.py
@@ -166,10 +166,12 @@ class AsyncBaseClientOpenTelemetry:
         except ValueError as exc:
             raise GraphQLClientInvalidResponseError(response=response) from exc
 
-        if (not isinstance(response_json, dict)) or ("data" not in response_json):
+        if (not isinstance(response_json, dict)) or (
+            "data" not in response_json and "errors" not in response_json
+        ):
             raise GraphQLClientInvalidResponseError(response=response)
 
-        data = response_json["data"]
+        data = response_json.get("data")
         errors = response_json.get("errors")
 
         if errors:

--- a/ariadne_codegen/client_generators/dependencies/base_client.py
+++ b/ariadne_codegen/client_generators/dependencies/base_client.py
@@ -64,7 +64,7 @@ class BaseClient:
             **kwargs,
         )
 
-    def get_data(self, response: httpx.Response) -> dict[str, Any]:
+    def get_data(self, response: httpx.Response) -> Dict[str, Any]:
         if not response.is_success:
             raise GraphQLClientHttpError(
                 status_code=response.status_code, response=response
@@ -75,10 +75,12 @@ class BaseClient:
         except ValueError as exc:
             raise GraphQLClientInvalidResponseError(response=response) from exc
 
-        if (not isinstance(response_json, dict)) or ("data" not in response_json):
+        if (not isinstance(response_json, dict)) or (
+            "data" not in response_json and "errors" not in response_json
+        ):
             raise GraphQLClientInvalidResponseError(response=response)
 
-        data = response_json["data"]
+        data = response_json.get("data")
         errors = response_json.get("errors")
 
         if errors:
@@ -86,7 +88,7 @@ class BaseClient:
                 errors_dicts=errors, data=data
             )
 
-        return cast(dict[str, Any], data)
+        return cast(Dict[str, Any], data)
 
     def _process_variables(
         self, variables: Optional[Dict[str, Any]]

--- a/ariadne_codegen/client_generators/dependencies/base_client_open_telemetry.py
+++ b/ariadne_codegen/client_generators/dependencies/base_client_open_telemetry.py
@@ -87,7 +87,7 @@ class BaseClientOpenTelemetry:
             query=query, operation_name=operation_name, variables=variables, **kwargs
         )
 
-    def get_data(self, response: httpx.Response) -> dict[str, Any]:
+    def get_data(self, response: httpx.Response) -> Dict[str, Any]:
         if not response.is_success:
             raise GraphQLClientHttpError(
                 status_code=response.status_code, response=response
@@ -98,10 +98,12 @@ class BaseClientOpenTelemetry:
         except ValueError as exc:
             raise GraphQLClientInvalidResponseError(response=response) from exc
 
-        if (not isinstance(response_json, dict)) or ("data" not in response_json):
+        if (not isinstance(response_json, dict)) or (
+            "data" not in response_json and "errors" not in response_json
+        ):
             raise GraphQLClientInvalidResponseError(response=response)
 
-        data = response_json["data"]
+        data = response_json.get("data")
         errors = response_json.get("errors")
 
         if errors:
@@ -109,7 +111,7 @@ class BaseClientOpenTelemetry:
                 errors_dicts=errors, data=data
             )
 
-        return cast(dict[str, Any], data)
+        return cast(Dict[str, Any], data)
 
     def _execute(
         self,

--- a/ariadne_codegen/client_generators/dependencies/exceptions.py
+++ b/ariadne_codegen/client_generators/dependencies/exceptions.py
@@ -54,7 +54,11 @@ class GraphQLClientGraphQLError(GraphQLClientError):
 
 
 class GraphQLClientGraphQLMultiError(GraphQLClientError):
-    def __init__(self, errors: List[GraphQLClientGraphQLError], data: Dict[str, Any]):
+    def __init__(
+        self,
+        errors: List[GraphQLClientGraphQLError],
+        data: Optional[Dict[str, Any]] = None,
+    ):
         self.errors = errors
         self.data = data
 
@@ -63,7 +67,7 @@ class GraphQLClientGraphQLMultiError(GraphQLClientError):
 
     @classmethod
     def from_errors_dicts(
-        cls, errors_dicts: List[Dict[str, Any]], data: Dict[str, Any]
+        cls, errors_dicts: List[Dict[str, Any]], data: Optional[Dict[str, Any]] = None
     ) -> "GraphQLClientGraphQLMultiError":
         return cls(
             errors=[GraphQLClientGraphQLError.from_dict(e) for e in errors_dicts],

--- a/tests/client_generators/dependencies/test_async_base_client.py
+++ b/tests/client_generators/dependencies/test_async_base_client.py
@@ -546,6 +546,11 @@ def test_get_data_raises_graphql_client_invalid_response_error(
                 },
             ],
         },
+        {
+            "errors": [
+                {"message": "Error message"},
+            ],
+        },
     ],
 )
 def test_get_data_raises_graphql_client_graphql_multi_error(mocker, response_content):

--- a/tests/client_generators/dependencies/test_async_base_client_open_telemetry.py
+++ b/tests/client_generators/dependencies/test_async_base_client_open_telemetry.py
@@ -563,6 +563,11 @@ def test_get_data_raises_graphql_client_invalid_response_error(
                 },
             ],
         },
+        {
+            "errors": [
+                {"message": "Error message"},
+            ],
+        },
     ],
 )
 def test_get_data_raises_graphql_client_graphql_multi_error(mocker, response_content):

--- a/tests/client_generators/dependencies/test_base_client.py
+++ b/tests/client_generators/dependencies/test_base_client.py
@@ -519,6 +519,11 @@ def test_get_data_raises_graphql_client_invalid_response_error(
                 },
             ],
         },
+        {
+            "errors": [
+                {"message": "Error message"},
+            ],
+        },
     ],
 )
 def test_get_data_raises_graphql_client_graphql_multi_error(mocker, response_content):

--- a/tests/client_generators/dependencies/test_base_client_open_telemetry.py
+++ b/tests/client_generators/dependencies/test_base_client_open_telemetry.py
@@ -532,6 +532,11 @@ def test_get_data_raises_graphql_client_invalid_response_error(
                 },
             ],
         },
+        {
+            "errors": [
+                {"message": "Error message"},
+            ],
+        },
     ],
 )
 def test_get_data_raises_graphql_client_graphql_multi_error(mocker, response_content):

--- a/tests/main/clients/custom_config_file/expected_client/async_base_client.py
+++ b/tests/main/clients/custom_config_file/expected_client/async_base_client.py
@@ -127,10 +127,12 @@ class AsyncBaseClient:
         except ValueError as exc:
             raise GraphQLClientInvalidResponseError(response=response) from exc
 
-        if (not isinstance(response_json, dict)) or ("data" not in response_json):
+        if (not isinstance(response_json, dict)) or (
+            "data" not in response_json and "errors" not in response_json
+        ):
             raise GraphQLClientInvalidResponseError(response=response)
 
-        data = response_json["data"]
+        data = response_json.get("data")
         errors = response_json.get("errors")
 
         if errors:

--- a/tests/main/clients/custom_config_file/expected_client/exceptions.py
+++ b/tests/main/clients/custom_config_file/expected_client/exceptions.py
@@ -54,7 +54,11 @@ class GraphQLClientGraphQLError(GraphQLClientError):
 
 
 class GraphQLClientGraphQLMultiError(GraphQLClientError):
-    def __init__(self, errors: List[GraphQLClientGraphQLError], data: Dict[str, Any]):
+    def __init__(
+        self,
+        errors: List[GraphQLClientGraphQLError],
+        data: Optional[Dict[str, Any]] = None,
+    ):
         self.errors = errors
         self.data = data
 
@@ -63,7 +67,7 @@ class GraphQLClientGraphQLMultiError(GraphQLClientError):
 
     @classmethod
     def from_errors_dicts(
-        cls, errors_dicts: List[Dict[str, Any]], data: Dict[str, Any]
+        cls, errors_dicts: List[Dict[str, Any]], data: Optional[Dict[str, Any]] = None
     ) -> "GraphQLClientGraphQLMultiError":
         return cls(
             errors=[GraphQLClientGraphQLError.from_dict(e) for e in errors_dicts],

--- a/tests/main/clients/custom_files_names/expected_client/async_base_client.py
+++ b/tests/main/clients/custom_files_names/expected_client/async_base_client.py
@@ -127,10 +127,12 @@ class AsyncBaseClient:
         except ValueError as exc:
             raise GraphQLClientInvalidResponseError(response=response) from exc
 
-        if (not isinstance(response_json, dict)) or ("data" not in response_json):
+        if (not isinstance(response_json, dict)) or (
+            "data" not in response_json and "errors" not in response_json
+        ):
             raise GraphQLClientInvalidResponseError(response=response)
 
-        data = response_json["data"]
+        data = response_json.get("data")
         errors = response_json.get("errors")
 
         if errors:

--- a/tests/main/clients/custom_files_names/expected_client/exceptions.py
+++ b/tests/main/clients/custom_files_names/expected_client/exceptions.py
@@ -54,7 +54,11 @@ class GraphQLClientGraphQLError(GraphQLClientError):
 
 
 class GraphQLClientGraphQLMultiError(GraphQLClientError):
-    def __init__(self, errors: List[GraphQLClientGraphQLError], data: Dict[str, Any]):
+    def __init__(
+        self,
+        errors: List[GraphQLClientGraphQLError],
+        data: Optional[Dict[str, Any]] = None,
+    ):
         self.errors = errors
         self.data = data
 
@@ -63,7 +67,7 @@ class GraphQLClientGraphQLMultiError(GraphQLClientError):
 
     @classmethod
     def from_errors_dicts(
-        cls, errors_dicts: List[Dict[str, Any]], data: Dict[str, Any]
+        cls, errors_dicts: List[Dict[str, Any]], data: Optional[Dict[str, Any]] = None
     ) -> "GraphQLClientGraphQLMultiError":
         return cls(
             errors=[GraphQLClientGraphQLError.from_dict(e) for e in errors_dicts],

--- a/tests/main/clients/custom_scalars/expected_client/async_base_client.py
+++ b/tests/main/clients/custom_scalars/expected_client/async_base_client.py
@@ -127,10 +127,12 @@ class AsyncBaseClient:
         except ValueError as exc:
             raise GraphQLClientInvalidResponseError(response=response) from exc
 
-        if (not isinstance(response_json, dict)) or ("data" not in response_json):
+        if (not isinstance(response_json, dict)) or (
+            "data" not in response_json and "errors" not in response_json
+        ):
             raise GraphQLClientInvalidResponseError(response=response)
 
-        data = response_json["data"]
+        data = response_json.get("data")
         errors = response_json.get("errors")
 
         if errors:

--- a/tests/main/clients/custom_scalars/expected_client/exceptions.py
+++ b/tests/main/clients/custom_scalars/expected_client/exceptions.py
@@ -54,7 +54,11 @@ class GraphQLClientGraphQLError(GraphQLClientError):
 
 
 class GraphQLClientGraphQLMultiError(GraphQLClientError):
-    def __init__(self, errors: List[GraphQLClientGraphQLError], data: Dict[str, Any]):
+    def __init__(
+        self,
+        errors: List[GraphQLClientGraphQLError],
+        data: Optional[Dict[str, Any]] = None,
+    ):
         self.errors = errors
         self.data = data
 
@@ -63,7 +67,7 @@ class GraphQLClientGraphQLMultiError(GraphQLClientError):
 
     @classmethod
     def from_errors_dicts(
-        cls, errors_dicts: List[Dict[str, Any]], data: Dict[str, Any]
+        cls, errors_dicts: List[Dict[str, Any]], data: Optional[Dict[str, Any]] = None
     ) -> "GraphQLClientGraphQLMultiError":
         return cls(
             errors=[GraphQLClientGraphQLError.from_dict(e) for e in errors_dicts],

--- a/tests/main/clients/example/expected_client/async_base_client.py
+++ b/tests/main/clients/example/expected_client/async_base_client.py
@@ -127,10 +127,12 @@ class AsyncBaseClient:
         except ValueError as exc:
             raise GraphQLClientInvalidResponseError(response=response) from exc
 
-        if (not isinstance(response_json, dict)) or ("data" not in response_json):
+        if (not isinstance(response_json, dict)) or (
+            "data" not in response_json and "errors" not in response_json
+        ):
             raise GraphQLClientInvalidResponseError(response=response)
 
-        data = response_json["data"]
+        data = response_json.get("data")
         errors = response_json.get("errors")
 
         if errors:

--- a/tests/main/clients/example/expected_client/exceptions.py
+++ b/tests/main/clients/example/expected_client/exceptions.py
@@ -54,7 +54,11 @@ class GraphQLClientGraphQLError(GraphQLClientError):
 
 
 class GraphQLClientGraphQLMultiError(GraphQLClientError):
-    def __init__(self, errors: List[GraphQLClientGraphQLError], data: Dict[str, Any]):
+    def __init__(
+        self,
+        errors: List[GraphQLClientGraphQLError],
+        data: Optional[Dict[str, Any]] = None,
+    ):
         self.errors = errors
         self.data = data
 
@@ -63,7 +67,7 @@ class GraphQLClientGraphQLMultiError(GraphQLClientError):
 
     @classmethod
     def from_errors_dicts(
-        cls, errors_dicts: List[Dict[str, Any]], data: Dict[str, Any]
+        cls, errors_dicts: List[Dict[str, Any]], data: Optional[Dict[str, Any]] = None
     ) -> "GraphQLClientGraphQLMultiError":
         return cls(
             errors=[GraphQLClientGraphQLError.from_dict(e) for e in errors_dicts],

--- a/tests/main/clients/extended_models/expected_client/async_base_client.py
+++ b/tests/main/clients/extended_models/expected_client/async_base_client.py
@@ -127,10 +127,12 @@ class AsyncBaseClient:
         except ValueError as exc:
             raise GraphQLClientInvalidResponseError(response=response) from exc
 
-        if (not isinstance(response_json, dict)) or ("data" not in response_json):
+        if (not isinstance(response_json, dict)) or (
+            "data" not in response_json and "errors" not in response_json
+        ):
             raise GraphQLClientInvalidResponseError(response=response)
 
-        data = response_json["data"]
+        data = response_json.get("data")
         errors = response_json.get("errors")
 
         if errors:

--- a/tests/main/clients/extended_models/expected_client/exceptions.py
+++ b/tests/main/clients/extended_models/expected_client/exceptions.py
@@ -54,7 +54,11 @@ class GraphQLClientGraphQLError(GraphQLClientError):
 
 
 class GraphQLClientGraphQLMultiError(GraphQLClientError):
-    def __init__(self, errors: List[GraphQLClientGraphQLError], data: Dict[str, Any]):
+    def __init__(
+        self,
+        errors: List[GraphQLClientGraphQLError],
+        data: Optional[Dict[str, Any]] = None,
+    ):
         self.errors = errors
         self.data = data
 
@@ -63,7 +67,7 @@ class GraphQLClientGraphQLMultiError(GraphQLClientError):
 
     @classmethod
     def from_errors_dicts(
-        cls, errors_dicts: List[Dict[str, Any]], data: Dict[str, Any]
+        cls, errors_dicts: List[Dict[str, Any]], data: Optional[Dict[str, Any]] = None
     ) -> "GraphQLClientGraphQLMultiError":
         return cls(
             errors=[GraphQLClientGraphQLError.from_dict(e) for e in errors_dicts],

--- a/tests/main/clients/fragments_on_abstract_types/expected_client/async_base_client.py
+++ b/tests/main/clients/fragments_on_abstract_types/expected_client/async_base_client.py
@@ -127,10 +127,12 @@ class AsyncBaseClient:
         except ValueError as exc:
             raise GraphQLClientInvalidResponseError(response=response) from exc
 
-        if (not isinstance(response_json, dict)) or ("data" not in response_json):
+        if (not isinstance(response_json, dict)) or (
+            "data" not in response_json and "errors" not in response_json
+        ):
             raise GraphQLClientInvalidResponseError(response=response)
 
-        data = response_json["data"]
+        data = response_json.get("data")
         errors = response_json.get("errors")
 
         if errors:

--- a/tests/main/clients/fragments_on_abstract_types/expected_client/exceptions.py
+++ b/tests/main/clients/fragments_on_abstract_types/expected_client/exceptions.py
@@ -54,7 +54,11 @@ class GraphQLClientGraphQLError(GraphQLClientError):
 
 
 class GraphQLClientGraphQLMultiError(GraphQLClientError):
-    def __init__(self, errors: List[GraphQLClientGraphQLError], data: Dict[str, Any]):
+    def __init__(
+        self,
+        errors: List[GraphQLClientGraphQLError],
+        data: Optional[Dict[str, Any]] = None,
+    ):
         self.errors = errors
         self.data = data
 
@@ -63,7 +67,7 @@ class GraphQLClientGraphQLMultiError(GraphQLClientError):
 
     @classmethod
     def from_errors_dicts(
-        cls, errors_dicts: List[Dict[str, Any]], data: Dict[str, Any]
+        cls, errors_dicts: List[Dict[str, Any]], data: Optional[Dict[str, Any]] = None
     ) -> "GraphQLClientGraphQLMultiError":
         return cls(
             errors=[GraphQLClientGraphQLError.from_dict(e) for e in errors_dicts],

--- a/tests/main/clients/inline_fragments/expected_client/async_base_client.py
+++ b/tests/main/clients/inline_fragments/expected_client/async_base_client.py
@@ -127,10 +127,12 @@ class AsyncBaseClient:
         except ValueError as exc:
             raise GraphQLClientInvalidResponseError(response=response) from exc
 
-        if (not isinstance(response_json, dict)) or ("data" not in response_json):
+        if (not isinstance(response_json, dict)) or (
+            "data" not in response_json and "errors" not in response_json
+        ):
             raise GraphQLClientInvalidResponseError(response=response)
 
-        data = response_json["data"]
+        data = response_json.get("data")
         errors = response_json.get("errors")
 
         if errors:

--- a/tests/main/clients/inline_fragments/expected_client/exceptions.py
+++ b/tests/main/clients/inline_fragments/expected_client/exceptions.py
@@ -54,7 +54,11 @@ class GraphQLClientGraphQLError(GraphQLClientError):
 
 
 class GraphQLClientGraphQLMultiError(GraphQLClientError):
-    def __init__(self, errors: List[GraphQLClientGraphQLError], data: Dict[str, Any]):
+    def __init__(
+        self,
+        errors: List[GraphQLClientGraphQLError],
+        data: Optional[Dict[str, Any]] = None,
+    ):
         self.errors = errors
         self.data = data
 
@@ -63,7 +67,7 @@ class GraphQLClientGraphQLMultiError(GraphQLClientError):
 
     @classmethod
     def from_errors_dicts(
-        cls, errors_dicts: List[Dict[str, Any]], data: Dict[str, Any]
+        cls, errors_dicts: List[Dict[str, Any]], data: Optional[Dict[str, Any]] = None
     ) -> "GraphQLClientGraphQLMultiError":
         return cls(
             errors=[GraphQLClientGraphQLError.from_dict(e) for e in errors_dicts],

--- a/tests/main/clients/multiple_fragments/expected_client/async_base_client.py
+++ b/tests/main/clients/multiple_fragments/expected_client/async_base_client.py
@@ -127,10 +127,12 @@ class AsyncBaseClient:
         except ValueError as exc:
             raise GraphQLClientInvalidResponseError(response=response) from exc
 
-        if (not isinstance(response_json, dict)) or ("data" not in response_json):
+        if (not isinstance(response_json, dict)) or (
+            "data" not in response_json and "errors" not in response_json
+        ):
             raise GraphQLClientInvalidResponseError(response=response)
 
-        data = response_json["data"]
+        data = response_json.get("data")
         errors = response_json.get("errors")
 
         if errors:

--- a/tests/main/clients/multiple_fragments/expected_client/exceptions.py
+++ b/tests/main/clients/multiple_fragments/expected_client/exceptions.py
@@ -54,7 +54,11 @@ class GraphQLClientGraphQLError(GraphQLClientError):
 
 
 class GraphQLClientGraphQLMultiError(GraphQLClientError):
-    def __init__(self, errors: List[GraphQLClientGraphQLError], data: Dict[str, Any]):
+    def __init__(
+        self,
+        errors: List[GraphQLClientGraphQLError],
+        data: Optional[Dict[str, Any]] = None,
+    ):
         self.errors = errors
         self.data = data
 
@@ -63,7 +67,7 @@ class GraphQLClientGraphQLMultiError(GraphQLClientError):
 
     @classmethod
     def from_errors_dicts(
-        cls, errors_dicts: List[Dict[str, Any]], data: Dict[str, Any]
+        cls, errors_dicts: List[Dict[str, Any]], data: Optional[Dict[str, Any]] = None
     ) -> "GraphQLClientGraphQLMultiError":
         return cls(
             errors=[GraphQLClientGraphQLError.from_dict(e) for e in errors_dicts],

--- a/tests/main/clients/only_used_inputs_and_enums/expected_client/async_base_client.py
+++ b/tests/main/clients/only_used_inputs_and_enums/expected_client/async_base_client.py
@@ -127,10 +127,12 @@ class AsyncBaseClient:
         except ValueError as exc:
             raise GraphQLClientInvalidResponseError(response=response) from exc
 
-        if (not isinstance(response_json, dict)) or ("data" not in response_json):
+        if (not isinstance(response_json, dict)) or (
+            "data" not in response_json and "errors" not in response_json
+        ):
             raise GraphQLClientInvalidResponseError(response=response)
 
-        data = response_json["data"]
+        data = response_json.get("data")
         errors = response_json.get("errors")
 
         if errors:

--- a/tests/main/clients/only_used_inputs_and_enums/expected_client/exceptions.py
+++ b/tests/main/clients/only_used_inputs_and_enums/expected_client/exceptions.py
@@ -54,7 +54,11 @@ class GraphQLClientGraphQLError(GraphQLClientError):
 
 
 class GraphQLClientGraphQLMultiError(GraphQLClientError):
-    def __init__(self, errors: List[GraphQLClientGraphQLError], data: Dict[str, Any]):
+    def __init__(
+        self,
+        errors: List[GraphQLClientGraphQLError],
+        data: Optional[Dict[str, Any]] = None,
+    ):
         self.errors = errors
         self.data = data
 
@@ -63,7 +67,7 @@ class GraphQLClientGraphQLMultiError(GraphQLClientError):
 
     @classmethod
     def from_errors_dicts(
-        cls, errors_dicts: List[Dict[str, Any]], data: Dict[str, Any]
+        cls, errors_dicts: List[Dict[str, Any]], data: Optional[Dict[str, Any]] = None
     ) -> "GraphQLClientGraphQLMultiError":
         return cls(
             errors=[GraphQLClientGraphQLError.from_dict(e) for e in errors_dicts],

--- a/tests/main/clients/operations/expected_client/async_base_client.py
+++ b/tests/main/clients/operations/expected_client/async_base_client.py
@@ -127,10 +127,12 @@ class AsyncBaseClient:
         except ValueError as exc:
             raise GraphQLClientInvalidResponseError(response=response) from exc
 
-        if (not isinstance(response_json, dict)) or ("data" not in response_json):
+        if (not isinstance(response_json, dict)) or (
+            "data" not in response_json and "errors" not in response_json
+        ):
             raise GraphQLClientInvalidResponseError(response=response)
 
-        data = response_json["data"]
+        data = response_json.get("data")
         errors = response_json.get("errors")
 
         if errors:

--- a/tests/main/clients/operations/expected_client/exceptions.py
+++ b/tests/main/clients/operations/expected_client/exceptions.py
@@ -54,7 +54,11 @@ class GraphQLClientGraphQLError(GraphQLClientError):
 
 
 class GraphQLClientGraphQLMultiError(GraphQLClientError):
-    def __init__(self, errors: List[GraphQLClientGraphQLError], data: Dict[str, Any]):
+    def __init__(
+        self,
+        errors: List[GraphQLClientGraphQLError],
+        data: Optional[Dict[str, Any]] = None,
+    ):
         self.errors = errors
         self.data = data
 
@@ -63,7 +67,7 @@ class GraphQLClientGraphQLMultiError(GraphQLClientError):
 
     @classmethod
     def from_errors_dicts(
-        cls, errors_dicts: List[Dict[str, Any]], data: Dict[str, Any]
+        cls, errors_dicts: List[Dict[str, Any]], data: Optional[Dict[str, Any]] = None
     ) -> "GraphQLClientGraphQLMultiError":
         return cls(
             errors=[GraphQLClientGraphQLError.from_dict(e) for e in errors_dicts],

--- a/tests/main/clients/remote_schema/expected_client/async_base_client.py
+++ b/tests/main/clients/remote_schema/expected_client/async_base_client.py
@@ -127,10 +127,12 @@ class AsyncBaseClient:
         except ValueError as exc:
             raise GraphQLClientInvalidResponseError(response=response) from exc
 
-        if (not isinstance(response_json, dict)) or ("data" not in response_json):
+        if (not isinstance(response_json, dict)) or (
+            "data" not in response_json and "errors" not in response_json
+        ):
             raise GraphQLClientInvalidResponseError(response=response)
 
-        data = response_json["data"]
+        data = response_json.get("data")
         errors = response_json.get("errors")
 
         if errors:

--- a/tests/main/clients/remote_schema/expected_client/exceptions.py
+++ b/tests/main/clients/remote_schema/expected_client/exceptions.py
@@ -54,7 +54,11 @@ class GraphQLClientGraphQLError(GraphQLClientError):
 
 
 class GraphQLClientGraphQLMultiError(GraphQLClientError):
-    def __init__(self, errors: List[GraphQLClientGraphQLError], data: Dict[str, Any]):
+    def __init__(
+        self,
+        errors: List[GraphQLClientGraphQLError],
+        data: Optional[Dict[str, Any]] = None,
+    ):
         self.errors = errors
         self.data = data
 
@@ -63,7 +67,7 @@ class GraphQLClientGraphQLMultiError(GraphQLClientError):
 
     @classmethod
     def from_errors_dicts(
-        cls, errors_dicts: List[Dict[str, Any]], data: Dict[str, Any]
+        cls, errors_dicts: List[Dict[str, Any]], data: Optional[Dict[str, Any]] = None
     ) -> "GraphQLClientGraphQLMultiError":
         return cls(
             errors=[GraphQLClientGraphQLError.from_dict(e) for e in errors_dicts],

--- a/tests/main/clients/shorter_results/expected_client/async_base_client.py
+++ b/tests/main/clients/shorter_results/expected_client/async_base_client.py
@@ -127,10 +127,12 @@ class AsyncBaseClient:
         except ValueError as exc:
             raise GraphQLClientInvalidResponseError(response=response) from exc
 
-        if (not isinstance(response_json, dict)) or ("data" not in response_json):
+        if (not isinstance(response_json, dict)) or (
+            "data" not in response_json and "errors" not in response_json
+        ):
             raise GraphQLClientInvalidResponseError(response=response)
 
-        data = response_json["data"]
+        data = response_json.get("data")
         errors = response_json.get("errors")
 
         if errors:

--- a/tests/main/clients/shorter_results/expected_client/exceptions.py
+++ b/tests/main/clients/shorter_results/expected_client/exceptions.py
@@ -54,7 +54,11 @@ class GraphQLClientGraphQLError(GraphQLClientError):
 
 
 class GraphQLClientGraphQLMultiError(GraphQLClientError):
-    def __init__(self, errors: List[GraphQLClientGraphQLError], data: Dict[str, Any]):
+    def __init__(
+        self,
+        errors: List[GraphQLClientGraphQLError],
+        data: Optional[Dict[str, Any]] = None,
+    ):
         self.errors = errors
         self.data = data
 
@@ -63,7 +67,7 @@ class GraphQLClientGraphQLMultiError(GraphQLClientError):
 
     @classmethod
     def from_errors_dicts(
-        cls, errors_dicts: List[Dict[str, Any]], data: Dict[str, Any]
+        cls, errors_dicts: List[Dict[str, Any]], data: Optional[Dict[str, Any]] = None
     ) -> "GraphQLClientGraphQLMultiError":
         return cls(
             errors=[GraphQLClientGraphQLError.from_dict(e) for e in errors_dicts],


### PR DESCRIPTION
This pr changes base clients to raise `GraphQLClientGraphQLMultiError` instead of `GraphQLClientInvalidResponseError` for payloads with `errors` key but without `data`.

resolves #240 