### PR TITLE
Fix enum name processing and add uppercase flag

### DIFF
--- a/ariadne_codegen/client_generators/package.py
+++ b/ariadne_codegen/client_generators/package.py
@@ -364,7 +364,12 @@ def get_package_generator(
         custom_scalars=settings.scalars,
         plugin_manager=plugin_manager,
     )
-    enums_generator = EnumsGenerator(schema=schema, plugin_manager=plugin_manager)
+    enums_generator = EnumsGenerator(
+        schema=schema, 
+        plugin_manager=plugin_manager, 
+        convert_to_snake_case=settings.convert_to_snake_case,
+        convert_to_upper_snake_case=settings.convert_enums_names_to_upper_snake_case
+    )
     input_types_generator = InputTypesGenerator(
         schema=schema,
         enums_module=settings.enums_module_name,

--- a/ariadne_codegen/settings.py
+++ b/ariadne_codegen/settings.py
@@ -65,6 +65,7 @@ class ClientSettings(BaseSettings):
     fragments_module_name: str = "fragments"
     include_comments: CommentsStrategy = field(default=CommentsStrategy.STABLE)
     convert_to_snake_case: bool = True
+    convert_enums_names_to_upper_snake_case: bool = False
     include_all_inputs: bool = True
     include_all_enums: bool = True
     async_client: bool = True
@@ -148,6 +149,11 @@ class ClientSettings(BaseSettings):
             if self.convert_to_snake_case
             else "Not converting fields and arguments name to snake case."
         )
+        enum_upper_snake_case_msg = (
+            "Converting enum names to upper snake case."
+            if self.convert_enums_names_to_upper_snake_case
+            else "Not converting enum names to upper snake case."
+        )
         async_client_msg = (
             "Generating async client."
             if self.async_client
@@ -180,6 +186,7 @@ class ClientSettings(BaseSettings):
             Generating fragments into '{self.fragments_module_name}.py'.
             Comments type: {self.include_comments.value}
             {snake_case_msg}
+            {enum_upper_snake_case_msg}
             {async_client_msg}
             {files_to_include_msg}
             {plugins_msg}

--- a/ariadne_codegen/utils.py
+++ b/ariadne_codegen/utils.py
@@ -39,8 +39,10 @@ def str_to_snake_case(name: str) -> str:
     # upper-case letters, excluding last letter if it is followed by a lower-case letter
     uppercase_words = r"[A-Z]+(?=[A-Z][a-z]|\d|\W|$)"
     numbers = r"\d+"
+    # match upper-case only segments, this is placed after uppercase_words so that match gets priority
+    uppercase_only = r"[A-Z]+"
 
-    words = re.findall(rf"{lowercase_words}|{uppercase_words}|{numbers}", name)
+    words = re.findall(rf"{lowercase_words}|{uppercase_words}|{numbers}|{uppercase_only}", name)    
     return "_".join(map(str.lower, words))
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -115,6 +115,9 @@ def test_ast_to_str_removes_unused_imports():
         ("testWORD123", "test_word_123"),
         ("TestWORD123", "test_word_123"),
         ("TESTWord123", "test_word_123"),
+        ("ASC_NULLS_FIRST", "asc_nulls_first"),
+        ("DESC", "desc"),
+        ("DESC_NULLS_LAST", "desc_nulls_last"),
     ],
 )
 def test_str_to_snake_case_returns_correct_string(name, expected_result):


### PR DESCRIPTION
This PR fixes the following bugs in the processing of enum names:

1. the snake_case conversion function did not properly handle names with all uppercase eg `DESC_NULLS_LAST` was being converted into `LAST`
2. The enum generator was not calling `process_name` and so could not be hooked into the plugin customization pipeline
3. The enum generator did not respect the `convert_to_snake_case` option

This PR additionally adds the `convert_enums_names_to_upper_snake_case` option to convert enum members to upper snake case like:

```python
enum Foo:
  FOO_BAR
  BAZ_BOW
```

I think this should be a core option rather than a plugin since it is more idiomatic. It also avoid enum name conflicts. For instance I had an enum with `title` and `name` as members, which conflicted with the built-in enum methods of the same name. I set the flag to default False for backwards compat.