### PR TITLE
Separate subdirectory for result types

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Optional settings:
 - `enums_module_name` (defaults to `"enums"`) - name of file with generated enums models
 - `input_types_module_name` (defaults to `"input_types"`) - name of file with generated input types models
 - `fragments_module_name` (defaults to `"fragments"`) - name of file with generated fragments models
+- `result_types_directory_name` - name the subdirectory where modules with result types will be stored. If not specified, these modules will be saved in the root of the package
 - `include_comments` (defaults to `"stable"`) - option which sets content of comments included at the top of every generated file. Valid choices are: `"none"` (no comments), `"timestamp"` (comment with generation timestamp), `"stable"` (comment contains a message that this is a generated file)
 - `convert_to_snake_case` (defaults to `true`) - a flag that specifies whether to convert fields and arguments names to snake case
 - `include_all_inputs` (defaults to `true`) - a flag specifying whether to include all inputs defined in the schema, or only those used in supplied operations

--- a/ariadne_codegen/config.py
+++ b/ariadne_codegen/config.py
@@ -34,7 +34,7 @@ def get_config_dict(config_file_name: Optional[str] = None) -> Dict:
 
 def get_client_settings(config_dict: Dict) -> ClientSettings:
     """Parse configuration dict and return ClientSettings instance."""
-    section = get_section(config_dict)
+    section = get_section(config_dict).copy()
     settings_fields_names = {f.name for f in fields(ClientSettings)}
     try:
         section["scalars"] = {

--- a/tests/main/clients/result_types_directory/common_mixins.py
+++ b/tests/main/clients/result_types_directory/common_mixins.py
@@ -1,0 +1,2 @@
+class CommonMixin:
+    pass

--- a/tests/main/clients/result_types_directory/custom_scalars.py
+++ b/tests/main/clients/result_types_directory/custom_scalars.py
@@ -1,0 +1,14 @@
+SimpleScalar = str
+
+
+class ComplexScalar:
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+
+def parse_complex_scalar(value: str) -> ComplexScalar:
+    return ComplexScalar(value)
+
+
+def serialize_complex_scalar(value: ComplexScalar) -> str:
+    return value.value

--- a/tests/main/clients/result_types_directory/expected_client/__init__.py
+++ b/tests/main/clients/result_types_directory/expected_client/__init__.py
@@ -1,0 +1,78 @@
+from .async_base_client import AsyncBaseClient
+from .base_model import BaseModel, Upload
+from .client import Client
+from .enums import EnumI
+from .exceptions import (
+    GraphQLClientError,
+    GraphQLClientGraphQLError,
+    GraphQLClientGraphQLMultiError,
+    GraphQLClientHttpError,
+    GraphQLClientInvalidResponseError,
+)
+from .fragments import FragmentA, FragmentB, GetQueryAFragment, GetQueryAFragmentQueryA
+from .input_types import InputI
+from .operations import (
+    GET_COMPLEX_SCALAR_GQL,
+    GET_QUERY_A_GQL,
+    GET_QUERY_A_WITH_FRAGMENT_GQL,
+    GET_QUERY_B_GQL,
+    GET_QUERY_I_GQL,
+    GET_QUERY_WITH_MIXINS_FRAGMENTS_GQL,
+    GET_SIMPLE_SCALAR_GQL,
+    SUBSCRIBE_TO_TYPE_A_GQL,
+)
+from .result_types.get_complex_scalar import GetComplexScalar
+from .result_types.get_query_a import GetQueryA, GetQueryAQueryA
+from .result_types.get_query_a_with_fragment import GetQueryAWithFragment
+from .result_types.get_query_b import GetQueryB, GetQueryBQueryB
+from .result_types.get_query_i import GetQueryI, GetQueryIQueryI
+from .result_types.get_query_with_mixins_fragments import (
+    GetQueryWithMixinsFragments,
+    GetQueryWithMixinsFragmentsQueryA,
+    GetQueryWithMixinsFragmentsQueryB,
+)
+from .result_types.get_simple_scalar import GetSimpleScalar
+from .result_types.subscribe_to_type_a import (
+    SubscribeToTypeA,
+    SubscribeToTypeASubscribeToTypeA,
+)
+
+__all__ = [
+    "AsyncBaseClient",
+    "BaseModel",
+    "Client",
+    "EnumI",
+    "FragmentA",
+    "FragmentB",
+    "GET_COMPLEX_SCALAR_GQL",
+    "GET_QUERY_A_GQL",
+    "GET_QUERY_A_WITH_FRAGMENT_GQL",
+    "GET_QUERY_B_GQL",
+    "GET_QUERY_I_GQL",
+    "GET_QUERY_WITH_MIXINS_FRAGMENTS_GQL",
+    "GET_SIMPLE_SCALAR_GQL",
+    "GetComplexScalar",
+    "GetQueryA",
+    "GetQueryAFragment",
+    "GetQueryAFragmentQueryA",
+    "GetQueryAQueryA",
+    "GetQueryAWithFragment",
+    "GetQueryB",
+    "GetQueryBQueryB",
+    "GetQueryI",
+    "GetQueryIQueryI",
+    "GetQueryWithMixinsFragments",
+    "GetQueryWithMixinsFragmentsQueryA",
+    "GetQueryWithMixinsFragmentsQueryB",
+    "GetSimpleScalar",
+    "GraphQLClientError",
+    "GraphQLClientGraphQLError",
+    "GraphQLClientGraphQLMultiError",
+    "GraphQLClientHttpError",
+    "GraphQLClientInvalidResponseError",
+    "InputI",
+    "SUBSCRIBE_TO_TYPE_A_GQL",
+    "SubscribeToTypeA",
+    "SubscribeToTypeASubscribeToTypeA",
+    "Upload",
+]

--- a/tests/main/clients/result_types_directory/expected_client/async_base_client.py
+++ b/tests/main/clients/result_types_directory/expected_client/async_base_client.py
@@ -1,0 +1,356 @@
+import enum
+import json
+from typing import IO, Any, AsyncIterator, Dict, List, Optional, Tuple, TypeVar, cast
+from uuid import uuid4
+
+import httpx
+from pydantic import BaseModel
+from pydantic_core import to_jsonable_python
+
+from .base_model import UNSET, Upload
+from .exceptions import (
+    GraphQLClientGraphQLMultiError,
+    GraphQLClientHttpError,
+    GraphQLClientInvalidMessageFormat,
+    GraphQLClientInvalidResponseError,
+)
+
+try:
+    from websockets.client import (  # type: ignore[import-not-found,unused-ignore]
+        WebSocketClientProtocol,
+        connect as ws_connect,
+    )
+    from websockets.typing import (  # type: ignore[import-not-found,unused-ignore]
+        Data,
+        Origin,
+        Subprotocol,
+    )
+except ImportError:
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager  # type: ignore
+    async def ws_connect(*args, **kwargs):  # pylint: disable=unused-argument
+        raise NotImplementedError("Subscriptions require 'websockets' package.")
+        yield  # pylint: disable=unreachable
+
+    WebSocketClientProtocol = Any  # type: ignore[misc,assignment,unused-ignore]
+    Data = Any  # type: ignore[misc,assignment,unused-ignore]
+    Origin = Any  # type: ignore[misc,assignment,unused-ignore]
+
+    def Subprotocol(*args, **kwargs):  # type: ignore # pylint: disable=invalid-name
+        raise NotImplementedError("Subscriptions require 'websockets' package.")
+
+
+Self = TypeVar("Self", bound="AsyncBaseClient")
+
+GRAPHQL_TRANSPORT_WS = "graphql-transport-ws"
+
+
+class GraphQLTransportWSMessageType(str, enum.Enum):
+    CONNECTION_INIT = "connection_init"
+    CONNECTION_ACK = "connection_ack"
+    PING = "ping"
+    PONG = "pong"
+    SUBSCRIBE = "subscribe"
+    NEXT = "next"
+    ERROR = "error"
+    COMPLETE = "complete"
+
+
+class AsyncBaseClient:
+    def __init__(
+        self,
+        url: str = "",
+        headers: Optional[Dict[str, str]] = None,
+        http_client: Optional[httpx.AsyncClient] = None,
+        ws_url: str = "",
+        ws_headers: Optional[Dict[str, Any]] = None,
+        ws_origin: Optional[str] = None,
+        ws_connection_init_payload: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.url = url
+        self.headers = headers
+        self.http_client = (
+            http_client if http_client else httpx.AsyncClient(headers=headers)
+        )
+
+        self.ws_url = ws_url
+        self.ws_headers = ws_headers or {}
+        self.ws_origin = Origin(ws_origin) if ws_origin else None
+        self.ws_connection_init_payload = ws_connection_init_payload
+
+    async def __aenter__(self: Self) -> Self:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: object,
+        exc_val: object,
+        exc_tb: object,
+    ) -> None:
+        await self.http_client.aclose()
+
+    async def execute(
+        self,
+        query: str,
+        operation_name: Optional[str] = None,
+        variables: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> httpx.Response:
+        processed_variables, files, files_map = self._process_variables(variables)
+
+        if files and files_map:
+            return await self._execute_multipart(
+                query=query,
+                operation_name=operation_name,
+                variables=processed_variables,
+                files=files,
+                files_map=files_map,
+                **kwargs,
+            )
+
+        return await self._execute_json(
+            query=query,
+            operation_name=operation_name,
+            variables=processed_variables,
+            **kwargs,
+        )
+
+    def get_data(self, response: httpx.Response) -> Dict[str, Any]:
+        if not response.is_success:
+            raise GraphQLClientHttpError(
+                status_code=response.status_code, response=response
+            )
+
+        try:
+            response_json = response.json()
+        except ValueError as exc:
+            raise GraphQLClientInvalidResponseError(response=response) from exc
+
+        if (not isinstance(response_json, dict)) or (
+            "data" not in response_json and "errors" not in response_json
+        ):
+            raise GraphQLClientInvalidResponseError(response=response)
+
+        data = response_json.get("data")
+        errors = response_json.get("errors")
+
+        if errors:
+            raise GraphQLClientGraphQLMultiError.from_errors_dicts(
+                errors_dicts=errors, data=data
+            )
+
+        return cast(Dict[str, Any], data)
+
+    async def execute_ws(
+        self,
+        query: str,
+        operation_name: Optional[str] = None,
+        variables: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[Dict[str, Any]]:
+        headers = self.ws_headers.copy()
+        headers.update(kwargs.get("extra_headers", {}))
+
+        merged_kwargs: Dict[str, Any] = {"origin": self.ws_origin}
+        merged_kwargs.update(kwargs)
+        merged_kwargs["extra_headers"] = headers
+
+        operation_id = str(uuid4())
+        async with ws_connect(
+            self.ws_url,
+            subprotocols=[Subprotocol(GRAPHQL_TRANSPORT_WS)],
+            **merged_kwargs,
+        ) as websocket:
+            await self._send_connection_init(websocket)
+            await self._send_subscribe(
+                websocket,
+                operation_id=operation_id,
+                query=query,
+                operation_name=operation_name,
+                variables=variables,
+            )
+
+            async for message in websocket:
+                data = await self._handle_ws_message(message, websocket)
+                if data:
+                    yield data
+
+    def _process_variables(
+        self, variables: Optional[Dict[str, Any]]
+    ) -> Tuple[
+        Dict[str, Any], Dict[str, Tuple[str, IO[bytes], str]], Dict[str, List[str]]
+    ]:
+        if not variables:
+            return {}, {}, {}
+
+        serializable_variables = self._convert_dict_to_json_serializable(variables)
+        return self._get_files_from_variables(serializable_variables)
+
+    def _convert_dict_to_json_serializable(
+        self, dict_: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        return {
+            key: self._convert_value(value)
+            for key, value in dict_.items()
+            if value is not UNSET
+        }
+
+    def _convert_value(self, value: Any) -> Any:
+        if isinstance(value, BaseModel):
+            return value.model_dump(by_alias=True, exclude_unset=True)
+        if isinstance(value, list):
+            return [self._convert_value(item) for item in value]
+        return value
+
+    def _get_files_from_variables(
+        self, variables: Dict[str, Any]
+    ) -> Tuple[
+        Dict[str, Any], Dict[str, Tuple[str, IO[bytes], str]], Dict[str, List[str]]
+    ]:
+        files_map: Dict[str, List[str]] = {}
+        files_list: List[Upload] = []
+
+        def separate_files(path: str, obj: Any) -> Any:
+            if isinstance(obj, list):
+                nulled_list = []
+                for index, value in enumerate(obj):
+                    value = separate_files(f"{path}.{index}", value)
+                    nulled_list.append(value)
+                return nulled_list
+
+            if isinstance(obj, dict):
+                nulled_dict = {}
+                for key, value in obj.items():
+                    value = separate_files(f"{path}.{key}", value)
+                    nulled_dict[key] = value
+                return nulled_dict
+
+            if isinstance(obj, Upload):
+                if obj in files_list:
+                    file_index = files_list.index(obj)
+                    files_map[str(file_index)].append(path)
+                else:
+                    file_index = len(files_list)
+                    files_list.append(obj)
+                    files_map[str(file_index)] = [path]
+                return None
+
+            return obj
+
+        nulled_variables = separate_files("variables", variables)
+        files: Dict[str, Tuple[str, IO[bytes], str]] = {
+            str(i): (file_.filename, cast(IO[bytes], file_.content), file_.content_type)
+            for i, file_ in enumerate(files_list)
+        }
+        return nulled_variables, files, files_map
+
+    async def _execute_multipart(
+        self,
+        query: str,
+        operation_name: Optional[str],
+        variables: Dict[str, Any],
+        files: Dict[str, Tuple[str, IO[bytes], str]],
+        files_map: Dict[str, List[str]],
+        **kwargs: Any,
+    ) -> httpx.Response:
+        data = {
+            "operations": json.dumps(
+                {
+                    "query": query,
+                    "operationName": operation_name,
+                    "variables": variables,
+                },
+                default=to_jsonable_python,
+            ),
+            "map": json.dumps(files_map, default=to_jsonable_python),
+        }
+
+        return await self.http_client.post(
+            url=self.url, data=data, files=files, **kwargs
+        )
+
+    async def _execute_json(
+        self,
+        query: str,
+        operation_name: Optional[str],
+        variables: Dict[str, Any],
+        **kwargs: Any,
+    ) -> httpx.Response:
+        headers: Dict[str, str] = {"Content-Type": "application/json"}
+        headers.update(kwargs.get("headers", {}))
+
+        merged_kwargs: Dict[str, Any] = kwargs.copy()
+        merged_kwargs["headers"] = headers
+
+        return await self.http_client.post(
+            url=self.url,
+            content=json.dumps(
+                {
+                    "query": query,
+                    "operationName": operation_name,
+                    "variables": variables,
+                },
+                default=to_jsonable_python,
+            ),
+            **merged_kwargs,
+        )
+
+    async def _send_connection_init(self, websocket: WebSocketClientProtocol) -> None:
+        payload: Dict[str, Any] = {
+            "type": GraphQLTransportWSMessageType.CONNECTION_INIT.value
+        }
+        if self.ws_connection_init_payload:
+            payload["payload"] = self.ws_connection_init_payload
+        await websocket.send(json.dumps(payload))
+
+    async def _send_subscribe(
+        self,
+        websocket: WebSocketClientProtocol,
+        operation_id: str,
+        query: str,
+        operation_name: Optional[str] = None,
+        variables: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        payload: Dict[str, Any] = {
+            "id": operation_id,
+            "type": GraphQLTransportWSMessageType.SUBSCRIBE.value,
+            "payload": {"query": query, "operationName": operation_name},
+        }
+        if variables:
+            payload["payload"]["variables"] = self._convert_dict_to_json_serializable(
+                variables
+            )
+        await websocket.send(json.dumps(payload))
+
+    async def _handle_ws_message(
+        self, message: Data, websocket: WebSocketClientProtocol
+    ) -> Optional[Dict[str, Any]]:
+        try:
+            message_dict = json.loads(message)
+        except json.JSONDecodeError as exc:
+            raise GraphQLClientInvalidMessageFormat(message=message) from exc
+
+        type_ = message_dict.get("type")
+        payload = message_dict.get("payload", {})
+
+        if not type_ or type_ not in {t.value for t in GraphQLTransportWSMessageType}:
+            raise GraphQLClientInvalidMessageFormat(message=message)
+
+        if type_ == GraphQLTransportWSMessageType.NEXT:
+            if "data" not in payload:
+                raise GraphQLClientInvalidMessageFormat(message=message)
+            return cast(Dict[str, Any], payload["data"])
+
+        if type_ == GraphQLTransportWSMessageType.COMPLETE:
+            await websocket.close()
+        elif type_ == GraphQLTransportWSMessageType.PING:
+            await websocket.send(
+                json.dumps({"type": GraphQLTransportWSMessageType.PONG.value})
+            )
+        elif type_ == GraphQLTransportWSMessageType.ERROR:
+            raise GraphQLClientGraphQLMultiError.from_errors_dicts(
+                errors_dicts=payload, data=message_dict
+            )
+
+        return None

--- a/tests/main/clients/result_types_directory/expected_client/base_model.py
+++ b/tests/main/clients/result_types_directory/expected_client/base_model.py
@@ -1,0 +1,27 @@
+from io import IOBase
+
+from pydantic import BaseModel as PydanticBaseModel, ConfigDict
+
+
+class UnsetType:
+    def __bool__(self) -> bool:
+        return False
+
+
+UNSET = UnsetType()
+
+
+class BaseModel(PydanticBaseModel):
+    model_config = ConfigDict(
+        populate_by_name=True,
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+        protected_namespaces=(),
+    )
+
+
+class Upload:
+    def __init__(self, filename: str, content: IOBase, content_type: str):
+        self.filename = filename
+        self.content = content
+        self.content_type = content_type

--- a/tests/main/clients/result_types_directory/expected_client/client.py
+++ b/tests/main/clients/result_types_directory/expected_client/client.py
@@ -1,0 +1,123 @@
+from typing import Any, AsyncIterator, Dict
+
+from .async_base_client import AsyncBaseClient
+from .fragments import GetQueryAFragmentQueryA
+from .input_types import InputI
+from .operations import (
+    GET_COMPLEX_SCALAR_GQL,
+    GET_QUERY_A_GQL,
+    GET_QUERY_A_WITH_FRAGMENT_GQL,
+    GET_QUERY_B_GQL,
+    GET_QUERY_I_GQL,
+    GET_QUERY_WITH_MIXINS_FRAGMENTS_GQL,
+    GET_SIMPLE_SCALAR_GQL,
+    SUBSCRIBE_TO_TYPE_A_GQL,
+)
+from .result_types.get_complex_scalar import GetComplexScalar
+from .result_types.get_query_a import GetQueryA, GetQueryAQueryA
+from .result_types.get_query_a_with_fragment import GetQueryAWithFragment
+from .result_types.get_query_b import GetQueryB, GetQueryBQueryB
+from .result_types.get_query_i import GetQueryI, GetQueryIQueryI
+from .result_types.get_query_with_mixins_fragments import GetQueryWithMixinsFragments
+from .result_types.get_simple_scalar import GetSimpleScalar
+from .result_types.subscribe_to_type_a import (
+    SubscribeToTypeA,
+    SubscribeToTypeASubscribeToTypeA,
+)
+
+
+def gql(q: str) -> str:
+    return q
+
+
+class Client(AsyncBaseClient):
+    async def get_query_a(self, **kwargs: Any) -> GetQueryAQueryA:
+        variables: Dict[str, object] = {}
+        response = await self.execute(
+            query=GET_QUERY_A_GQL,
+            operation_name="getQueryA",
+            variables=variables,
+            **kwargs
+        )
+        data = self.get_data(response)
+        return GetQueryA.model_validate(data).query_a
+
+    async def get_query_b(self, **kwargs: Any) -> GetQueryBQueryB:
+        variables: Dict[str, object] = {}
+        response = await self.execute(
+            query=GET_QUERY_B_GQL,
+            operation_name="getQueryB",
+            variables=variables,
+            **kwargs
+        )
+        data = self.get_data(response)
+        return GetQueryB.model_validate(data).query_b
+
+    async def get_query_i(self, data_i: InputI, **kwargs: Any) -> GetQueryIQueryI:
+        variables: Dict[str, object] = {"dataI": data_i}
+        response = await self.execute(
+            query=GET_QUERY_I_GQL,
+            operation_name="getQueryI",
+            variables=variables,
+            **kwargs
+        )
+        data = self.get_data(response)
+        return GetQueryI.model_validate(data).query_i
+
+    async def get_query_a_with_fragment(self, **kwargs: Any) -> GetQueryAFragmentQueryA:
+        variables: Dict[str, object] = {}
+        response = await self.execute(
+            query=GET_QUERY_A_WITH_FRAGMENT_GQL,
+            operation_name="getQueryAWithFragment",
+            variables=variables,
+            **kwargs
+        )
+        data = self.get_data(response)
+        return GetQueryAWithFragment.model_validate(data).query_a
+
+    async def get_query_with_mixins_fragments(
+        self, **kwargs: Any
+    ) -> GetQueryWithMixinsFragments:
+        variables: Dict[str, object] = {}
+        response = await self.execute(
+            query=GET_QUERY_WITH_MIXINS_FRAGMENTS_GQL,
+            operation_name="getQueryWithMixinsFragments",
+            variables=variables,
+            **kwargs
+        )
+        data = self.get_data(response)
+        return GetQueryWithMixinsFragments.model_validate(data)
+
+    async def get_simple_scalar(self, **kwargs: Any) -> Any:
+        variables: Dict[str, object] = {}
+        response = await self.execute(
+            query=GET_SIMPLE_SCALAR_GQL,
+            operation_name="GetSimpleScalar",
+            variables=variables,
+            **kwargs
+        )
+        data = self.get_data(response)
+        return GetSimpleScalar.model_validate(data).just_simple_scalar
+
+    async def get_complex_scalar(self, **kwargs: Any) -> Any:
+        variables: Dict[str, object] = {}
+        response = await self.execute(
+            query=GET_COMPLEX_SCALAR_GQL,
+            operation_name="GetComplexScalar",
+            variables=variables,
+            **kwargs
+        )
+        data = self.get_data(response)
+        return GetComplexScalar.model_validate(data).just_complex_scalar
+
+    async def subscribe_to_type_a(
+        self, **kwargs: Any
+    ) -> AsyncIterator[SubscribeToTypeASubscribeToTypeA]:
+        variables: Dict[str, object] = {}
+        async for data in self.execute_ws(
+            query=SUBSCRIBE_TO_TYPE_A_GQL,
+            operation_name="SubscribeToTypeA",
+            variables=variables,
+            **kwargs
+        ):
+            yield SubscribeToTypeA.model_validate(data).subscribe_to_type_a

--- a/tests/main/clients/result_types_directory/expected_client/common_mixins.py
+++ b/tests/main/clients/result_types_directory/expected_client/common_mixins.py
@@ -1,0 +1,2 @@
+class CommonMixin:
+    pass

--- a/tests/main/clients/result_types_directory/expected_client/custom_scalars.py
+++ b/tests/main/clients/result_types_directory/expected_client/custom_scalars.py
@@ -1,0 +1,14 @@
+SimpleScalar = str
+
+
+class ComplexScalar:
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+
+def parse_complex_scalar(value: str) -> ComplexScalar:
+    return ComplexScalar(value)
+
+
+def serialize_complex_scalar(value: ComplexScalar) -> str:
+    return value.value

--- a/tests/main/clients/result_types_directory/expected_client/enums.py
+++ b/tests/main/clients/result_types_directory/expected_client/enums.py
@@ -1,0 +1,7 @@
+from enum import Enum
+
+
+class EnumI(str, Enum):
+    A = "A"
+    B = "B"
+    C = "C"

--- a/tests/main/clients/result_types_directory/expected_client/exceptions.py
+++ b/tests/main/clients/result_types_directory/expected_client/exceptions.py
@@ -1,0 +1,83 @@
+from typing import Any, Dict, List, Optional, Union
+
+import httpx
+
+
+class GraphQLClientError(Exception):
+    """Base exception."""
+
+
+class GraphQLClientHttpError(GraphQLClientError):
+    def __init__(self, status_code: int, response: httpx.Response) -> None:
+        self.status_code = status_code
+        self.response = response
+
+    def __str__(self) -> str:
+        return f"HTTP status code: {self.status_code}"
+
+
+class GraphQLClientInvalidResponseError(GraphQLClientError):
+    def __init__(self, response: httpx.Response) -> None:
+        self.response = response
+
+    def __str__(self) -> str:
+        return "Invalid response format."
+
+
+class GraphQLClientGraphQLError(GraphQLClientError):
+    def __init__(
+        self,
+        message: str,
+        locations: Optional[List[Dict[str, int]]] = None,
+        path: Optional[List[str]] = None,
+        extensions: Optional[Dict[str, object]] = None,
+        orginal: Optional[Dict[str, object]] = None,
+    ):
+        self.message = message
+        self.locations = locations
+        self.path = path
+        self.extensions = extensions
+        self.orginal = orginal
+
+    def __str__(self) -> str:
+        return self.message
+
+    @classmethod
+    def from_dict(cls, error: Dict[str, Any]) -> "GraphQLClientGraphQLError":
+        return cls(
+            message=error["message"],
+            locations=error.get("locations"),
+            path=error.get("path"),
+            extensions=error.get("extensions"),
+            orginal=error,
+        )
+
+
+class GraphQLClientGraphQLMultiError(GraphQLClientError):
+    def __init__(
+        self,
+        errors: List[GraphQLClientGraphQLError],
+        data: Optional[Dict[str, Any]] = None,
+    ):
+        self.errors = errors
+        self.data = data
+
+    def __str__(self) -> str:
+        return "; ".join(str(e) for e in self.errors)
+
+    @classmethod
+    def from_errors_dicts(
+        cls, errors_dicts: List[Dict[str, Any]], data: Optional[Dict[str, Any]] = None
+    ) -> "GraphQLClientGraphQLMultiError":
+        return cls(
+            errors=[GraphQLClientGraphQLError.from_dict(e) for e in errors_dicts],
+            data=data,
+        )
+
+
+class GraphQLClientInvalidMessageFormat(GraphQLClientError):
+    def __init__(self, message: Union[str, bytes]) -> None:
+        self.message = message
+
+    def __str__(self) -> str:
+        return "Invalid message format."

--- a/tests/main/clients/result_types_directory/expected_client/fragments.py
+++ b/tests/main/clients/result_types_directory/expected_client/fragments.py
@@ -1,0 +1,22 @@
+from pydantic import Field
+
+from .base_model import BaseModel
+from .common_mixins import CommonMixin
+from .mixins_a import MixinA
+from .mixins_b import MixinB
+
+
+class FragmentA(BaseModel, MixinA):
+    field_a: int = Field(alias="fieldA")
+
+
+class FragmentB(BaseModel, MixinB):
+    field_b: str = Field(alias="fieldB")
+
+
+class GetQueryAFragment(BaseModel):
+    query_a: "GetQueryAFragmentQueryA" = Field(alias="queryA")
+
+
+class GetQueryAFragmentQueryA(BaseModel, MixinA, CommonMixin):
+    field_a: int = Field(alias="fieldA")

--- a/tests/main/clients/result_types_directory/expected_client/input_types.py
+++ b/tests/main/clients/result_types_directory/expected_client/input_types.py
@@ -1,0 +1,6 @@
+from .base_model import BaseModel
+from .enums import EnumI
+
+
+class InputI(BaseModel):
+    version: EnumI

--- a/tests/main/clients/result_types_directory/expected_client/mixins_a.py
+++ b/tests/main/clients/result_types_directory/expected_client/mixins_a.py
@@ -1,0 +1,2 @@
+class MixinA:
+    pass

--- a/tests/main/clients/result_types_directory/expected_client/mixins_b.py
+++ b/tests/main/clients/result_types_directory/expected_client/mixins_b.py
@@ -1,0 +1,2 @@
+class MixinB:
+    pass

--- a/tests/main/clients/result_types_directory/expected_client/operations.py
+++ b/tests/main/clients/result_types_directory/expected_client/operations.py
@@ -1,0 +1,86 @@
+__all__ = [
+    "GET_COMPLEX_SCALAR_GQL",
+    "GET_QUERY_A_GQL",
+    "GET_QUERY_A_WITH_FRAGMENT_GQL",
+    "GET_QUERY_B_GQL",
+    "GET_QUERY_I_GQL",
+    "GET_QUERY_WITH_MIXINS_FRAGMENTS_GQL",
+    "GET_SIMPLE_SCALAR_GQL",
+    "SUBSCRIBE_TO_TYPE_A_GQL",
+]
+
+GET_QUERY_A_GQL = """
+query getQueryA {
+  queryA {
+    fieldA
+  }
+}
+"""
+
+GET_QUERY_B_GQL = """
+query getQueryB {
+  queryB {
+    fieldB
+  }
+}
+"""
+
+GET_QUERY_I_GQL = """
+query getQueryI($dataI: InputI!) {
+  queryI(dataI: $dataI) {
+    fieldI
+    date
+  }
+}
+"""
+
+GET_QUERY_A_WITH_FRAGMENT_GQL = """
+query getQueryAWithFragment {
+  ...getQueryAFragment
+}
+
+fragment getQueryAFragment on Query {
+  queryA {
+    fieldA
+  }
+}
+"""
+
+GET_QUERY_WITH_MIXINS_FRAGMENTS_GQL = """
+query getQueryWithMixinsFragments {
+  queryA {
+    ...fragmentA
+  }
+  queryB {
+    ...fragmentB
+  }
+}
+
+fragment fragmentA on TypeA @mixin(from: ".mixins_a", import: "MixinA") {
+  fieldA
+}
+
+fragment fragmentB on TypeB @mixin(from: ".mixins_b", import: "MixinB") {
+  fieldB
+}
+"""
+
+GET_SIMPLE_SCALAR_GQL = """
+query GetSimpleScalar {
+  justSimpleScalar
+}
+"""
+
+GET_COMPLEX_SCALAR_GQL = """
+query GetComplexScalar {
+  justComplexScalar
+}
+"""
+
+SUBSCRIBE_TO_TYPE_A_GQL = """
+subscription SubscribeToTypeA {
+  subscribeToTypeA {
+    fieldA
+  }
+}
+"""

--- a/tests/main/clients/result_types_directory/expected_client/result_types/get_complex_scalar.py
+++ b/tests/main/clients/result_types_directory/expected_client/result_types/get_complex_scalar.py
@@ -1,0 +1,9 @@
+from typing import Any
+
+from pydantic import Field
+
+from ..base_model import BaseModel
+
+
+class GetComplexScalar(BaseModel):
+    just_complex_scalar: Any = Field(alias="justComplexScalar")

--- a/tests/main/clients/result_types_directory/expected_client/result_types/get_query_a.py
+++ b/tests/main/clients/result_types_directory/expected_client/result_types/get_query_a.py
@@ -1,0 +1,13 @@
+from pydantic import Field
+
+from ..base_model import BaseModel
+from ..common_mixins import CommonMixin
+from ..mixins_a import MixinA
+
+
+class GetQueryA(BaseModel):
+    query_a: "GetQueryAQueryA" = Field(alias="queryA")
+
+
+class GetQueryAQueryA(BaseModel, MixinA, CommonMixin):
+    field_a: int = Field(alias="fieldA")

--- a/tests/main/clients/result_types_directory/expected_client/result_types/get_query_a_with_fragment.py
+++ b/tests/main/clients/result_types_directory/expected_client/result_types/get_query_a_with_fragment.py
@@ -1,0 +1,5 @@
+from ..fragments import GetQueryAFragment
+
+
+class GetQueryAWithFragment(GetQueryAFragment):
+    pass

--- a/tests/main/clients/result_types_directory/expected_client/result_types/get_query_b.py
+++ b/tests/main/clients/result_types_directory/expected_client/result_types/get_query_b.py
@@ -1,0 +1,13 @@
+from pydantic import Field
+
+from ..base_model import BaseModel
+from ..common_mixins import CommonMixin
+from ..mixins_b import MixinB
+
+
+class GetQueryB(BaseModel):
+    query_b: "GetQueryBQueryB" = Field(alias="queryB")
+
+
+class GetQueryBQueryB(BaseModel, MixinB, CommonMixin):
+    field_b: str = Field(alias="fieldB")

--- a/tests/main/clients/result_types_directory/expected_client/result_types/get_query_i.py
+++ b/tests/main/clients/result_types_directory/expected_client/result_types/get_query_i.py
@@ -1,0 +1,14 @@
+from typing import Any
+
+from pydantic import Field
+
+from ..base_model import BaseModel
+
+
+class GetQueryI(BaseModel):
+    query_i: "GetQueryIQueryI" = Field(alias="queryI")
+
+
+class GetQueryIQueryI(BaseModel):
+    field_i: int = Field(alias="fieldI")
+    date: Any

--- a/tests/main/clients/result_types_directory/expected_client/result_types/get_query_with_mixins_fragments.py
+++ b/tests/main/clients/result_types_directory/expected_client/result_types/get_query_with_mixins_fragments.py
@@ -1,0 +1,18 @@
+from pydantic import Field
+
+from ..base_model import BaseModel
+from ..common_mixins import CommonMixin
+from ..fragments import FragmentA, FragmentB
+
+
+class GetQueryWithMixinsFragments(BaseModel):
+    query_a: "GetQueryWithMixinsFragmentsQueryA" = Field(alias="queryA")
+    query_b: "GetQueryWithMixinsFragmentsQueryB" = Field(alias="queryB")
+
+
+class GetQueryWithMixinsFragmentsQueryA(FragmentA, CommonMixin):
+    pass
+
+
+class GetQueryWithMixinsFragmentsQueryB(FragmentB, CommonMixin):
+    pass

--- a/tests/main/clients/result_types_directory/expected_client/result_types/get_simple_scalar.py
+++ b/tests/main/clients/result_types_directory/expected_client/result_types/get_simple_scalar.py
@@ -1,0 +1,9 @@
+from typing import Any
+
+from pydantic import Field
+
+from ..base_model import BaseModel
+
+
+class GetSimpleScalar(BaseModel):
+    just_simple_scalar: Any = Field(alias="justSimpleScalar")

--- a/tests/main/clients/result_types_directory/expected_client/result_types/subscribe_to_type_a.py
+++ b/tests/main/clients/result_types_directory/expected_client/result_types/subscribe_to_type_a.py
@@ -1,0 +1,13 @@
+from pydantic import Field
+
+from ..base_model import BaseModel
+
+
+class SubscribeToTypeA(BaseModel):
+    subscribe_to_type_a: "SubscribeToTypeASubscribeToTypeA" = Field(
+        alias="subscribeToTypeA"
+    )
+
+
+class SubscribeToTypeASubscribeToTypeA(BaseModel):
+    field_a: int = Field(alias="fieldA")

--- a/tests/main/clients/result_types_directory/mixins_a.py
+++ b/tests/main/clients/result_types_directory/mixins_a.py
@@ -1,0 +1,2 @@
+class MixinA:
+    pass

--- a/tests/main/clients/result_types_directory/mixins_b.py
+++ b/tests/main/clients/result_types_directory/mixins_b.py
@@ -1,0 +1,2 @@
+class MixinB:
+    pass

--- a/tests/main/clients/result_types_directory/pyproject.toml
+++ b/tests/main/clients/result_types_directory/pyproject.toml
@@ -1,0 +1,12 @@
+[tool.ariadne-codegen]
+schema_path = "schema.graphql"
+queries_path = "queries.graphql"
+include_comments = "none"
+target_package_name = "client_result_types_directory"
+files_to_include = ["common_mixins.py", "mixins_a.py", "mixins_b.py", "custom_scalars.py"]
+result_types_directory_name = "result_types"
+
+plugins = [
+    "ariadne_codegen.contrib.shorter_results.ShorterResultsPlugin",
+    "ariadne_codegen.contrib.extract_operations.ExtractOperationsPlugin",
+]

--- a/tests/main/clients/result_types_directory/queries.graphql
+++ b/tests/main/clients/result_types_directory/queries.graphql
@@ -1,0 +1,65 @@
+query getQueryA {
+  queryA
+    @mixin(from: ".mixins_a", import: "MixinA")
+    @mixin(from: ".common_mixins", import: "CommonMixin") {
+    fieldA
+  }
+}
+
+query getQueryB {
+  queryB
+    @mixin(from: ".mixins_b", import: "MixinB")
+    @mixin(from: ".common_mixins", import: "CommonMixin") {
+    fieldB
+  }
+}
+
+query getQueryI($dataI: InputI!) {
+  queryI(dataI: $dataI) {
+    fieldI
+    date
+  }
+}
+
+query getQueryAWithFragment {
+  ...getQueryAFragment
+}
+
+fragment getQueryAFragment on Query {
+  queryA
+    @mixin(from: ".mixins_a", import: "MixinA")
+    @mixin(from: ".common_mixins", import: "CommonMixin") {
+    fieldA
+  }
+}
+
+query getQueryWithMixinsFragments {
+  queryA @mixin(from: ".common_mixins", import: "CommonMixin") {
+    ...fragmentA
+  }
+  queryB @mixin(from: ".common_mixins", import: "CommonMixin") {
+    ...fragmentB
+  }
+}
+
+fragment fragmentA on TypeA @mixin(from: ".mixins_a", import: "MixinA") {
+  fieldA
+}
+
+fragment fragmentB on TypeB @mixin(from: ".mixins_b", import: "MixinB") {
+  fieldB
+}
+
+query GetSimpleScalar {
+  justSimpleScalar
+}
+
+query GetComplexScalar {
+  justComplexScalar
+}
+
+subscription SubscribeToTypeA {
+  subscribeToTypeA {
+    fieldA
+  }
+}

--- a/tests/main/clients/result_types_directory/schema.graphql
+++ b/tests/main/clients/result_types_directory/schema.graphql
@@ -1,0 +1,45 @@
+scalar SimpleScalar
+scalar ComplexScalar
+scalar DATETIME
+
+schema {
+  query: Query
+  subscription: Subscription
+}
+
+type Subscription {
+  subscribeToTypeA: TypeA!
+  subscribeToTypeB: TypeB!
+  subscribeToTypeI: TypeI!
+}
+
+type Query {
+  queryA: TypeA!
+  queryB: TypeB!
+  queryI(dataI: InputI!): TypeI!
+  justSimpleScalar: SimpleScalar!
+  justComplexScalar: ComplexScalar!
+}
+
+type TypeA {
+  fieldA: Int!
+}
+
+type TypeB {
+  fieldB: String!
+}
+
+type TypeI {
+  fieldI: Int!
+  date: DATETIME!
+}
+
+input InputI {
+  version: EnumI!
+}
+
+enum EnumI {
+  A
+  B
+  C
+}

--- a/tests/main/test_main.py
+++ b/tests/main/test_main.py
@@ -38,15 +38,22 @@ def copy_files(files_to_copy: List[Path], target_dir: Path):
 
 
 def assert_the_same_files_in_directories(dir1: Path, dir2: Path):
-    files1 = {f for f in dir1.glob("*") if f.name != "__pycache__"}
-    assert {f.name for f in files1} == {
-        f.name for f in dir2.glob("*") if f.name != "__pycache__"
+    files1 = {
+        f for f in dir1.glob("**/*") if f.is_file() and "__pycache__" not in f.parts
+    }
+    files2 = {
+        f for f in dir2.glob("**/*") if f.is_file() and "__pycache__" not in f.parts
+    }
+
+    assert {f.relative_to(dir1) for f in files1} == {
+        f.relative_to(dir2) for f in files2
     }
 
     for file_ in files1:
         content1 = file_.read_text()
-        content2 = dir2.joinpath(file_.name).read_text()
-        assert content1 == content2, file_.name
+        relative_path = file_.relative_to(dir1)
+        content2 = (dir2 / relative_path).read_text()
+        assert content1 == content2, relative_path
 
 
 def test_main_shows_version():
@@ -185,6 +192,21 @@ def test_main_shows_version():
             ),
             "client_only_used_inputs_and_enums",
             CLIENTS_PATH / "only_used_inputs_and_enums" / "expected_client",
+        ),
+        (
+            (
+                CLIENTS_PATH / "result_types_directory" / "pyproject.toml",
+                (
+                    CLIENTS_PATH / "result_types_directory" / "queries.graphql",
+                    CLIENTS_PATH / "result_types_directory" / "schema.graphql",
+                    CLIENTS_PATH / "result_types_directory" / "custom_scalars.py",
+                    CLIENTS_PATH / "result_types_directory" / "common_mixins.py",
+                    CLIENTS_PATH / "result_types_directory" / "mixins_a.py",
+                    CLIENTS_PATH / "result_types_directory" / "mixins_b.py",
+                ),
+            ),
+            "client_result_types_directory",
+            CLIENTS_PATH / "result_types_directory" / "expected_client",
         ),
     ],
     indirect=["project_dir"],


### PR DESCRIPTION
Dear Maintainers,

I am excited to propose an enhancement to library, which I believe will improve its usability.

**Issue Addressed**:
Currently, the library's hundreds of modules, including client enums, inputs, fragments, and the client itself, are housed in a single package directory. [More information is available in the issue.](https://github.com/mirumee/ariadne-codegen/issues/262)

**Proposed Change**:
To address this, I have implemented a feature that allows result types to be saved into a separate subdirectory. This feature is disabled by default and have no breaking changes for current users.

**Implementation Details**:
1. **Direct Integration into Client Generator**: Recognizing the limitation of being unable to save result types into a different directory without modifying package module, I've directly incorporated the necessary logic into the client generator.
2. **New Configuration Option**: A new parameter, `result_types_directory_name`, has been introduced. Users can specify the name of the subdirectory for result types using this parameter. If this parameter is omitted or left empty, the result types will be stored in the package root, maintaining the existing behavior.
3. **Compatibility with Current Plugins**: This feature has been tested to be fully compatible with all current plugins, 

Thank you for your time and for considering this contribution to the project. If you have any suggestions or remarks about the code changes, please feel free to comment here, and I will do my best to find a better solution.

Best regards,
Alex