### PR TITLE
fix: Include `model_rebuild` for input types as well 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## Unreleased
+
+- Fixed `model_rebuild` for input types with forward references.
+
+
 ## 0.13.0 (2024-03-4)
 
 - Fixed `str_to_snake_case` utility to capture fully capitalized words followed by an underscore.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # CHANGELOG
 
-## Unreleased
+## 0.14.0 (Unreleased)
 
-- Fixed `model_rebuild` for input types with forward references.
+- Re-added `model_rebuild` calls for input types with forward references.
 
 
 ## 0.13.0 (2024-03-4)

--- a/ariadne_codegen/client_generators/input_types.py
+++ b/ariadne_codegen/client_generators/input_types.py
@@ -19,7 +19,7 @@ from ..codegen import (
     generate_method_call,
     generate_module,
     generate_pydantic_field,
-    include_model_rebuild,
+    model_has_forward_refs,
 )
 from ..plugins.manager import PluginManager
 from ..utils import process_name
@@ -92,7 +92,7 @@ class InputTypesGenerator:
         model_rebuild_calls = [
             generate_expr(generate_method_call(class_def.name, MODEL_REBUILD_METHOD))
             for class_def in class_defs
-            if include_model_rebuild(class_def)
+            if model_has_forward_refs(class_def)
         ]
 
         module_body = (

--- a/ariadne_codegen/client_generators/input_types.py
+++ b/ariadne_codegen/client_generators/input_types.py
@@ -9,7 +9,6 @@ from graphql import (
     GraphQLSchema,
 )
 
-
 from ..codegen import (
     generate_ann_assign,
     generate_class_def,

--- a/ariadne_codegen/client_generators/result_types.py
+++ b/ariadne_codegen/client_generators/result_types.py
@@ -40,7 +40,7 @@ from ..codegen import (
     generate_module,
     generate_pass,
     generate_pydantic_field,
-    include_model_rebuild,
+    model_has_forward_refs,
 )
 from ..exceptions import NotSupported, ParsingError
 from ..plugins.manager import PluginManager
@@ -159,7 +159,7 @@ class ResultTypesGenerator:
         model_rebuild_calls = [
             generate_expr(generate_method_call(class_def.name, MODEL_REBUILD_METHOD))
             for class_def in self._class_defs
-            if include_model_rebuild(class_def)
+            if model_has_forward_refs(class_def)
         ]
 
         module_body = (

--- a/ariadne_codegen/codegen.py
+++ b/ariadne_codegen/codegen.py
@@ -332,3 +332,25 @@ def generate_yield(value: Optional[ast.expr] = None) -> ast.Yield:
 
 def generate_pass() -> ast.Pass:
     return ast.Pass()
+
+
+def include_model_rebuild(class_def: ast.ClassDef) -> bool:
+    visitor = ClassDefNamesVisitor()
+    visitor.visit(class_def)
+    return visitor.found_name_with_quote
+
+
+class ClassDefNamesVisitor(ast.NodeVisitor):
+    def __init__(self):
+        self.found_name_with_quote = False
+
+    def visit_Name(self, node):  # pylint: disable=C0103
+        if '"' in node.id:
+            self.found_name_with_quote = True
+        self.generic_visit(node)
+
+    def visit_Subscript(self, node):  # pylint: disable=C0103
+        if isinstance(node.value, ast.Name) and node.value.id == "Literal":
+            return
+
+        self.generic_visit(node)

--- a/ariadne_codegen/codegen.py
+++ b/ariadne_codegen/codegen.py
@@ -334,7 +334,7 @@ def generate_pass() -> ast.Pass:
     return ast.Pass()
 
 
-def include_model_rebuild(class_def: ast.ClassDef) -> bool:
+def model_has_forward_refs(class_def: ast.ClassDef) -> bool:
     visitor = ClassDefNamesVisitor()
     visitor.visit(class_def)
     return visitor.found_name_with_quote

--- a/tests/main/clients/example/expected_client/input_types.py
+++ b/tests/main/clients/example/expected_client/input_types.py
@@ -46,3 +46,7 @@ class NotificationsPreferencesInput(BaseModel):
     receive_push_notifications: bool = Field(alias="receivePushNotifications")
     receive_sms: bool = Field(alias="receiveSms")
     title: str
+
+
+UserCreateInput.model_rebuild()
+UserPreferencesInput.model_rebuild()

--- a/tests/main/clients/only_used_inputs_and_enums/expected_client/input_types.py
+++ b/tests/main/clients/only_used_inputs_and_enums/expected_client/input_types.py
@@ -26,3 +26,8 @@ class InputAB(BaseModel):
 
 class InputE(BaseModel):
     val: EnumE
+
+
+InputA.model_rebuild()
+InputAA.model_rebuild()
+InputAB.model_rebuild()


### PR DESCRIPTION
Followup from https://github.com/mirumee/ariadne-codegen/pull/278 and https://github.com/mirumee/ariadne-codegen/issues/276. We added back support to call
`model_rebuild` when needed for result types but didn't add it for input
types. Since input types can also require model rebuild when containing
nested fields we need to call `include_model_rebuild` for these types as
well.