### PR TITLE
respect convert_to_snake_case settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Changed code typing to satisfy MyPy 1.11.0 version
 - Added support for `async_client=false` to work with `enable_custom_operations=true`
-
+- Fix propagating `convert_to_snake_case` to clients during package generation
 
 ## 0.14.0 (2024-07-17)
 

--- a/ariadne_codegen/client_generators/package.py
+++ b/ariadne_codegen/client_generators/package.py
@@ -46,44 +46,44 @@ from .scalars import ScalarData
 
 class PackageGenerator:
     def __init__(
-            self,
-            package_name: str,
-            target_path: str,
-            schema: GraphQLSchema,
-            init_generator: InitFileGenerator,
-            client_generator: ClientGenerator,
-            enums_generator: EnumsGenerator,
-            input_types_generator: InputTypesGenerator,
-            fragments_generator: FragmentsGenerator,
-            custom_fields_generator: Optional[CustomFieldsGenerator] = None,
-            custom_fields_typing_generator: Optional[CustomFieldsTypingGenerator] = None,
-            custom_query_generator: Optional[CustomOperationGenerator] = None,
-            custom_mutation_generator: Optional[CustomOperationGenerator] = None,
-            fragments_definitions: Optional[Dict[str, FragmentDefinitionNode]] = None,
-            client_name: str = "Client",
-            async_client: bool = True,
-            base_client_name: str = "AsyncBaseClient",
-            base_client_file_path: str = DEFAULT_ASYNC_BASE_CLIENT_PATH.as_posix(),
-            client_file_name: str = "client",
-            enums_module_name: str = "enums",
-            input_types_module_name: str = "input_types",
-            fragments_module_name: str = "fragments",
-            custom_help_field_module_name: str = "custom_typing_fields",
-            comments_strategy: CommentsStrategy = CommentsStrategy.STABLE,
-            queries_source: str = "",
-            schema_source: str = "",
-            convert_to_snake_case: bool = True,
-            include_all_inputs: bool = True,
-            include_all_enums: bool = True,
-            base_model_file_path: str = BASE_MODEL_FILE_PATH.as_posix(),
-            base_schema_root_file_path: str = BASE_OPERATION_FILE_PATH.as_posix(),
-            base_model_import: ast.ImportFrom = BASE_MODEL_IMPORT,
-            upload_import: ast.ImportFrom = UPLOAD_IMPORT,
-            unset_import: ast.ImportFrom = UNSET_IMPORT,
-            files_to_include: Optional[List[str]] = None,
-            custom_scalars: Optional[Dict[str, ScalarData]] = None,
-            plugin_manager: Optional[PluginManager] = None,
-            enable_custom_operations: bool = False,
+        self,
+        package_name: str,
+        target_path: str,
+        schema: GraphQLSchema,
+        init_generator: InitFileGenerator,
+        client_generator: ClientGenerator,
+        enums_generator: EnumsGenerator,
+        input_types_generator: InputTypesGenerator,
+        fragments_generator: FragmentsGenerator,
+        custom_fields_generator: Optional[CustomFieldsGenerator] = None,
+        custom_fields_typing_generator: Optional[CustomFieldsTypingGenerator] = None,
+        custom_query_generator: Optional[CustomOperationGenerator] = None,
+        custom_mutation_generator: Optional[CustomOperationGenerator] = None,
+        fragments_definitions: Optional[Dict[str, FragmentDefinitionNode]] = None,
+        client_name: str = "Client",
+        async_client: bool = True,
+        base_client_name: str = "AsyncBaseClient",
+        base_client_file_path: str = DEFAULT_ASYNC_BASE_CLIENT_PATH.as_posix(),
+        client_file_name: str = "client",
+        enums_module_name: str = "enums",
+        input_types_module_name: str = "input_types",
+        fragments_module_name: str = "fragments",
+        custom_help_field_module_name: str = "custom_typing_fields",
+        comments_strategy: CommentsStrategy = CommentsStrategy.STABLE,
+        queries_source: str = "",
+        schema_source: str = "",
+        convert_to_snake_case: bool = True,
+        include_all_inputs: bool = True,
+        include_all_enums: bool = True,
+        base_model_file_path: str = BASE_MODEL_FILE_PATH.as_posix(),
+        base_schema_root_file_path: str = BASE_OPERATION_FILE_PATH.as_posix(),
+        base_model_import: ast.ImportFrom = BASE_MODEL_IMPORT,
+        upload_import: ast.ImportFrom = UPLOAD_IMPORT,
+        unset_import: ast.ImportFrom = UNSET_IMPORT,
+        files_to_include: Optional[List[str]] = None,
+        custom_scalars: Optional[Dict[str, ScalarData]] = None,
+        plugin_manager: Optional[PluginManager] = None,
+        enable_custom_operations: bool = False,
     ) -> None:
         self.package_path = Path(target_path) / package_name
 
@@ -156,16 +156,16 @@ class PackageGenerator:
         if self.enable_custom_operations:
             self._generate_custom_fields_typing()
             self._generate_custom_fields()
-            self.client_generator.add_execute_custom_operation_method()
+            self.client_generator.add_execute_custom_operation_method(self.async_client)
             if self.custom_query_generator:
                 self._generate_custom_queries()
                 self.client_generator.create_custom_operation_method(
-                    "query", OperationType.QUERY.value.upper()
+                    "query", OperationType.QUERY.value.upper(), self.async_client
                 )
             if self.custom_mutation_generator:
                 self._generate_custom_mutations()
                 self.client_generator.create_custom_operation_method(
-                    "mutation", OperationType.MUTATION.value.upper()
+                    "mutation", OperationType.MUTATION.value.upper(), self.async_client
                 )
 
         self._generate_client()
@@ -221,10 +221,10 @@ class PackageGenerator:
 
     def _include_exceptions(self):
         if self.base_client_file_path in (
-                DEFAULT_ASYNC_BASE_CLIENT_PATH,
-                DEFAULT_BASE_CLIENT_PATH,
-                DEFAULT_ASYNC_BASE_CLIENT_OPEN_TELEMETRY_PATH,
-                DEFAULT_BASE_CLIENT_OPEN_TELEMETRY_PATH,
+            DEFAULT_ASYNC_BASE_CLIENT_PATH,
+            DEFAULT_BASE_CLIENT_PATH,
+            DEFAULT_ASYNC_BASE_CLIENT_OPEN_TELEMETRY_PATH,
+            DEFAULT_BASE_CLIENT_OPEN_TELEMETRY_PATH,
         ):
             self.files_to_include.append(EXCEPTIONS_FILE_PATH)
             self.init_generator.add_import(
@@ -235,16 +235,16 @@ class PackageGenerator:
 
     def _validate_unique_file_names(self):
         file_names = (
-                [
-                    f"{self.client_file_name}.py",
-                    self.base_client_file_path.name,
-                    self.base_model_file_path.name,
-                    f"{self.enums_module_name}.py",
-                    f"{self.input_types_module_name}.py",
-                    f"{self.fragments_module_name}.py",
-                ]
-                + list(self._result_types_files.keys())
-                + [f.name for f in self.files_to_include]
+            [
+                f"{self.client_file_name}.py",
+                self.base_client_file_path.name,
+                self.base_model_file_path.name,
+                f"{self.enums_module_name}.py",
+                f"{self.input_types_module_name}.py",
+                f"{self.fragments_module_name}.py",
+            ]
+            + list(self._result_types_files.keys())
+            + [f.name for f in self.files_to_include]
         )
 
         if len(file_names) != len(set(file_names)):
@@ -327,7 +327,7 @@ class PackageGenerator:
 
     def _generate_fragments(self):
         if not set(self.fragments_definitions.keys()).difference(
-                self._unpacked_fragments
+            self._unpacked_fragments
         ):
             return
 
@@ -408,10 +408,10 @@ class PackageGenerator:
 
 
 def get_package_generator(
-        schema: GraphQLSchema,
-        fragments: List[FragmentDefinitionNode],
-        settings: ClientSettings,
-        plugin_manager: PluginManager,
+    schema: GraphQLSchema,
+    fragments: List[FragmentDefinitionNode],
+    settings: ClientSettings,
+    plugin_manager: PluginManager,
 ) -> PackageGenerator:
     init_generator = InitFileGenerator(plugin_manager=plugin_manager)
     client_generator = ClientGenerator(

--- a/ariadne_codegen/client_generators/package.py
+++ b/ariadne_codegen/client_generators/package.py
@@ -46,44 +46,44 @@ from .scalars import ScalarData
 
 class PackageGenerator:
     def __init__(
-        self,
-        package_name: str,
-        target_path: str,
-        schema: GraphQLSchema,
-        init_generator: InitFileGenerator,
-        client_generator: ClientGenerator,
-        enums_generator: EnumsGenerator,
-        input_types_generator: InputTypesGenerator,
-        fragments_generator: FragmentsGenerator,
-        custom_fields_generator: Optional[CustomFieldsGenerator] = None,
-        custom_fields_typing_generator: Optional[CustomFieldsTypingGenerator] = None,
-        custom_query_generator: Optional[CustomOperationGenerator] = None,
-        custom_mutation_generator: Optional[CustomOperationGenerator] = None,
-        fragments_definitions: Optional[Dict[str, FragmentDefinitionNode]] = None,
-        client_name: str = "Client",
-        async_client: bool = True,
-        base_client_name: str = "AsyncBaseClient",
-        base_client_file_path: str = DEFAULT_ASYNC_BASE_CLIENT_PATH.as_posix(),
-        client_file_name: str = "client",
-        enums_module_name: str = "enums",
-        input_types_module_name: str = "input_types",
-        fragments_module_name: str = "fragments",
-        custom_help_field_module_name: str = "custom_typing_fields",
-        comments_strategy: CommentsStrategy = CommentsStrategy.STABLE,
-        queries_source: str = "",
-        schema_source: str = "",
-        convert_to_snake_case: bool = True,
-        include_all_inputs: bool = True,
-        include_all_enums: bool = True,
-        base_model_file_path: str = BASE_MODEL_FILE_PATH.as_posix(),
-        base_schema_root_file_path: str = BASE_OPERATION_FILE_PATH.as_posix(),
-        base_model_import: ast.ImportFrom = BASE_MODEL_IMPORT,
-        upload_import: ast.ImportFrom = UPLOAD_IMPORT,
-        unset_import: ast.ImportFrom = UNSET_IMPORT,
-        files_to_include: Optional[List[str]] = None,
-        custom_scalars: Optional[Dict[str, ScalarData]] = None,
-        plugin_manager: Optional[PluginManager] = None,
-        enable_custom_operations: bool = False,
+            self,
+            package_name: str,
+            target_path: str,
+            schema: GraphQLSchema,
+            init_generator: InitFileGenerator,
+            client_generator: ClientGenerator,
+            enums_generator: EnumsGenerator,
+            input_types_generator: InputTypesGenerator,
+            fragments_generator: FragmentsGenerator,
+            custom_fields_generator: Optional[CustomFieldsGenerator] = None,
+            custom_fields_typing_generator: Optional[CustomFieldsTypingGenerator] = None,
+            custom_query_generator: Optional[CustomOperationGenerator] = None,
+            custom_mutation_generator: Optional[CustomOperationGenerator] = None,
+            fragments_definitions: Optional[Dict[str, FragmentDefinitionNode]] = None,
+            client_name: str = "Client",
+            async_client: bool = True,
+            base_client_name: str = "AsyncBaseClient",
+            base_client_file_path: str = DEFAULT_ASYNC_BASE_CLIENT_PATH.as_posix(),
+            client_file_name: str = "client",
+            enums_module_name: str = "enums",
+            input_types_module_name: str = "input_types",
+            fragments_module_name: str = "fragments",
+            custom_help_field_module_name: str = "custom_typing_fields",
+            comments_strategy: CommentsStrategy = CommentsStrategy.STABLE,
+            queries_source: str = "",
+            schema_source: str = "",
+            convert_to_snake_case: bool = True,
+            include_all_inputs: bool = True,
+            include_all_enums: bool = True,
+            base_model_file_path: str = BASE_MODEL_FILE_PATH.as_posix(),
+            base_schema_root_file_path: str = BASE_OPERATION_FILE_PATH.as_posix(),
+            base_model_import: ast.ImportFrom = BASE_MODEL_IMPORT,
+            upload_import: ast.ImportFrom = UPLOAD_IMPORT,
+            unset_import: ast.ImportFrom = UNSET_IMPORT,
+            files_to_include: Optional[List[str]] = None,
+            custom_scalars: Optional[Dict[str, ScalarData]] = None,
+            plugin_manager: Optional[PluginManager] = None,
+            enable_custom_operations: bool = False,
     ) -> None:
         self.package_path = Path(target_path) / package_name
 
@@ -156,16 +156,16 @@ class PackageGenerator:
         if self.enable_custom_operations:
             self._generate_custom_fields_typing()
             self._generate_custom_fields()
-            self.client_generator.add_execute_custom_operation_method(self.async_client)
+            self.client_generator.add_execute_custom_operation_method()
             if self.custom_query_generator:
                 self._generate_custom_queries()
                 self.client_generator.create_custom_operation_method(
-                    "query", OperationType.QUERY.value.upper(), self.async_client
+                    "query", OperationType.QUERY.value.upper()
                 )
             if self.custom_mutation_generator:
                 self._generate_custom_mutations()
                 self.client_generator.create_custom_operation_method(
-                    "mutation", OperationType.MUTATION.value.upper(), self.async_client
+                    "mutation", OperationType.MUTATION.value.upper()
                 )
 
         self._generate_client()
@@ -221,10 +221,10 @@ class PackageGenerator:
 
     def _include_exceptions(self):
         if self.base_client_file_path in (
-            DEFAULT_ASYNC_BASE_CLIENT_PATH,
-            DEFAULT_BASE_CLIENT_PATH,
-            DEFAULT_ASYNC_BASE_CLIENT_OPEN_TELEMETRY_PATH,
-            DEFAULT_BASE_CLIENT_OPEN_TELEMETRY_PATH,
+                DEFAULT_ASYNC_BASE_CLIENT_PATH,
+                DEFAULT_BASE_CLIENT_PATH,
+                DEFAULT_ASYNC_BASE_CLIENT_OPEN_TELEMETRY_PATH,
+                DEFAULT_BASE_CLIENT_OPEN_TELEMETRY_PATH,
         ):
             self.files_to_include.append(EXCEPTIONS_FILE_PATH)
             self.init_generator.add_import(
@@ -235,16 +235,16 @@ class PackageGenerator:
 
     def _validate_unique_file_names(self):
         file_names = (
-            [
-                f"{self.client_file_name}.py",
-                self.base_client_file_path.name,
-                self.base_model_file_path.name,
-                f"{self.enums_module_name}.py",
-                f"{self.input_types_module_name}.py",
-                f"{self.fragments_module_name}.py",
-            ]
-            + list(self._result_types_files.keys())
-            + [f.name for f in self.files_to_include]
+                [
+                    f"{self.client_file_name}.py",
+                    self.base_client_file_path.name,
+                    self.base_model_file_path.name,
+                    f"{self.enums_module_name}.py",
+                    f"{self.input_types_module_name}.py",
+                    f"{self.fragments_module_name}.py",
+                ]
+                + list(self._result_types_files.keys())
+                + [f.name for f in self.files_to_include]
         )
 
         if len(file_names) != len(set(file_names)):
@@ -327,7 +327,7 @@ class PackageGenerator:
 
     def _generate_fragments(self):
         if not set(self.fragments_definitions.keys()).difference(
-            self._unpacked_fragments
+                self._unpacked_fragments
         ):
             return
 
@@ -408,10 +408,10 @@ class PackageGenerator:
 
 
 def get_package_generator(
-    schema: GraphQLSchema,
-    fragments: List[FragmentDefinitionNode],
-    settings: ClientSettings,
-    plugin_manager: PluginManager,
+        schema: GraphQLSchema,
+        fragments: List[FragmentDefinitionNode],
+        settings: ClientSettings,
+        plugin_manager: PluginManager,
 ) -> PackageGenerator:
     init_generator = InitFileGenerator(plugin_manager=plugin_manager)
     client_generator = ClientGenerator(
@@ -456,7 +456,10 @@ def get_package_generator(
         plugin_manager=plugin_manager,
     )
     custom_fields_generator = CustomFieldsGenerator(
-        schema=schema, custom_scalars=settings.scalars, plugin_manager=plugin_manager
+        schema=schema,
+        custom_scalars=settings.scalars,
+        convert_to_snake_case=settings.convert_to_snake_case,
+        plugin_manager=plugin_manager,
     )
     custom_fields_typing_generator = CustomFieldsTypingGenerator(schema=schema)
     custom_query_generator = None
@@ -466,6 +469,7 @@ def get_package_generator(
             name="Query",
             base_name=BASE_GRAPHQL_OPERATION_CLASS_NAME,
             enums_module_name=settings.enums_module_name,
+            convert_to_snake_case=settings.convert_to_snake_case,
             custom_scalars=settings.scalars,
             plugin_manager=plugin_manager,
             arguments_generator=ArgumentsGenerator(
@@ -482,6 +486,7 @@ def get_package_generator(
             name="Mutation",
             base_name=BASE_GRAPHQL_OPERATION_CLASS_NAME,
             enums_module_name=settings.enums_module_name,
+            convert_to_snake_case=settings.convert_to_snake_case,
             custom_scalars=settings.scalars,
             plugin_manager=plugin_manager,
             arguments_generator=ArgumentsGenerator(

--- a/tests/client_generators/package_generator/test_generator_generation.py
+++ b/tests/client_generators/package_generator/test_generator_generation.py
@@ -81,10 +81,10 @@ def test_get_package_generator_without_default_settings(tmp_path: Path):
     custom_mutation_generator = package_generator.custom_mutation_generator
 
     # client generator
+    # pylint: disable=protected-access
     assert {i.module for i in client_generator._imports} == {
         "typing",
         "valid_file",
-        "base_model",
         "base_model",
     }
     assert (
@@ -96,6 +96,7 @@ def test_get_package_generator_without_default_settings(tmp_path: Path):
         == settings_without_defaults.scalars
     )
     assert client_generator.name == settings_without_defaults.client_name
+    # pylint: disable=protected-access
     assert (
         client_generator._class_def.bases[0].id
         == settings_without_defaults.base_client_name

--- a/tests/client_generators/package_generator/test_generator_generation.py
+++ b/tests/client_generators/package_generator/test_generator_generation.py
@@ -1,0 +1,167 @@
+from pathlib import Path
+
+from graphql import build_ast_schema, parse
+
+from ariadne_codegen.client_generators.package import get_package_generator
+from ariadne_codegen.client_generators.scalars import ScalarData
+from ariadne_codegen.plugins.manager import PluginManager
+from ariadne_codegen.settings import ClientSettings, CommentsStrategy
+
+
+def test_get_package_generator_without_default_settings(tmp_path: Path):
+    schema_path = tmp_path / "schema.graphql"
+    schema_path.touch()
+    queries_path = tmp_path / "queries.graphql"
+    queries_path.touch()
+    base_client_file_path = tmp_path / "valid_file.txt"
+    base_client_file_path.touch()
+    base_client_file_path.write_text("class Class")
+
+    test_schema = build_ast_schema(
+        parse(
+            """
+    schema {
+      query: Query
+      mutation: Mutation
+      subscription: Subscription
+    }
+    type Query {
+      query1(num: Int!): Int!
+    }
+    
+    type Mutation {
+        mutation1(num: Int!): Int!
+    }
+    
+    type Subscription {
+      subscription1(num: Int!): Int!
+    }
+    """
+        )
+    )
+
+    settings_without_defaults = ClientSettings(
+        schema_path=schema_path.as_posix(),
+        remote_schema_url="remote_schema_url",
+        remote_schema_headers={"header": "header"},
+        remote_schema_verify_ssl=False,
+        enable_custom_operations=True,
+        plugins=["imaplugin"],
+        queries_path=schema_path.as_posix(),
+        target_package_name="target_package_name",
+        target_package_path=tmp_path.as_posix(),
+        client_name="client_name",
+        client_file_name="client_file_name",
+        base_client_name="Class",
+        base_client_file_path=base_client_file_path.as_posix(),
+        enums_module_name="enums_module_name",
+        input_types_module_name="input_types_module_name",
+        fragments_module_name="fragments_module_name",
+        include_comments=CommentsStrategy.NONE,
+        convert_to_snake_case=False,
+        include_all_inputs=False,
+        include_all_enums=False,
+        async_client=False,
+        opentelemetry_client=True,
+        files_to_include=[schema_path.as_posix()],
+        scalars={"scalar1": ScalarData(type_="str", graphql_name="scalar1")},
+    )
+    package_generator = get_package_generator(
+        schema=test_schema,
+        fragments=[],
+        settings=settings_without_defaults,
+        plugin_manager=PluginManager(schema=test_schema),
+    )
+
+    # separate out the generated clients
+    client_generator = package_generator.client_generator
+    input_types_generator = package_generator.input_types_generator
+    fragments_generator = package_generator.fragments_generator
+    custom_query_generator = package_generator.custom_query_generator
+    custom_mutation_generator = package_generator.custom_mutation_generator
+
+    # client generator
+    assert {i.module for i in client_generator._imports} == {
+        "typing",
+        "valid_file",
+        "base_model",
+        "base_model",
+    }
+    assert (
+            client_generator.arguments_generator.convert_to_snake_case
+            == settings_without_defaults.convert_to_snake_case
+    )
+    assert (
+            client_generator.arguments_generator.custom_scalars
+            == settings_without_defaults.scalars
+    )
+    assert client_generator.name == settings_without_defaults.client_name
+    assert (
+            client_generator._class_def.bases[0].id
+            == settings_without_defaults.base_client_name
+    )
+    assert (
+            client_generator.enums_module_name
+            == settings_without_defaults.enums_module_name
+    )
+    assert (
+            client_generator.input_types_module_name
+            == settings_without_defaults.input_types_module_name
+    )
+    assert client_generator.custom_scalars == settings_without_defaults.scalars
+    # input types generator
+    assert (
+            input_types_generator.enums_module
+            == settings_without_defaults.enums_module_name
+    )
+    assert (
+            input_types_generator.convert_to_snake_case
+            == settings_without_defaults.convert_to_snake_case
+    )
+    assert input_types_generator.custom_scalars == settings_without_defaults.scalars
+    # fragments generator
+    assert (
+            fragments_generator.enums_module_name
+            == settings_without_defaults.enums_module_name
+    )
+    assert (
+            fragments_generator.convert_to_snake_case
+            == settings_without_defaults.convert_to_snake_case
+    )
+    assert fragments_generator.custom_scalars == settings_without_defaults.scalars
+    # custom query generator
+    assert (
+            custom_query_generator.enums_module_name
+            == settings_without_defaults.enums_module_name
+    )
+    assert custom_query_generator.custom_scalars == settings_without_defaults.scalars
+    assert (
+            custom_query_generator.convert_to_snake_case
+            == settings_without_defaults.convert_to_snake_case
+    )
+    assert (
+            custom_query_generator.arguments_generator.convert_to_snake_case
+            == settings_without_defaults.convert_to_snake_case
+    )
+    assert (
+            custom_query_generator.arguments_generator.custom_scalars
+            == settings_without_defaults.scalars
+    )
+    # custom mutation generator
+    assert (
+            custom_mutation_generator.enums_module_name
+            == settings_without_defaults.enums_module_name
+    )
+    assert custom_mutation_generator.custom_scalars == settings_without_defaults.scalars
+    assert (
+            custom_mutation_generator.convert_to_snake_case
+            == settings_without_defaults.convert_to_snake_case
+    )
+    assert (
+            custom_mutation_generator.arguments_generator.convert_to_snake_case
+            == settings_without_defaults.convert_to_snake_case
+    )
+    assert (
+            custom_mutation_generator.arguments_generator.custom_scalars
+            == settings_without_defaults.scalars
+    )

--- a/tests/client_generators/package_generator/test_generator_generation.py
+++ b/tests/client_generators/package_generator/test_generator_generation.py
@@ -88,80 +88,80 @@ def test_get_package_generator_without_default_settings(tmp_path: Path):
         "base_model",
     }
     assert (
-            client_generator.arguments_generator.convert_to_snake_case
-            == settings_without_defaults.convert_to_snake_case
+        client_generator.arguments_generator.convert_to_snake_case
+        == settings_without_defaults.convert_to_snake_case
     )
     assert (
-            client_generator.arguments_generator.custom_scalars
-            == settings_without_defaults.scalars
+        client_generator.arguments_generator.custom_scalars
+        == settings_without_defaults.scalars
     )
     assert client_generator.name == settings_without_defaults.client_name
     assert (
-            client_generator._class_def.bases[0].id
-            == settings_without_defaults.base_client_name
+        client_generator._class_def.bases[0].id
+        == settings_without_defaults.base_client_name
     )
     assert (
-            client_generator.enums_module_name
-            == settings_without_defaults.enums_module_name
+        client_generator.enums_module_name
+        == settings_without_defaults.enums_module_name
     )
     assert (
-            client_generator.input_types_module_name
-            == settings_without_defaults.input_types_module_name
+        client_generator.input_types_module_name
+        == settings_without_defaults.input_types_module_name
     )
     assert client_generator.custom_scalars == settings_without_defaults.scalars
     # input types generator
     assert (
-            input_types_generator.enums_module
-            == settings_without_defaults.enums_module_name
+        input_types_generator.enums_module
+        == settings_without_defaults.enums_module_name
     )
     assert (
-            input_types_generator.convert_to_snake_case
-            == settings_without_defaults.convert_to_snake_case
+        input_types_generator.convert_to_snake_case
+        == settings_without_defaults.convert_to_snake_case
     )
     assert input_types_generator.custom_scalars == settings_without_defaults.scalars
     # fragments generator
     assert (
-            fragments_generator.enums_module_name
-            == settings_without_defaults.enums_module_name
+        fragments_generator.enums_module_name
+        == settings_without_defaults.enums_module_name
     )
     assert (
-            fragments_generator.convert_to_snake_case
-            == settings_without_defaults.convert_to_snake_case
+        fragments_generator.convert_to_snake_case
+        == settings_without_defaults.convert_to_snake_case
     )
     assert fragments_generator.custom_scalars == settings_without_defaults.scalars
     # custom query generator
     assert (
-            custom_query_generator.enums_module_name
-            == settings_without_defaults.enums_module_name
+        custom_query_generator.enums_module_name
+        == settings_without_defaults.enums_module_name
     )
     assert custom_query_generator.custom_scalars == settings_without_defaults.scalars
     assert (
-            custom_query_generator.convert_to_snake_case
-            == settings_without_defaults.convert_to_snake_case
+        custom_query_generator.convert_to_snake_case
+        == settings_without_defaults.convert_to_snake_case
     )
     assert (
-            custom_query_generator.arguments_generator.convert_to_snake_case
-            == settings_without_defaults.convert_to_snake_case
+        custom_query_generator.arguments_generator.convert_to_snake_case
+        == settings_without_defaults.convert_to_snake_case
     )
     assert (
-            custom_query_generator.arguments_generator.custom_scalars
-            == settings_without_defaults.scalars
+        custom_query_generator.arguments_generator.custom_scalars
+        == settings_without_defaults.scalars
     )
     # custom mutation generator
     assert (
-            custom_mutation_generator.enums_module_name
-            == settings_without_defaults.enums_module_name
+        custom_mutation_generator.enums_module_name
+        == settings_without_defaults.enums_module_name
     )
     assert custom_mutation_generator.custom_scalars == settings_without_defaults.scalars
     assert (
-            custom_mutation_generator.convert_to_snake_case
-            == settings_without_defaults.convert_to_snake_case
+        custom_mutation_generator.convert_to_snake_case
+        == settings_without_defaults.convert_to_snake_case
     )
     assert (
-            custom_mutation_generator.arguments_generator.convert_to_snake_case
-            == settings_without_defaults.convert_to_snake_case
+        custom_mutation_generator.arguments_generator.convert_to_snake_case
+        == settings_without_defaults.convert_to_snake_case
     )
     assert (
-            custom_mutation_generator.arguments_generator.custom_scalars
-            == settings_without_defaults.scalars
+        custom_mutation_generator.arguments_generator.custom_scalars
+        == settings_without_defaults.scalars
     )


### PR DESCRIPTION
fixes https://github.com/mirumee/ariadne-codegen/issues/275 by passing the `convert_to_snake_case` to various generators created via the `get_package_generator` function. 

adds a test that attempts to test that all the generator class fields that are determined by data passed in from `ClientSettings` are respected.

tested both via unit tests and by regenerating code in which i experienced this issue myself