### PR TITLE
Fix blank line between class and first method not being formatted out.

### DIFF
--- a/ariadne_codegen/client_generators/client.py
+++ b/ariadne_codegen/client_generators/client.py
@@ -141,15 +141,15 @@ class ClientGenerator:
                 raise NotSupported(
                     "Subscriptions are only available when using async client."
                 )
-            method_def: Union[
-                ast.FunctionDef, ast.AsyncFunctionDef
-            ] = self._generate_subscription_method_def(
-                name=name,
-                operation_name=operation_name,
-                return_type=return_type,
-                arguments=arguments,
-                arguments_dict=arguments_dict,
-                operation_str=operation_str,
+            method_def: Union[ast.FunctionDef, ast.AsyncFunctionDef] = (
+                self._generate_subscription_method_def(
+                    name=name,
+                    operation_name=operation_name,
+                    return_type=return_type,
+                    arguments=arguments,
+                    arguments_dict=arguments_dict,
+                    operation_str=operation_str,
+                )
             )
         elif async_:
             method_def = self._generate_async_method(

--- a/ariadne_codegen/client_generators/result_fields.py
+++ b/ariadne_codegen/client_generators/result_fields.py
@@ -89,9 +89,9 @@ def parse_operation_field(
             schema=schema,
             field_node=field,
             custom_scalars=custom_scalars if custom_scalars else {},
-            fragments_definitions=fragments_definitions
-            if fragments_definitions
-            else {},
+            fragments_definitions=(
+                fragments_definitions if fragments_definitions else {}
+            ),
         )
     )
 

--- a/ariadne_codegen/utils.py
+++ b/ariadne_codegen/utils.py
@@ -25,11 +25,29 @@ def ast_to_str(
 ) -> str:
     """Convert ast object into string."""
     code = ast.unparse(ast_obj)
+    code = remove_blank_line_between_class_and_content(code)
     if remove_unused_imports:
         code = fix_code(code, remove_all_unused_imports=True)
     if multiline_strings:
         code = format_multiline_strings(code, offset=multiline_strings_offset)
     return format_str(isort.code(code), mode=Mode())
+
+
+def remove_blank_line_between_class_and_content(code: str) -> str:
+    """Removes blank lines between class and first method.
+
+    We are doing this for code style consistency and backwards compatibility.
+    """
+    code_lines: line[str] = []
+    skip_blank_lines = False
+    for line in code.splitlines():
+        if skip_blank_lines and line:
+            skip_blank_lines = False
+        elif line.startswith("class "):
+            skip_blank_lines = True
+        if not skip_blank_lines or line:
+            code_lines.append(line)
+    return "\n".join(code_lines)
 
 
 def str_to_snake_case(name: str) -> str:

--- a/ariadne_codegen/utils.py
+++ b/ariadne_codegen/utils.py
@@ -2,7 +2,7 @@ import ast
 import re
 from keyword import iskeyword
 from textwrap import indent
-from typing import Optional
+from typing import List, Optional
 
 import isort
 from autoflake import fix_code  # type: ignore
@@ -38,7 +38,7 @@ def remove_blank_line_between_class_and_content(code: str) -> str:
 
     We are doing this for code style consistency and backwards compatibility.
     """
-    code_lines: line[str] = []
+    code_lines: List[str] = []
     skip_blank_lines = False
     for line in code.splitlines():
         if skip_blank_lines and line:

--- a/tests/main/clients/inline_fragments/expected_client/union_a.py
+++ b/tests/main/clients/inline_fragments/expected_client/union_a.py
@@ -6,9 +6,9 @@ from .base_model import BaseModel
 
 
 class UnionA(BaseModel):
-    query_u: Union[
-        "UnionAQueryUTypeA", "UnionAQueryUTypeB", "UnionAQueryUTypeC"
-    ] = Field(alias="queryU", discriminator="typename__")
+    query_u: Union["UnionAQueryUTypeA", "UnionAQueryUTypeB", "UnionAQueryUTypeC"] = (
+        Field(alias="queryU", discriminator="typename__")
+    )
 
 
 class UnionAQueryUTypeA(BaseModel):

--- a/tests/main/clients/inline_fragments/expected_client/union_b.py
+++ b/tests/main/clients/inline_fragments/expected_client/union_b.py
@@ -6,9 +6,9 @@ from .base_model import BaseModel
 
 
 class UnionB(BaseModel):
-    query_u: Union[
-        "UnionBQueryUTypeA", "UnionBQueryUTypeB", "UnionBQueryUTypeC"
-    ] = Field(alias="queryU", discriminator="typename__")
+    query_u: Union["UnionBQueryUTypeA", "UnionBQueryUTypeB", "UnionBQueryUTypeC"] = (
+        Field(alias="queryU", discriminator="typename__")
+    )
 
 
 class UnionBQueryUTypeA(BaseModel):

--- a/tests/main/clients/shorter_results/expected_client/client.py
+++ b/tests/main/clients/shorter_results/expected_client/client.py
@@ -133,9 +133,7 @@ class Client(AsyncBaseClient):
         data = self.get_data(response)
         return ListTypeA.model_validate(data).list_optional_type_a
 
-    async def get_animal_by_name(
-        self, name: str, **kwargs: Any
-    ) -> Union[
+    async def get_animal_by_name(self, name: str, **kwargs: Any) -> Union[
         GetAnimalByNameAnimalByNameAnimal,
         GetAnimalByNameAnimalByNameCat,
         GetAnimalByNameAnimalByNameDog,
@@ -163,9 +161,7 @@ class Client(AsyncBaseClient):
         data = self.get_data(response)
         return GetAnimalByName.model_validate(data).animal_by_name
 
-    async def list_animals(
-        self, **kwargs: Any
-    ) -> List[
+    async def list_animals(self, **kwargs: Any) -> List[
         Union[
             ListAnimalsListAnimalsAnimal,
             ListAnimalsListAnimalsCat,


### PR DESCRIPTION
In the latest release (2024.1), black was changed to don't remove blank line between `class` and first method. This PR adds small format function that still forces this behavior in generated code, for code style consistency between generated and implemented client parts.

Rel: https://github.com/psf/black/issues/619