### PR TITLE
Support different schema formats in the `graphqlschema` strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.12.0 (UNRELEASED)
+
+- Added support to `graphqlschema` for saving schema as a GraphQL file.
+
+
 ## 0.11.0 (2023-12-05)
 
 - Removed `model_rebuild` calls for generated input, fragment and result models. 

--- a/README.md
+++ b/README.md
@@ -323,22 +323,44 @@ Example with simple schema and few queries and mutations is available [here](htt
 
 ## Generating graphql schema's python representation
 
-Instead of generating client, you can generate file with a copy of GraphQL schema as `GraphQLSchema` declaration. To do this call `ariadne-codegen` with `graphqlschema` argument:
+Instead of generating a client, you can generate a file with a copy of a GraphQL schema. To do this call `ariadne-codegen` with `graphqlschema` argument:
+
 ```
 ariadne-codegen graphqlschema
 ```
 
-`graphqlschema` mode reads configuration from the same place as [`client`](#configuration) but uses only `schema_path`, `remote_schema_url`, `remote_schema_headers`, `remote_schema_verify_ssl` and `plugins` options with addition to some extra options specific to it:
+`graphqlschema` mode reads configuration from the same place as [`client`](#configuration) but uses only `schema_path`, `remote_schema_url`, `remote_schema_headers`, `remote_schema_verify_ssl` options to retrieve the schema and `plugins` option to load plugins.
 
-- `target_file_path` (defaults to `"schema.py"`) - destination path for generated file
-- `schema_variable_name` (defaults to `"schema"`) - name for schema variable, must be valid python identifier
-- `type_map_variable_name` (defaults to `"type_map"`) - name for type map variable, must be valid python identifier
+In addition to the above, `graphqlschema` mode also accepts additional settings specific to it:
 
-Generated file contains:
+
+### `target_file_path`
+
+A string with destination path for generated file. Must be either a Python (`.py`), or GraphQL (`.graphql` or `.gql`) file.
+
+Defaults to `schema.py`.
+
+Generated Python file will contain:
 
 - Necessary imports
 - Type map declaration `{type_map_variable_name}: TypeMap = {...}`
 - Schema declaration `{schema_variable_name}: GraphQLSchema = GraphQLSchema(...)`
+
+Generated GraphQL file will contain a formatted output of the `print_schema` function from the `graphql-core` package.
+
+
+### `schema_variable_name`
+
+A string with a name for schema variable, must be valid python identifier.
+
+Defaults to `"schema"`. Used only if target is a Python file.
+
+
+### `type_map_variable_name`
+
+A string with a name for type map variable, must be valid python identifier.
+
+Defaults to `"type_map"`. Used only if target is a Python file.
 
 
 ## Contributing

--- a/ariadne_codegen/graphql_schema_generators/schema.py
+++ b/ariadne_codegen/graphql_schema_generators/schema.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from graphql import GraphQLSchema
 from graphql.type.schema import TypeMap
+from graphql import print_schema
 
 from ..codegen import (
     generate_ann_assign,
@@ -23,7 +24,11 @@ from .named_types import generate_named_type
 from .utils import get_optional_named_type
 
 
-def generate_graphql_schema_file(
+def generate_graphql_schema_graphql_file(schema: GraphQLSchema, target_file_path: str):
+    Path(target_file_path).write_text(print_schema(schema), encoding="UTF-8")
+
+
+def generate_graphql_schema_python_file(
     schema: GraphQLSchema,
     target_file_path: str,
     type_map_name: str,

--- a/ariadne_codegen/graphql_schema_generators/schema.py
+++ b/ariadne_codegen/graphql_schema_generators/schema.py
@@ -1,9 +1,8 @@
 import ast
 from pathlib import Path
 
-from graphql import GraphQLSchema
+from graphql import GraphQLSchema, print_schema
 from graphql.type.schema import TypeMap
-from graphql import print_schema
 
 from ..codegen import (
     generate_ann_assign,

--- a/ariadne_codegen/main.py
+++ b/ariadne_codegen/main.py
@@ -5,7 +5,10 @@ from graphql import assert_valid_schema
 
 from .client_generators.package import get_package_generator
 from .config import get_client_settings, get_config_dict, get_graphql_schema_settings
-from .graphql_schema_generators.schema import generate_graphql_schema_file
+from .graphql_schema_generators.schema import (
+    generate_graphql_schema_graphql_file,
+    generate_graphql_schema_python_file,
+)
 from .plugins.explorer import get_plugins_types
 from .plugins.manager import PluginManager
 from .schema import (
@@ -99,9 +102,15 @@ def graphql_schema(config_dict):
 
     sys.stdout.write(settings.used_settings_message)
 
-    generate_graphql_schema_file(
-        schema=schema,
-        target_file_path=settings.target_file_path,
-        type_map_name=settings.type_map_variable_name,
-        schema_variable_name=settings.schema_variable_name,
-    )
+    if settings.target_file_format == "py":
+        generate_graphql_schema_python_file(
+            schema=schema,
+            target_file_path=settings.target_file_path,
+            type_map_name=settings.type_map_variable_name,
+            schema_variable_name=settings.schema_variable_name,
+        )
+    else:
+        generate_graphql_schema_graphql_file(
+            schema=schema,
+            target_file_path=settings.target_file_path,
+        )

--- a/ariadne_codegen/settings.py
+++ b/ariadne_codegen/settings.py
@@ -257,7 +257,7 @@ def assert_string_is_valid_schema_target_filename(filename: str):
             f"Provided file name {filename} is missing a file type."
         )
 
-    file_type = file_type[1:].lower() 
+    file_type = file_type[1:].lower()
     if file_type not in ("py", "graphql", "gql"):
         raise InvalidConfiguration(
             f"Provided file name {filename} has an invalid type {file_type}."

--- a/tests/graphql_schema_generators/test_schema.py
+++ b/tests/graphql_schema_generators/test_schema.py
@@ -1,9 +1,10 @@
 import ast
 
-from graphql import Undefined, build_schema
+from graphql import Undefined, build_schema, print_schema
 
 from ariadne_codegen.graphql_schema_generators.schema import (
-    generate_graphql_schema_file,
+    generate_graphql_schema_graphql_file,
+    generate_graphql_schema_python_file,
     generate_schema,
     generate_schema_module,
     generate_type_map,
@@ -28,11 +29,24 @@ SCHEMA_STR = """
 """
 
 
-def test_generate_graphql_schema_file_creates_file_with_variables(tmp_path):
+def test_generate_graphql_schema_graphql_file_creates_file_printed_schema(tmp_path):
+    schema = build_schema(SCHEMA_STR)
+    file_path = tmp_path / "test_schema.graphql"
+
+    generate_graphql_schema_graphql_file(schema, file_path.as_posix())
+
+    assert file_path.exists()
+    assert file_path.is_file()
+    with file_path.open() as file_:
+        content = file_.read()
+        assert content == print_schema(schema)
+
+
+def test_generate_graphql_schema_python_file_creates_file_with_variables(tmp_path):
     schema = build_schema(SCHEMA_STR)
     file_path = tmp_path / "test_schema.py"
 
-    generate_graphql_schema_file(schema, file_path.as_posix(), "type_map", "schema")
+    generate_graphql_schema_python_file(schema, file_path.as_posix(), "type_map", "schema")
 
     assert file_path.exists()
     assert file_path.is_file()

--- a/tests/graphql_schema_generators/test_schema.py
+++ b/tests/graphql_schema_generators/test_schema.py
@@ -29,7 +29,9 @@ SCHEMA_STR = """
 """
 
 
-def test_generate_graphql_schema_graphql_file_creates_file_printed_schema(tmp_path):
+def test_generate_graphql_schema_graphql_file_creates_file_with_printed_schema(
+    tmp_path,
+):
     schema = build_schema(SCHEMA_STR)
     file_path = tmp_path / "test_schema.graphql"
 
@@ -42,11 +44,15 @@ def test_generate_graphql_schema_graphql_file_creates_file_printed_schema(tmp_pa
         assert content == print_schema(schema)
 
 
-def test_generate_graphql_schema_python_file_creates_file_with_variables(tmp_path):
+def test_generate_graphql_schema_python_file_creates_py_file_with_variables(
+    tmp_path,
+):
     schema = build_schema(SCHEMA_STR)
     file_path = tmp_path / "test_schema.py"
 
-    generate_graphql_schema_python_file(schema, file_path.as_posix(), "type_map", "schema")
+    generate_graphql_schema_python_file(
+        schema, file_path.as_posix(), "type_map", "schema"
+    )
 
     assert file_path.exists()
     assert file_path.is_file()

--- a/tests/main/graphql_schemas/example/expected_schema.gql
+++ b/tests/main/graphql_schemas/example/expected_schema.gql
@@ -1,0 +1,59 @@
+type Query {
+  users(country: String): [User!]!
+}
+
+type Mutation {
+  userCreate(userData: UserCreateInput!): User
+  userPreferences(data: UserPreferencesInput): Boolean!
+}
+
+input UserCreateInput {
+  firstName: String
+  lastName: String
+  email: String!
+  favouriteColor: Color
+  location: LocationInput
+}
+
+input LocationInput {
+  city: String
+  country: String
+}
+
+type User {
+  id: ID!
+  firstName: String
+  lastName: String
+  email: String!
+  favouriteColor: Color
+  location: Location
+}
+
+type Location {
+  city: String
+  country: String
+}
+
+enum Color {
+  BLACK
+  WHITE
+  RED
+  GREEN
+  BLUE
+  YELLOW
+}
+
+input UserPreferencesInput {
+  luckyNumber: Int = 7
+  favouriteWord: String = "word"
+  colorOpacity: Float = 1
+  excludedTags: [String!] = ["offtop", "tag123"]
+  notificationsPreferences: NotificationsPreferencesInput! = {receiveMails: true, receivePushNotifications: true, receiveSms: false, title: "Mr"}
+}
+
+input NotificationsPreferencesInput {
+  receiveMails: Boolean!
+  receivePushNotifications: Boolean!
+  receiveSms: Boolean!
+  title: String!
+}

--- a/tests/main/graphql_schemas/example/expected_schema.graphql
+++ b/tests/main/graphql_schemas/example/expected_schema.graphql
@@ -1,0 +1,59 @@
+type Query {
+  users(country: String): [User!]!
+}
+
+type Mutation {
+  userCreate(userData: UserCreateInput!): User
+  userPreferences(data: UserPreferencesInput): Boolean!
+}
+
+input UserCreateInput {
+  firstName: String
+  lastName: String
+  email: String!
+  favouriteColor: Color
+  location: LocationInput
+}
+
+input LocationInput {
+  city: String
+  country: String
+}
+
+type User {
+  id: ID!
+  firstName: String
+  lastName: String
+  email: String!
+  favouriteColor: Color
+  location: Location
+}
+
+type Location {
+  city: String
+  country: String
+}
+
+enum Color {
+  BLACK
+  WHITE
+  RED
+  GREEN
+  BLUE
+  YELLOW
+}
+
+input UserPreferencesInput {
+  luckyNumber: Int = 7
+  favouriteWord: String = "word"
+  colorOpacity: Float = 1
+  excludedTags: [String!] = ["offtop", "tag123"]
+  notificationsPreferences: NotificationsPreferencesInput! = {receiveMails: true, receivePushNotifications: true, receiveSms: false, title: "Mr"}
+}
+
+input NotificationsPreferencesInput {
+  receiveMails: Boolean!
+  receivePushNotifications: Boolean!
+  receiveSms: Boolean!
+  title: String!
+}

--- a/tests/main/graphql_schemas/example/pyproject-schema-gql.toml
+++ b/tests/main/graphql_schemas/example/pyproject-schema-gql.toml
@@ -1,0 +1,3 @@
+[tool.ariadne-codegen]
+schema_path = "schema.graphql"
+target_file_path = "expected_schema.gql"

--- a/tests/main/graphql_schemas/example/pyproject-schema-graphql.toml
+++ b/tests/main/graphql_schemas/example/pyproject-schema-graphql.toml
@@ -1,0 +1,3 @@
+[tool.ariadne-codegen]
+schema_path = "schema.graphql"
+target_file_path = "expected_schema.graphql"

--- a/tests/main/test_main.py
+++ b/tests/main/test_main.py
@@ -315,6 +315,22 @@ def test_main_can_read_config_from_provided_file(tmp_path):
             "schema.py",
             GRAPHQL_SCHEMAS_PATH / "all_types" / "expected_schema.py",
         ),
+        (
+            (
+                GRAPHQL_SCHEMAS_PATH / "example" / "pyproject-schema-graphql.toml",
+                (GRAPHQL_SCHEMAS_PATH / "example" / "schema.graphql",),
+            ),
+            "expected_schema.graphql",
+            GRAPHQL_SCHEMAS_PATH / "example" / "expected_schema.graphql",
+        ),
+        (
+            (
+                GRAPHQL_SCHEMAS_PATH / "example" / "pyproject-schema-gql.toml",
+                (GRAPHQL_SCHEMAS_PATH / "example" / "schema.graphql",),
+            ),
+            "expected_schema.gql",
+            GRAPHQL_SCHEMAS_PATH / "example" / "expected_schema.gql",
+        ),
     ],
     indirect=["project_dir"],
 )

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -226,6 +226,45 @@ def test_graphq_schema_settings_without_schema_path_with_remote_schema_url_is_va
     assert not settings.schema_path
 
 
+def test_graphql_schema_settings_with_target_file_path_with_py_extension_is_valid():
+    settings = GraphQLSchemaSettings(
+        remote_schema_url="http://testserver/graphq/",
+        target_file_path="schema_file.py",
+    )
+
+    assert settings.target_file_path == "schema_file.py"
+    assert settings.target_file_format == "py"
+
+
+def test_graphql_schema_settings_with_target_file_path_with_graphql_extension_is_valid():
+    settings = GraphQLSchemaSettings(
+        remote_schema_url="http://testserver/graphq/",
+        target_file_path="schema_file.graphql",
+    )
+
+    assert settings.target_file_path == "schema_file.graphql"
+    assert settings.target_file_format == "graphql"
+
+
+def test_graphql_schema_settings_with_target_file_path_with_graphql_extension_is_valid():
+    settings = GraphQLSchemaSettings(
+        remote_schema_url="http://testserver/graphq/",
+        target_file_path="schema_file.gql",
+    )
+
+    assert settings.target_file_path == "schema_file.gql"
+    assert settings.target_file_format == "gql"
+
+
+def test_graphql_schema_settings_target_file_format_is_lowercased():
+    settings = GraphQLSchemaSettings(
+        remote_schema_url="http://testserver/graphq/",
+        target_file_path="schema_file.GQL",
+    )
+
+    assert settings.target_file_format == "gql"
+
+
 def test_graphq_schema_settings_without_schema_path_or_remote_schema_url_is_not_valid():
     with pytest.raises(InvalidConfiguration):
         GraphQLSchemaSettings()
@@ -234,6 +273,22 @@ def test_graphq_schema_settings_without_schema_path_or_remote_schema_url_is_not_
 def test_graphql_schema_settings_raises_invalid_configuration_for_invalid_schema_path():
     with pytest.raises(InvalidConfiguration):
         GraphQLSchemaSettings(schema_path="not_exisitng.graphql")
+
+
+def test_graphql_schema_settings_with_target_file_path_missing_extension_raises_exception():
+    with pytest.raises(InvalidConfiguration):
+        GraphQLSchemaSettings(
+            remote_schema_url="http://testserver/graphq/",
+            target_file_path="schema_file",
+        )
+
+
+def test_graphql_schema_settings_with_target_file_path_invalid_extension_raises_exception():
+    with pytest.raises(InvalidConfiguration):
+        GraphQLSchemaSettings(
+            remote_schema_url="http://testserver/graphq/",
+            target_file_path="schema_file.invalid",
+        )
 
 
 def test_graphql_schema_settings_with_invalid_schema_variable_name_raises_exception():

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,3 +1,4 @@
+# pylint: disable=line-too-long
 import os
 from pathlib import Path
 from textwrap import dedent
@@ -246,7 +247,7 @@ def test_graphql_schema_settings_with_target_file_path_with_graphql_extension_is
     assert settings.target_file_format == "graphql"
 
 
-def test_graphql_schema_settings_with_target_file_path_with_graphql_extension_is_valid():
+def test_graphql_schema_settings_with_target_file_path_with_gql_extension_is_valid():
     settings = GraphQLSchemaSettings(
         remote_schema_url="http://testserver/graphq/",
         target_file_path="schema_file.gql",

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,4 +1,3 @@
-# pylint: disable=line-too-long
 import os
 from pathlib import Path
 from textwrap import dedent
@@ -237,7 +236,7 @@ def test_graphql_schema_settings_with_target_file_path_with_py_extension_is_vali
     assert settings.target_file_format == "py"
 
 
-def test_graphql_schema_settings_with_target_file_path_with_graphql_extension_is_valid():
+def test_graphql_schema_settings_with_target_file_with_graphql_extension_is_valid():
     settings = GraphQLSchemaSettings(
         remote_schema_url="http://testserver/graphq/",
         target_file_path="schema_file.graphql",
@@ -276,7 +275,7 @@ def test_graphql_schema_settings_raises_invalid_configuration_for_invalid_schema
         GraphQLSchemaSettings(schema_path="not_exisitng.graphql")
 
 
-def test_graphql_schema_settings_with_target_file_path_missing_extension_raises_exception():
+def test_graphql_schema_settings_with_target_file_missing_extension_raises_exception():
     with pytest.raises(InvalidConfiguration):
         GraphQLSchemaSettings(
             remote_schema_url="http://testserver/graphq/",
@@ -284,7 +283,7 @@ def test_graphql_schema_settings_with_target_file_path_missing_extension_raises_
         )
 
 
-def test_graphql_schema_settings_with_target_file_path_invalid_extension_raises_exception():
+def test_graphql_schema_settings_with_target_file_invalid_extension_raises_exception():
     with pytest.raises(InvalidConfiguration):
         GraphQLSchemaSettings(
             remote_schema_url="http://testserver/graphq/",


### PR DESCRIPTION
This PR updates the `graphqlschema` strategy to generate a different schema file depending on `target_file_path` pointing to the `*.py` file or `*.graphql` (or `.gql`) file.

Fixes #211
Superseds #214