### PR TITLE
feat: user-specified validation rule skips

### DIFF
--- a/ariadne_codegen/main.py
+++ b/ariadne_codegen/main.py
@@ -19,7 +19,7 @@ from .schema import (
     get_graphql_schema_from_path,
     get_graphql_schema_from_url,
 )
-from .settings import Strategy
+from .settings import Strategy, get_validation_rule
 
 
 @click.command()  # type: ignore
@@ -64,7 +64,7 @@ def client(config_dict):
     fragments = []
     queries = []
     if settings.queries_path:
-        definitions = get_graphql_queries(settings.queries_path, schema)
+        definitions = get_graphql_queries(settings.queries_path, schema, [get_validation_rule(e) for e in settings.skip_validation_rules])
         queries = filter_operations_definitions(definitions)
         fragments = filter_fragments_definitions(definitions)
 

--- a/ariadne_codegen/schema.py
+++ b/ariadne_codegen/schema.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from typing import Dict, Generator, List, Optional, Tuple, cast
+from typing_extensions import Any, Sequence
 
 import httpx
 from graphql import (
@@ -14,6 +15,7 @@ from graphql import (
     IntrospectionQuery,
     NoUnusedFragmentsRule,
     OperationDefinitionNode,
+    UniqueFragmentNamesRule,
     build_ast_schema,
     build_client_schema,
     get_introspection_query,
@@ -45,7 +47,7 @@ def filter_fragments_definitions(
 
 
 def get_graphql_queries(
-    queries_path: str, schema: GraphQLSchema
+    queries_path: str, schema: GraphQLSchema, skip_rules: Sequence[Any] = (NoUnusedFragmentsRule,)
 ) -> Tuple[DefinitionNode, ...]:
     """Get graphql queries definitions build from provided path."""
     queries_str = load_graphql_files_from_path(Path(queries_path))
@@ -53,7 +55,7 @@ def get_graphql_queries(
     validation_errors = validate(
         schema=schema,
         document_ast=queries_ast,
-        rules=[r for r in specified_rules if r is not NoUnusedFragmentsRule],
+        rules=[r for r in specified_rules if r not in skip_rules],
     )
     if validation_errors:
         raise InvalidOperationForSchema(

--- a/ariadne_codegen/settings.py
+++ b/ariadne_codegen/settings.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from textwrap import dedent
 from typing import Dict, List
 
+from graphql.validation import UniqueFragmentNamesRule, NoUnusedFragmentsRule
+
 from .client_generators.constants import (
     DEFAULT_ASYNC_BASE_CLIENT_NAME,
     DEFAULT_ASYNC_BASE_CLIENT_OPEN_TELEMETRY_NAME,
@@ -24,6 +26,18 @@ class CommentsStrategy(str, enum.Enum):
     NONE = "none"
     STABLE = "stable"
     TIMESTAMP = "timestamp"
+
+class ValidationRuleSkips(str, enum.Enum):
+    UniqueFragmentNames = "UniqueFragmentNames"
+    NoUnusedFragments = "NoUnusedFragments"
+
+def get_validation_rule(rule: ValidationRuleSkips):
+    if rule == ValidationRuleSkips.UniqueFragmentNames:
+        return UniqueFragmentNamesRule
+    elif rule == ValidationRuleSkips.NoUnusedFragments:
+        return NoUnusedFragmentsRule
+    else:
+        raise ValueError(f"Unknown validation rule: {rule}")
 
 
 class Strategy(str, enum.Enum):
@@ -70,6 +84,7 @@ class ClientSettings(BaseSettings):
     include_all_enums: bool = True
     async_client: bool = True
     opentelemetry_client: bool = False
+    skip_validation_rules: List[ValidationRuleSkips] = field(default_factory=lambda: [ValidationRuleSkips.UniqueFragmentNames,])
     files_to_include: List[str] = field(default_factory=list)
     scalars: Dict[str, ScalarData] = field(default_factory=dict)
 


### PR DESCRIPTION
This feature allows for the user to specify which validation rules they want to skip. Currently we only support 2 rules (the implicit no unused fragments rule and the UniqueFragmentNames rule).

My use-case is - the https://github.com/graphql-rust/graphql-client/ that I am using for for my rust client generation doesn't support importing fragments; but I have standard fragments for pagination that I would otherwise share. I don't want to maintain 2 sets of queries for my python and rust clients. As long as these fragments are identical, it doesn't matter whether they are re-defined, so I am safe to turn off this validation rule.