### PR TITLE
Add support for embedded variables in headers

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -148,6 +148,36 @@ def test_client_settings_resolves_env_variable_for_remote_schema_header_with_pre
 
     assert settings.remote_schema_headers["Authorization"] == "test_value"
 
+def test_client_settings_resolves_env_variable_for_remote_schema_header_with_prefix_inside(
+    tmp_path, mocker
+):
+    queries_path = tmp_path / "queries.graphql"
+    queries_path.touch()
+    mocker.patch.dict(os.environ, {"TEST_VAR": "test_value"})
+
+    settings = ClientSettings(
+        queries_path=queries_path,
+        remote_schema_url="https://test",
+        remote_schema_headers={"Authorization": "Bearer $TEST_VAR"},
+    )
+
+    assert settings.remote_schema_headers["Authorization"] == "Bearer test_value"
+
+def test_client_settings_resolves_env_variable_for_remote_schema_header_with_prefix_multiple(
+    tmp_path, mocker
+):
+    queries_path = tmp_path / "queries.graphql"
+    queries_path.touch()
+    mocker.patch.dict(os.environ, {"TEST_FOO": "test_foo"})
+    mocker.patch.dict(os.environ, {"TEST_BAR": "test_bar"})
+
+    settings = ClientSettings(
+        queries_path=queries_path,
+        remote_schema_url="https://test",
+        remote_schema_headers={"Authorization": "Bearer $TEST_FOO$TEST_BAR suffix"},
+    )
+
+    assert settings.remote_schema_headers["Authorization"] == "Bearer test_footest_bar suffix"
 
 def test_client_settings_doesnt_resolve_remote_schema_header_without_prefix(tmp_path):
     queries_path = tmp_path / "queries.graphql"


### PR DESCRIPTION
Hey,

Thanks for this awesome generator!

Unfortunately, I can't use it to fetch GitHub's own schemas because they require `Authorization` headers in the form of `Bearer token`. Currently, the generator only supports variable expansion if it's the only element in the header value. However, I can't hardcode the token in my `pyproject.toml` to work around this limitation.

So I added support for embedded and multiple variables (not that I need multiple variables, but you basically get that for free with my approach, so why not...).  There may be situations where it won't work like shell, but I would prefer simplicity over handling all possible corner cases.

Hope this helps you and others!