### PR TITLE
Add scalar to Operation plugin client test

### DIFF
--- a/tests/main/clients/operations/expected_client/__init__.py
+++ b/tests/main/clients/operations/expected_client/__init__.py
@@ -10,6 +10,7 @@ from .custom_operations import (
     C_SUBSCRIPTION_GQL,
     GET_A_GQL,
     GET_A_WITH_FRAGMENT_GQL,
+    GET_S_GQL,
     GET_XYZ_GQL,
 )
 from .exceptions import (
@@ -26,6 +27,7 @@ from .get_a_with_fragment import (
     GetAWithFragmentA,
     GetAWithFragmentAValueB,
 )
+from .get_s import GetS, GetSS
 from .get_xyz import GetXYZ, GetXYZXyzTypeX, GetXYZXyzTypeY, GetXYZXyzTypeZ
 
 __all__ = [
@@ -42,6 +44,7 @@ __all__ = [
     "FragmentY",
     "GET_A_GQL",
     "GET_A_WITH_FRAGMENT_GQL",
+    "GET_S_GQL",
     "GET_XYZ_GQL",
     "GetA",
     "GetAA",
@@ -49,6 +52,8 @@ __all__ = [
     "GetAWithFragment",
     "GetAWithFragmentA",
     "GetAWithFragmentAValueB",
+    "GetS",
+    "GetSS",
     "GetXYZ",
     "GetXYZXyzTypeX",
     "GetXYZXyzTypeY",

--- a/tests/main/clients/operations/expected_client/client.py
+++ b/tests/main/clients/operations/expected_client/client.py
@@ -10,10 +10,12 @@ from .custom_operations import (
     C_SUBSCRIPTION_GQL,
     GET_A_GQL,
     GET_A_WITH_FRAGMENT_GQL,
+    GET_S_GQL,
     GET_XYZ_GQL,
 )
 from .get_a import GetA
 from .get_a_with_fragment import GetAWithFragment
+from .get_s import GetS
 from .get_xyz import GetXYZ
 
 
@@ -77,3 +79,11 @@ class Client(AsyncBaseClient):
         )
         data = self.get_data(response)
         return GetXYZ.model_validate(data)
+
+    async def get_s(self, **kwargs: Any) -> GetS:
+        variables: Dict[str, object] = {}
+        response = await self.execute(
+            query=GET_S_GQL, operation_name="getS", variables=variables, **kwargs
+        )
+        data = self.get_data(response)
+        return GetS.model_validate(data)

--- a/tests/main/clients/operations/expected_client/custom_operations.py
+++ b/tests/main/clients/operations/expected_client/custom_operations.py
@@ -4,6 +4,7 @@ __all__ = [
     "C_SUBSCRIPTION_GQL",
     "GET_A_GQL",
     "GET_A_WITH_FRAGMENT_GQL",
+    "GET_S_GQL",
     "GET_XYZ_GQL",
 ]
 
@@ -66,5 +67,13 @@ query getXYZ {
 
 fragment fragmentY on TypeY {
   valueY
+}
+"""
+
+GET_S_GQL = """
+query getS {
+  s {
+    id
+  }
 }
 """

--- a/tests/main/clients/operations/expected_client/get_s.py
+++ b/tests/main/clients/operations/expected_client/get_s.py
@@ -1,0 +1,9 @@
+from .base_model import BaseModel
+
+
+class GetS(BaseModel):
+    s: "GetSS"
+
+
+class GetSS(BaseModel):
+    id: int

--- a/tests/main/clients/operations/pyproject.toml
+++ b/tests/main/clients/operations/pyproject.toml
@@ -5,5 +5,8 @@ target_package_name = "client_with_operations"
 include_comments = "none"
 plugins = ["ariadne_codegen.contrib.extract_operations.ExtractOperationsPlugin"]
 
+[tool.ariadne-codegen.scalars.CUSTOMID]
+type = "int"
+
 [tool.ariadne-codegen.extract-operations]
 operations_module_name = "custom_operations"

--- a/tests/main/clients/operations/queries.graphql
+++ b/tests/main/clients/operations/queries.graphql
@@ -46,3 +46,9 @@ query getXYZ {
     }
   }
 }
+
+query getS {
+  s {
+    id
+  }
+}

--- a/tests/main/clients/operations/schema.graphql
+++ b/tests/main/clients/operations/schema.graphql
@@ -1,6 +1,9 @@
+scalar CUSTOMID
+
 type Query {
     constQuery: String!
     a: TypeA!
+    s: TypeS!
     xyz: TypeXYZ!
 }
 
@@ -19,6 +22,10 @@ type TypeA {
 
 type TypeB {
     value: String!
+}
+
+type TypeS {
+  id: CUSTOMID!
 }
 
 type TypeX {


### PR DESCRIPTION
Hello @mat-sop! First, I want to thank you for this library; it has helped me a lot in my work, and I would be glad to provide any help in developing.

I found and fixed by myself the same issue as in [PR 256](https://github.com/mirumee/ariadne-codegen/pull/256). Trying to use get_client_settings in a plugin raises a TypeError. Although @slessans has already addressed this issue, I believe adding a test for this fix would be beneficial. I've updated the ExtractOperationsPlugin client test by including a scalar to verify the fix.

If there's anything I can do better, please let me know.