### PR TITLE
chore: Pin dependencies to make CI pass

### DIFF
--- a/ariadne_codegen/contrib/client_forward_refs.py
+++ b/ariadne_codegen/contrib/client_forward_refs.py
@@ -271,7 +271,7 @@ class ClientForwardRefsPlugin(Plugin):
         return_types_not_used_as_input = set(self.input_and_return_types)
 
         # The ones we import in the method don't need to be imported at all -
-        # unless that's the type we return. This behaviour can differ if you use
+        # unless that's the type we return. This behavior can differ if you use
         # a plugin such as `ShorterResultsPlugin` that will import a type that
         # is different from the type returned.
         return_types_not_used_as_input |= (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
 dev = [
   "ariadne",
   "pytest",
-  "pylint",
+  "pylint==3.2.7",
   "mypy",
   "types-toml",
   "pytest-mock",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
   "click~=8.1",
   "graphql-core>=3.2.0,<3.3",
   "toml~=0.10",
-  "httpx~=0.23",
+  "httpx<=0.27.0",
   "pydantic>=2.0.0,<3.0.0",
   "black",
   "isort",
@@ -41,7 +41,7 @@ dev = [
   "types-toml",
   "pytest-mock",
   "pytest-asyncio",
-  "pytest-httpx",
+  "pytest-httpx<=0.34.0",
   "freezegun",
   "requests-toolbelt",
 ]

--- a/tests/main/graphql_schemas/all_types/expected_schema.py
+++ b/tests/main/graphql_schemas/all_types/expected_schema.py
@@ -214,14 +214,14 @@ schema: GraphQLSchema = GraphQLSchema(
         ),
         GraphQLDirective(
             name="specifiedBy",
-            description="Exposes a URL that specifies the behaviour of this scalar.",
+            description="Exposes a URL that specifies the behavior of this scalar.",
             is_repeatable=False,
             locations=(DirectiveLocation.SCALAR,),
             args={
                 "url": GraphQLArgument(
                     GraphQLNonNull(GraphQLString),
                     default_value=Undefined,
-                    description="The URL that specifies the behaviour of this scalar.",
+                    description="The URL that specifies the behavior of this scalar.",
                     deprecation_reason=None,
                 )
             },

--- a/tests/main/graphql_schemas/example/expected_schema.py
+++ b/tests/main/graphql_schemas/example/expected_schema.py
@@ -355,14 +355,14 @@ example_schema: GraphQLSchema = GraphQLSchema(
         ),
         GraphQLDirective(
             name="specifiedBy",
-            description="Exposes a URL that specifies the behaviour of this scalar.",
+            description="Exposes a URL that specifies the behavior of this scalar.",
             is_repeatable=False,
             locations=(DirectiveLocation.SCALAR,),
             args={
                 "url": GraphQLArgument(
                     GraphQLNonNull(GraphQLString),
                     default_value=Undefined,
-                    description="The URL that specifies the behaviour of this scalar.",
+                    description="The URL that specifies the behavior of this scalar.",
                     deprecation_reason=None,
                 )
             },


### PR DESCRIPTION
This fixes spelling of "behavior". I actually don't know where this is coming from or why the test failed but they failed both locally [and in CI](https://github.com/mirumee/ariadne-codegen/actions/runs/12496640540/job/34868553516?pr=330) so this will change the spelling. 