### PR TITLE
Normalise schema spelling when comparing

### DIFF
--- a/tests/main/test_main.py
+++ b/tests/main/test_main.py
@@ -367,4 +367,11 @@ def test_main_generates_correct_schema_file(project_dir, file_name, expected_fil
     assert result.exit_code == 0
     schema_path = project_dir / file_name
 
-    assert schema_path.read_text() == expected_file_path.read_text()
+    # normalise texts to account for a spelling change in graphql-core 3.2.5
+    def normalise(schema: str) -> str:
+        return schema.replace(" behaviour ", " behavior ")
+
+    actual = normalise(schema_path.read_text())
+    expected = normalise(expected_file_path.read_text())
+
+    assert actual == expected


### PR DESCRIPTION
graphql-core 3.2.5 changed the spelling of 'behaviour' to the US English version 'behavior'. Normalise the (hardcoded) expected and generated values to allow for either spelling.

Fixes #334
