### PR TITLE
Handle connection_ack message for subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## UNRELEASED
+
+- Improved `graphql-transport-ws` protocol compliance for `connection_ack` messages
+
+
 ## 0.11.0 (2023-12-05)
 
 - Removed `model_rebuild` calls for generated input, fragment and result models. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # CHANGELOG
 
-## UNRELEASED
+## 0.12.0 (UNRELEASED)
 
-- Improved `graphql-transport-ws` protocol compliance for `connection_ack` messages
+- Fixed `graphql-transport-ws` protocol implementation not waiting for the `connection_ack` message on new connection.
 
 
 ## 0.11.0 (2023-12-05)

--- a/ariadne_codegen/client_generators/dependencies/async_base_client.py
+++ b/ariadne_codegen/client_generators/dependencies/async_base_client.py
@@ -333,7 +333,7 @@ class AsyncBaseClient:
         self,
         message: Data,
         websocket: WebSocketClientProtocol,
-        expected_type: GraphQLTransportWSMessageType | None = None,
+        expected_type: Optional[GraphQLTransportWSMessageType] = None,
     ) -> Optional[Dict[str, Any]]:
         try:
             message_dict = json.loads(message)

--- a/ariadne_codegen/client_generators/dependencies/async_base_client.py
+++ b/ariadne_codegen/client_generators/dependencies/async_base_client.py
@@ -348,7 +348,7 @@ class AsyncBaseClient:
 
         if expected_type and expected_type != type_:
             raise GraphQLClientInvalidMessageFormat(
-                f"Invalid message type - expected {expected_type.value}"
+                f"Invalid message received. Expected: {expected_type.value}"
             )
 
         if type_ == GraphQLTransportWSMessageType.NEXT:

--- a/ariadne_codegen/client_generators/dependencies/async_base_client_open_telemetry.py
+++ b/ariadne_codegen/client_generators/dependencies/async_base_client_open_telemetry.py
@@ -438,7 +438,7 @@ class AsyncBaseClientOpenTelemetry:
 
         if expected_type and expected_type != type_:
             raise GraphQLClientInvalidMessageFormat(
-                f"Invalid message type - expected {expected_type.value}"
+                f"Invalid message received. Expected: {expected_type.value}"
             )
 
         if type_ == GraphQLTransportWSMessageType.NEXT:
@@ -677,7 +677,7 @@ class AsyncBaseClientOpenTelemetry:
 
             if expected_type and expected_type != type_:
                 raise GraphQLClientInvalidMessageFormat(
-                    f"Invalid message type - expected {expected_type.value}"
+                    f"Invalid message received. Expected: {expected_type.value}"
                 )
 
             if type_ == GraphQLTransportWSMessageType.NEXT:

--- a/ariadne_codegen/client_generators/dependencies/async_base_client_open_telemetry.py
+++ b/ariadne_codegen/client_generators/dependencies/async_base_client_open_telemetry.py
@@ -639,7 +639,7 @@ class AsyncBaseClientOpenTelemetry:
         root_span: Span,
         message: Data,
         websocket: WebSocketClientProtocol,
-        expected_type: GraphQLTransportWSMessageType | None = None,
+        expected_type: Optional[GraphQLTransportWSMessageType] = None,
     ) -> Optional[Dict[str, Any]]:
         with self.tracer.start_as_current_span(  # type: ignore
             "received message", context=set_span_in_context(root_span)

--- a/tests/client_generators/dependencies/test_websockets.py
+++ b/tests/client_generators/dependencies/test_websockets.py
@@ -24,12 +24,13 @@ def mocked_websocket(mocked_ws_connect):
     websocket.__aiter__.return_value = [
         json.dumps({"type": "connection_ack"}),
     ]
+    websocket.recv.return_value = json.dumps({"type": "connection_ack"})
     return websocket
 
 
 @pytest.mark.asyncio
 async def test_execute_ws_creates_websocket_connection_with_correct_url(
-    mocked_ws_connect,
+    mocked_ws_connect, mocked_websocket  # pylint: disable=unused-argument
 ):
     async for _ in AsyncBaseClient(ws_url="ws://test_url").execute_ws(""):
         pass
@@ -40,7 +41,7 @@ async def test_execute_ws_creates_websocket_connection_with_correct_url(
 
 @pytest.mark.asyncio
 async def test_execute_ws_creates_websocket_connection_with_correct_subprotocol(
-    mocked_ws_connect,
+    mocked_ws_connect, mocked_websocket  # pylint: disable=unused-argument
 ):
     async for _ in AsyncBaseClient().execute_ws(""):
         pass
@@ -53,7 +54,7 @@ async def test_execute_ws_creates_websocket_connection_with_correct_subprotocol(
 
 @pytest.mark.asyncio
 async def test_execute_ws_creates_websocket_connection_with_correct_origin(
-    mocked_ws_connect,
+    mocked_ws_connect, mocked_websocket  # pylint: disable=unused-argument
 ):
     async for _ in AsyncBaseClient(ws_origin="test_origin").execute_ws(""):
         pass
@@ -64,7 +65,7 @@ async def test_execute_ws_creates_websocket_connection_with_correct_origin(
 
 @pytest.mark.asyncio
 async def test_execute_ws_creates_websocket_connection_with_correct_headers(
-    mocked_ws_connect,
+    mocked_ws_connect, mocked_websocket  # pylint: disable=unused-argument
 ):
     async for _ in AsyncBaseClient(ws_headers={"test_key": "test_value"}).execute_ws(
         ""
@@ -79,7 +80,7 @@ async def test_execute_ws_creates_websocket_connection_with_correct_headers(
 
 @pytest.mark.asyncio
 async def test_execute_ws_creates_websocket_connection_with_passed_extra_headers(
-    mocked_ws_connect,
+    mocked_ws_connect, mocked_websocket  # pylint: disable=unused-argument
 ):
     async for _ in AsyncBaseClient(
         ws_headers={"Client-A": "client_value_a", "Client-B": "client_value_b"}
@@ -98,7 +99,7 @@ async def test_execute_ws_creates_websocket_connection_with_passed_extra_headers
 
 @pytest.mark.asyncio
 async def test_execute_ws_creates_websocket_connection_with_passed_kwargs(
-    mocked_ws_connect,
+    mocked_ws_connect, mocked_websocket  # pylint: disable=unused-argument
 ):
     async for _ in AsyncBaseClient().execute_ws("", open_timeout=15, close_timeout=30):
         pass

--- a/tests/client_generators/dependencies/test_websockets_open_telemetry.py
+++ b/tests/client_generators/dependencies/test_websockets_open_telemetry.py
@@ -38,7 +38,7 @@ def mocked_faulty_websocket(mocked_ws_connect):
 
 @pytest.mark.asyncio
 async def test_execute_ws_creates_websocket_connection_with_correct_url(
-    mocked_ws_connect,
+    mocked_ws_connect, mocked_websocket
 ):
     async for _ in AsyncBaseClientOpenTelemetry(ws_url="ws://test_url").execute_ws(""):
         pass
@@ -49,7 +49,7 @@ async def test_execute_ws_creates_websocket_connection_with_correct_url(
 
 @pytest.mark.asyncio
 async def test_execute_ws_creates_websocket_connection_with_correct_subprotocol(
-    mocked_ws_connect,
+    mocked_ws_connect, mocked_websocket
 ):
     async for _ in AsyncBaseClientOpenTelemetry().execute_ws(""):
         pass
@@ -62,7 +62,7 @@ async def test_execute_ws_creates_websocket_connection_with_correct_subprotocol(
 
 @pytest.mark.asyncio
 async def test_execute_ws_creates_websocket_connection_with_correct_origin(
-    mocked_ws_connect,
+    mocked_ws_connect, mocked_websocket
 ):
     async for _ in AsyncBaseClientOpenTelemetry(ws_origin="test_origin").execute_ws(""):
         pass
@@ -73,7 +73,7 @@ async def test_execute_ws_creates_websocket_connection_with_correct_origin(
 
 @pytest.mark.asyncio
 async def test_execute_ws_creates_websocket_connection_with_correct_headers(
-    mocked_ws_connect,
+    mocked_ws_connect, mocked_websocket
 ):
     async for _ in AsyncBaseClientOpenTelemetry(
         ws_headers={"test_key": "test_value"}

--- a/tests/client_generators/dependencies/test_websockets_open_telemetry.py
+++ b/tests/client_generators/dependencies/test_websockets_open_telemetry.py
@@ -38,7 +38,7 @@ def mocked_faulty_websocket(mocked_ws_connect):
 
 @pytest.mark.asyncio
 async def test_execute_ws_creates_websocket_connection_with_correct_url(
-    mocked_ws_connect, mocked_websocket
+    mocked_ws_connect, mocked_websocket  # pylint: disable=unused-argument
 ):
     async for _ in AsyncBaseClientOpenTelemetry(ws_url="ws://test_url").execute_ws(""):
         pass
@@ -49,7 +49,7 @@ async def test_execute_ws_creates_websocket_connection_with_correct_url(
 
 @pytest.mark.asyncio
 async def test_execute_ws_creates_websocket_connection_with_correct_subprotocol(
-    mocked_ws_connect, mocked_websocket
+    mocked_ws_connect, mocked_websocket  # pylint: disable=unused-argument
 ):
     async for _ in AsyncBaseClientOpenTelemetry().execute_ws(""):
         pass
@@ -62,7 +62,7 @@ async def test_execute_ws_creates_websocket_connection_with_correct_subprotocol(
 
 @pytest.mark.asyncio
 async def test_execute_ws_creates_websocket_connection_with_correct_origin(
-    mocked_ws_connect, mocked_websocket
+    mocked_ws_connect, mocked_websocket  # pylint: disable=unused-argument
 ):
     async for _ in AsyncBaseClientOpenTelemetry(ws_origin="test_origin").execute_ws(""):
         pass
@@ -73,7 +73,7 @@ async def test_execute_ws_creates_websocket_connection_with_correct_origin(
 
 @pytest.mark.asyncio
 async def test_execute_ws_creates_websocket_connection_with_correct_headers(
-    mocked_ws_connect, mocked_websocket
+    mocked_ws_connect, mocked_websocket  # pylint: disable=unused-argument
 ):
     async for _ in AsyncBaseClientOpenTelemetry(
         ws_headers={"test_key": "test_value"}

--- a/tests/client_generators/dependencies/test_websockets_open_telemetry.py
+++ b/tests/client_generators/dependencies/test_websockets_open_telemetry.py
@@ -26,6 +26,7 @@ def mocked_websocket(mocked_ws_connect):
     websocket.__aiter__.return_value = [
         json.dumps({"type": "connection_ack"}),
     ]
+    websocket.recv.return_value = json.dumps({"type": "connection_ack"})
     return websocket
 
 
@@ -82,7 +83,7 @@ async def test_execute_ws_creates_websocket_connection_with_correct_headers(
 @pytest.mark.asyncio
 @pytest.mark.parametrize("tracer", ["tracer name", None])
 async def test_execute_ws_creates_websocket_connection_with_passed_extra_headers(
-    mocked_ws_connect, tracer
+    mocked_ws_connect, mocked_websocket, tracer  # pylint: disable=unused-argument
 ):
     async for _ in AsyncBaseClientOpenTelemetry(
         ws_headers={"Client-A": "client_value_a", "Client-B": "client_value_b"},
@@ -103,7 +104,7 @@ async def test_execute_ws_creates_websocket_connection_with_passed_extra_headers
 @pytest.mark.asyncio
 @pytest.mark.parametrize("tracer", ["tracer name", None])
 async def test_execute_ws_creates_websocket_connection_with_passed_kwargs(
-    mocked_ws_connect, tracer
+    mocked_ws_connect, mocked_websocket, tracer  # pylint: disable=unused-argument
 ):
     async for _ in AsyncBaseClientOpenTelemetry(tracer=tracer).execute_ws(
         "", open_timeout=15, close_timeout=30

--- a/tests/client_generators/dependencies/test_websockets_open_telemetry.py
+++ b/tests/client_generators/dependencies/test_websockets_open_telemetry.py
@@ -30,6 +30,12 @@ def mocked_websocket(mocked_ws_connect):
     return websocket
 
 
+@pytest.fixture
+def mocked_faulty_websocket(mocked_ws_connect):
+    websocket = mocked_ws_connect.return_value.__aenter__.return_value
+    return websocket
+
+
 @pytest.mark.asyncio
 async def test_execute_ws_creates_websocket_connection_with_correct_url(
     mocked_ws_connect,
@@ -260,6 +266,19 @@ async def test_execute_ws_raises_graphql_multi_error_for_message_with_error_type
             pass
 
 
+@pytest.mark.asyncio
+async def test_execute_ws_raises_invalid_message_format_for_missing_ack_after_init(
+    mocked_faulty_websocket,
+):
+    mocked_faulty_websocket.recv.return_value = json.dumps(
+        {"type": "next", "payload": {"data": "test_data"}}
+    )
+
+    with pytest.raises(GraphQLClientInvalidMessageFormat):
+        async for _ in AsyncBaseClientOpenTelemetry().execute_ws(""):
+            pass
+
+
 @pytest.fixture
 def mocked_start_as_current_span(mocker):
     mocker_get_tracer = mocker.patch(
@@ -395,3 +414,22 @@ async def test_execute_ws_creates_span_for_received_error_message(
     mocked_start_as_current_span.assert_any_call("received message", context=ANY)
     with mocked_start_as_current_span.return_value as span:
         span.set_attribute.assert_any_call("type", "error")
+
+
+@pytest.mark.asyncio
+async def test_execute_ws_ws_creates_span_for_missing_ack_after_init(
+    mocked_faulty_websocket, mocked_start_as_current_span
+):
+    mocked_faulty_websocket.recv.return_value = json.dumps(
+        {"type": "next", "payload": {"data": "test_data"}}
+    )
+
+    client = AsyncBaseClientOpenTelemetry(ws_url="ws://test_url", tracer="tracker")
+
+    with pytest.raises(GraphQLClientInvalidMessageFormat):
+        async for _ in client.execute_ws(""):
+            pass
+
+    mocked_start_as_current_span.assert_any_call("received message", context=ANY)
+    with mocked_start_as_current_span.return_value as span:
+        span.set_attribute.assert_any_call("type", "next")

--- a/tests/main/clients/custom_config_file/expected_client/async_base_client.py
+++ b/tests/main/clients/custom_config_file/expected_client/async_base_client.py
@@ -333,7 +333,7 @@ class AsyncBaseClient:
         self,
         message: Data,
         websocket: WebSocketClientProtocol,
-        expected_type: GraphQLTransportWSMessageType | None = None,
+        expected_type: Optional[GraphQLTransportWSMessageType] = None,
     ) -> Optional[Dict[str, Any]]:
         try:
             message_dict = json.loads(message)

--- a/tests/main/clients/custom_config_file/expected_client/async_base_client.py
+++ b/tests/main/clients/custom_config_file/expected_client/async_base_client.py
@@ -348,7 +348,7 @@ class AsyncBaseClient:
 
         if expected_type and expected_type != type_:
             raise GraphQLClientInvalidMessageFormat(
-                f"Invalid message type - expected {expected_type.value}"
+                f"Invalid message received. Expected: {expected_type.value}"
             )
 
         if type_ == GraphQLTransportWSMessageType.NEXT:

--- a/tests/main/clients/custom_files_names/expected_client/async_base_client.py
+++ b/tests/main/clients/custom_files_names/expected_client/async_base_client.py
@@ -333,7 +333,7 @@ class AsyncBaseClient:
         self,
         message: Data,
         websocket: WebSocketClientProtocol,
-        expected_type: GraphQLTransportWSMessageType | None = None,
+        expected_type: Optional[GraphQLTransportWSMessageType] = None,
     ) -> Optional[Dict[str, Any]]:
         try:
             message_dict = json.loads(message)

--- a/tests/main/clients/custom_files_names/expected_client/async_base_client.py
+++ b/tests/main/clients/custom_files_names/expected_client/async_base_client.py
@@ -348,7 +348,7 @@ class AsyncBaseClient:
 
         if expected_type and expected_type != type_:
             raise GraphQLClientInvalidMessageFormat(
-                f"Invalid message type - expected {expected_type.value}"
+                f"Invalid message received. Expected: {expected_type.value}"
             )
 
         if type_ == GraphQLTransportWSMessageType.NEXT:

--- a/tests/main/clients/custom_scalars/expected_client/async_base_client.py
+++ b/tests/main/clients/custom_scalars/expected_client/async_base_client.py
@@ -333,7 +333,7 @@ class AsyncBaseClient:
         self,
         message: Data,
         websocket: WebSocketClientProtocol,
-        expected_type: GraphQLTransportWSMessageType | None = None,
+        expected_type: Optional[GraphQLTransportWSMessageType] = None,
     ) -> Optional[Dict[str, Any]]:
         try:
             message_dict = json.loads(message)

--- a/tests/main/clients/custom_scalars/expected_client/async_base_client.py
+++ b/tests/main/clients/custom_scalars/expected_client/async_base_client.py
@@ -348,7 +348,7 @@ class AsyncBaseClient:
 
         if expected_type and expected_type != type_:
             raise GraphQLClientInvalidMessageFormat(
-                f"Invalid message type - expected {expected_type.value}"
+                f"Invalid message received. Expected: {expected_type.value}"
             )
 
         if type_ == GraphQLTransportWSMessageType.NEXT:

--- a/tests/main/clients/example/expected_client/async_base_client.py
+++ b/tests/main/clients/example/expected_client/async_base_client.py
@@ -333,7 +333,7 @@ class AsyncBaseClient:
         self,
         message: Data,
         websocket: WebSocketClientProtocol,
-        expected_type: GraphQLTransportWSMessageType | None = None,
+        expected_type: Optional[GraphQLTransportWSMessageType] = None,
     ) -> Optional[Dict[str, Any]]:
         try:
             message_dict = json.loads(message)

--- a/tests/main/clients/example/expected_client/async_base_client.py
+++ b/tests/main/clients/example/expected_client/async_base_client.py
@@ -348,7 +348,7 @@ class AsyncBaseClient:
 
         if expected_type and expected_type != type_:
             raise GraphQLClientInvalidMessageFormat(
-                f"Invalid message type - expected {expected_type.value}"
+                f"Invalid message received. Expected: {expected_type.value}"
             )
 
         if type_ == GraphQLTransportWSMessageType.NEXT:

--- a/tests/main/clients/extended_models/expected_client/async_base_client.py
+++ b/tests/main/clients/extended_models/expected_client/async_base_client.py
@@ -333,7 +333,7 @@ class AsyncBaseClient:
         self,
         message: Data,
         websocket: WebSocketClientProtocol,
-        expected_type: GraphQLTransportWSMessageType | None = None,
+        expected_type: Optional[GraphQLTransportWSMessageType] = None,
     ) -> Optional[Dict[str, Any]]:
         try:
             message_dict = json.loads(message)

--- a/tests/main/clients/extended_models/expected_client/async_base_client.py
+++ b/tests/main/clients/extended_models/expected_client/async_base_client.py
@@ -348,7 +348,7 @@ class AsyncBaseClient:
 
         if expected_type and expected_type != type_:
             raise GraphQLClientInvalidMessageFormat(
-                f"Invalid message type - expected {expected_type.value}"
+                f"Invalid message received. Expected: {expected_type.value}"
             )
 
         if type_ == GraphQLTransportWSMessageType.NEXT:

--- a/tests/main/clients/fragments_on_abstract_types/expected_client/async_base_client.py
+++ b/tests/main/clients/fragments_on_abstract_types/expected_client/async_base_client.py
@@ -333,7 +333,7 @@ class AsyncBaseClient:
         self,
         message: Data,
         websocket: WebSocketClientProtocol,
-        expected_type: GraphQLTransportWSMessageType | None = None,
+        expected_type: Optional[GraphQLTransportWSMessageType] = None,
     ) -> Optional[Dict[str, Any]]:
         try:
             message_dict = json.loads(message)

--- a/tests/main/clients/fragments_on_abstract_types/expected_client/async_base_client.py
+++ b/tests/main/clients/fragments_on_abstract_types/expected_client/async_base_client.py
@@ -348,7 +348,7 @@ class AsyncBaseClient:
 
         if expected_type and expected_type != type_:
             raise GraphQLClientInvalidMessageFormat(
-                f"Invalid message type - expected {expected_type.value}"
+                f"Invalid message received. Expected: {expected_type.value}"
             )
 
         if type_ == GraphQLTransportWSMessageType.NEXT:

--- a/tests/main/clients/inline_fragments/expected_client/async_base_client.py
+++ b/tests/main/clients/inline_fragments/expected_client/async_base_client.py
@@ -333,7 +333,7 @@ class AsyncBaseClient:
         self,
         message: Data,
         websocket: WebSocketClientProtocol,
-        expected_type: GraphQLTransportWSMessageType | None = None,
+        expected_type: Optional[GraphQLTransportWSMessageType] = None,
     ) -> Optional[Dict[str, Any]]:
         try:
             message_dict = json.loads(message)

--- a/tests/main/clients/inline_fragments/expected_client/async_base_client.py
+++ b/tests/main/clients/inline_fragments/expected_client/async_base_client.py
@@ -348,7 +348,7 @@ class AsyncBaseClient:
 
         if expected_type and expected_type != type_:
             raise GraphQLClientInvalidMessageFormat(
-                f"Invalid message type - expected {expected_type.value}"
+                f"Invalid message received. Expected: {expected_type.value}"
             )
 
         if type_ == GraphQLTransportWSMessageType.NEXT:

--- a/tests/main/clients/multiple_fragments/expected_client/async_base_client.py
+++ b/tests/main/clients/multiple_fragments/expected_client/async_base_client.py
@@ -333,7 +333,7 @@ class AsyncBaseClient:
         self,
         message: Data,
         websocket: WebSocketClientProtocol,
-        expected_type: GraphQLTransportWSMessageType | None = None,
+        expected_type: Optional[GraphQLTransportWSMessageType] = None,
     ) -> Optional[Dict[str, Any]]:
         try:
             message_dict = json.loads(message)

--- a/tests/main/clients/multiple_fragments/expected_client/async_base_client.py
+++ b/tests/main/clients/multiple_fragments/expected_client/async_base_client.py
@@ -348,7 +348,7 @@ class AsyncBaseClient:
 
         if expected_type and expected_type != type_:
             raise GraphQLClientInvalidMessageFormat(
-                f"Invalid message type - expected {expected_type.value}"
+                f"Invalid message received. Expected: {expected_type.value}"
             )
 
         if type_ == GraphQLTransportWSMessageType.NEXT:

--- a/tests/main/clients/only_used_inputs_and_enums/expected_client/async_base_client.py
+++ b/tests/main/clients/only_used_inputs_and_enums/expected_client/async_base_client.py
@@ -333,7 +333,7 @@ class AsyncBaseClient:
         self,
         message: Data,
         websocket: WebSocketClientProtocol,
-        expected_type: GraphQLTransportWSMessageType | None = None,
+        expected_type: Optional[GraphQLTransportWSMessageType] = None,
     ) -> Optional[Dict[str, Any]]:
         try:
             message_dict = json.loads(message)

--- a/tests/main/clients/only_used_inputs_and_enums/expected_client/async_base_client.py
+++ b/tests/main/clients/only_used_inputs_and_enums/expected_client/async_base_client.py
@@ -348,7 +348,7 @@ class AsyncBaseClient:
 
         if expected_type and expected_type != type_:
             raise GraphQLClientInvalidMessageFormat(
-                f"Invalid message type - expected {expected_type.value}"
+                f"Invalid message received. Expected: {expected_type.value}"
             )
 
         if type_ == GraphQLTransportWSMessageType.NEXT:

--- a/tests/main/clients/operations/expected_client/async_base_client.py
+++ b/tests/main/clients/operations/expected_client/async_base_client.py
@@ -333,7 +333,7 @@ class AsyncBaseClient:
         self,
         message: Data,
         websocket: WebSocketClientProtocol,
-        expected_type: GraphQLTransportWSMessageType | None = None,
+        expected_type: Optional[GraphQLTransportWSMessageType] = None,
     ) -> Optional[Dict[str, Any]]:
         try:
             message_dict = json.loads(message)

--- a/tests/main/clients/operations/expected_client/async_base_client.py
+++ b/tests/main/clients/operations/expected_client/async_base_client.py
@@ -348,7 +348,7 @@ class AsyncBaseClient:
 
         if expected_type and expected_type != type_:
             raise GraphQLClientInvalidMessageFormat(
-                f"Invalid message type - expected {expected_type.value}"
+                f"Invalid message received. Expected: {expected_type.value}"
             )
 
         if type_ == GraphQLTransportWSMessageType.NEXT:

--- a/tests/main/clients/remote_schema/expected_client/async_base_client.py
+++ b/tests/main/clients/remote_schema/expected_client/async_base_client.py
@@ -333,7 +333,7 @@ class AsyncBaseClient:
         self,
         message: Data,
         websocket: WebSocketClientProtocol,
-        expected_type: GraphQLTransportWSMessageType | None = None,
+        expected_type: Optional[GraphQLTransportWSMessageType] = None,
     ) -> Optional[Dict[str, Any]]:
         try:
             message_dict = json.loads(message)

--- a/tests/main/clients/remote_schema/expected_client/async_base_client.py
+++ b/tests/main/clients/remote_schema/expected_client/async_base_client.py
@@ -348,7 +348,7 @@ class AsyncBaseClient:
 
         if expected_type and expected_type != type_:
             raise GraphQLClientInvalidMessageFormat(
-                f"Invalid message type - expected {expected_type.value}"
+                f"Invalid message received. Expected: {expected_type.value}"
             )
 
         if type_ == GraphQLTransportWSMessageType.NEXT:

--- a/tests/main/clients/shorter_results/expected_client/async_base_client.py
+++ b/tests/main/clients/shorter_results/expected_client/async_base_client.py
@@ -333,7 +333,7 @@ class AsyncBaseClient:
         self,
         message: Data,
         websocket: WebSocketClientProtocol,
-        expected_type: GraphQLTransportWSMessageType | None = None,
+        expected_type: Optional[GraphQLTransportWSMessageType] = None,
     ) -> Optional[Dict[str, Any]]:
         try:
             message_dict = json.loads(message)

--- a/tests/main/clients/shorter_results/expected_client/async_base_client.py
+++ b/tests/main/clients/shorter_results/expected_client/async_base_client.py
@@ -348,7 +348,7 @@ class AsyncBaseClient:
 
         if expected_type and expected_type != type_:
             raise GraphQLClientInvalidMessageFormat(
-                f"Invalid message type - expected {expected_type.value}"
+                f"Invalid message received. Expected: {expected_type.value}"
             )
 
         if type_ == GraphQLTransportWSMessageType.NEXT:


### PR DESCRIPTION
After `connection_init` message is sent to server by the client, the client should wait for `connection_ack` message to be returned by the server as described in the protocol description: https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md

Failing to do this can result in errors related to auth, such as (result from using the async client to subscribe to [Tensor.trade GQL API](https://studio.apollographql.com/public/Tensor-Trade-API/variant/current/explorer?collectionId=eab3dcef-31d0-4380-a749-ea70956854da&focusCollectionId=eab3dcef-31d0-4380-a749-ea70956854da)):
```
  File "/home/damjan/workspace/tensor-trade-sdk-py/tensortradesdk/clients/async_base_client.py", line 164, in execute_ws
    async for message in websocket:
  File "/home/damjan/workspace/tensor-trade-sdk-py/venv/lib/python3.11/site-packages/websockets/legacy/protocol.py", line 497, in __aiter__
    yield await self.recv()
          ^^^^^^^^^^^^^^^^^
  File "/home/damjan/workspace/tensor-trade-sdk-py/venv/lib/python3.11/site-packages/websockets/legacy/protocol.py", line 568, in recv
    await self.ensure_open()
  File "/home/damjan/workspace/tensor-trade-sdk-py/venv/lib/python3.11/site-packages/websockets/legacy/protocol.py", line 944, in ensure_open
    raise self.connection_closed_exc()
websockets.exceptions.ConnectionClosedError: received 4401 (private use) Unauthorized; then sent 4401 (private use) Unauthorized
```