### PR TITLE
[bug] Fix scalar data issue in plugin settings

### DIFF
--- a/ariadne_codegen/config.py
+++ b/ariadne_codegen/config.py
@@ -38,7 +38,9 @@ def get_client_settings(config_dict: Dict) -> ClientSettings:
     settings_fields_names = {f.name for f in fields(ClientSettings)}
     try:
         section["scalars"] = {
-            name: ScalarData(
+            name: data
+            if isinstance(data, ScalarData)
+            else ScalarData(
                 type_=data["type"],
                 serialize=data.get("serialize"),
                 parse=data.get("parse"),


### PR DESCRIPTION
For some reason when loading the config during plugin execution, `ScalarData` has already been converted which causes this code to throw an error.  I added a check to take the `ScalarData` as is if it has already been converted.