### PR TITLE
Add `include_typename` configuration option for better GraphQL API compatibility

### DIFF
--- a/ariadne_codegen/client_generators/fragments.py
+++ b/ariadne_codegen/client_generators/fragments.py
@@ -20,6 +20,7 @@ class FragmentsGenerator:
         convert_to_snake_case: bool = True,
         custom_scalars: Optional[Dict[str, ScalarData]] = None,
         plugin_manager: Optional[PluginManager] = None,
+        include_typename: bool = True,
     ) -> None:
         self.schema = schema
         self.enums_module_name = enums_module_name
@@ -28,6 +29,7 @@ class FragmentsGenerator:
         self.convert_to_snake_case = convert_to_snake_case
         self.custom_scalars = custom_scalars
         self.plugin_manager = plugin_manager
+        self.include_typename = include_typename
 
         self._fragments_names = set(self.fragments_definitions.keys())
         self._generated_public_names: List[str] = []
@@ -52,6 +54,7 @@ class FragmentsGenerator:
                 convert_to_snake_case=self.convert_to_snake_case,
                 custom_scalars=self.custom_scalars,
                 plugin_manager=self.plugin_manager,
+                include_typename=self.include_typename,
             )
             imports.extend(generator.get_imports())
             class_defs = generator.get_classes()

--- a/ariadne_codegen/client_generators/package.py
+++ b/ariadne_codegen/client_generators/package.py
@@ -84,6 +84,7 @@ class PackageGenerator:
         custom_scalars: Optional[Dict[str, ScalarData]] = None,
         plugin_manager: Optional[PluginManager] = None,
         enable_custom_operations: bool = False,
+        include_typename: bool = True,
     ) -> None:
         self.package_path = Path(target_path) / package_name
 
@@ -133,6 +134,7 @@ class PackageGenerator:
         )
         self.custom_scalars = custom_scalars if custom_scalars else {}
         self.plugin_manager = plugin_manager
+        self.include_typename = include_typename
 
         self._result_types_files: Dict[str, ast.Module] = {}
         self._generated_files: List[str] = []
@@ -199,6 +201,7 @@ class PackageGenerator:
             convert_to_snake_case=self.convert_to_snake_case,
             custom_scalars=self.custom_scalars,
             plugin_manager=self.plugin_manager,
+            include_typename=self.include_typename,
         )
         self._unpacked_fragments = self._unpacked_fragments.union(
             query_types_generator.get_unpacked_fragments()
@@ -454,6 +457,7 @@ def get_package_generator(
         convert_to_snake_case=settings.convert_to_snake_case,
         custom_scalars=settings.scalars,
         plugin_manager=plugin_manager,
+        include_typename=settings.include_typename,
     )
     custom_fields_generator = CustomFieldsGenerator(
         schema=schema,
@@ -533,4 +537,5 @@ def get_package_generator(
         custom_scalars=settings.scalars,
         plugin_manager=plugin_manager,
         enable_custom_operations=settings.enable_custom_operations,
+        include_typename=settings.include_typename,
     )

--- a/ariadne_codegen/client_generators/result_fields.py
+++ b/ariadne_codegen/client_generators/result_fields.py
@@ -82,6 +82,7 @@ def parse_operation_field(
     typename_values: Optional[List[str]] = None,
     custom_scalars: Optional[Dict[str, ScalarData]] = None,
     fragments_definitions: Optional[Dict[str, FragmentDefinitionNode]] = None,
+    include_typename: bool = True,
 ) -> Tuple[Annotation, Optional[ast.Constant], FieldContext]:
     default_value: Optional[ast.Constant] = None
     context = FieldContext(
@@ -107,7 +108,7 @@ def parse_operation_field(
     )
     if isinstance(annotation, ast.Subscript):
         annotation.slice = annotate_nested_unions(
-            cast(AnnotationSlice, annotation.slice)
+            cast(AnnotationSlice, annotation.slice), include_typename
         )
     annotation, default_value = parse_directives(
         annotation=annotation, directives=directives if directives else tuple()
@@ -363,11 +364,11 @@ def get_fragments_on_subtype(
     return fragments
 
 
-def annotate_nested_unions(annotation: AnnotationSlice) -> AnnotationSlice:
+def annotate_nested_unions(annotation: AnnotationSlice, include_typename: bool = True) -> AnnotationSlice:
     if isinstance(annotation, ast.Tuple):
         return generate_tuple(
             [
-                annotate_nested_unions(cast(AnnotationSlice, elt))
+                annotate_nested_unions(cast(AnnotationSlice, elt), include_typename)
                 for elt in annotation.elts
             ]
         )
@@ -376,19 +377,23 @@ def annotate_nested_unions(annotation: AnnotationSlice) -> AnnotationSlice:
         return annotation
 
     if isinstance(annotation.value, ast.Name) and annotation.value.id == UNION:
-        return generate_subscript(
-            value=generate_name(ANNOTATED),
-            slice_=generate_tuple(
-                [
-                    annotation,
-                    generate_pydantic_field(
-                        {DISCRIMINATOR_KEYWORD: generate_constant(TYPENAME_ALIAS)}
-                    ),
-                ]
-            ),
-        )
+        if include_typename:
+            return generate_subscript(
+                value=generate_name(ANNOTATED),
+                slice_=generate_tuple(
+                    [
+                        annotation,
+                        generate_pydantic_field(
+                            {DISCRIMINATOR_KEYWORD: generate_constant(TYPENAME_ALIAS)}
+                        ),
+                    ]
+                ),
+            )
+        else:
+            # When include_typename=False, return the union without discriminator
+            return annotation
 
-    annotation.slice = annotate_nested_unions(cast(AnnotationSlice, annotation.slice))
+    annotation.slice = annotate_nested_unions(cast(AnnotationSlice, annotation.slice), include_typename)
     return annotation
 
 

--- a/ariadne_codegen/client_generators/result_types.py
+++ b/ariadne_codegen/client_generators/result_types.py
@@ -85,6 +85,7 @@ class ResultTypesGenerator:
         convert_to_snake_case: bool = True,
         custom_scalars: Optional[Dict[str, ScalarData]] = None,
         plugin_manager: Optional[PluginManager] = None,
+        include_typename: bool = True,
     ) -> None:
         self.schema = schema
         self.operation_definition = operation_definition
@@ -99,6 +100,7 @@ class ResultTypesGenerator:
         self.custom_scalars = custom_scalars if custom_scalars else {}
         self.convert_to_snake_case = convert_to_snake_case
         self.plugin_manager = plugin_manager
+        self.include_typename = include_typename
 
         self._imports: List[ast.ImportFrom] = [
             generate_import_from(
@@ -262,6 +264,7 @@ class ResultTypesGenerator:
                 typename_values=typename_values,
                 custom_scalars=self.custom_scalars,
                 fragments_definitions=self.fragments_definitions,
+                include_typename=self.include_typename,
             )
 
             field_implementation = generate_ann_assign(
@@ -382,6 +385,10 @@ class ResultTypesGenerator:
     def _add_typename_field_to_selections(
         self, resolved_fields: List[FieldNode], selection_set: SelectionSetNode
     ) -> Tuple[List[FieldNode], Tuple[SelectionNode, ...]]:
+        if not self.include_typename:
+            # Don't add __typename to fields or selections when include_typename=False
+            return resolved_fields, selection_set.selections
+            
         field_names = {f.name.value for f in resolved_fields}
         if TYPENAME_FIELD_NAME not in field_names:
             typename_field = FieldNode(name=NameNode(value=TYPENAME_FIELD_NAME))
@@ -436,7 +443,7 @@ class ResultTypesGenerator:
         ):
             keywords[ALIAS_KEYWORD] = generate_constant(field_schema_name)
 
-        if is_union(field_implementation.annotation):
+        if is_union(field_implementation.annotation) and self.include_typename:
             keywords[DISCRIMINATOR_KEYWORD] = generate_constant(TYPENAME_ALIAS)
 
         if keywords and isinstance(field_implementation.value, ast.Constant):

--- a/ariadne_codegen/settings.py
+++ b/ariadne_codegen/settings.py
@@ -72,6 +72,7 @@ class ClientSettings(BaseSettings):
     opentelemetry_client: bool = False
     files_to_include: List[str] = field(default_factory=list)
     scalars: Dict[str, ScalarData] = field(default_factory=dict)
+    include_typename: bool = True
 
     def __post_init__(self):
         if not self.queries_path and not self.enable_custom_operations:
@@ -166,6 +167,11 @@ class ClientSettings(BaseSettings):
             if self.plugins
             else "No plugin is being used."
         )
+        include_typename_msg = (
+            "Including __typename fields in generated queries."
+            if self.include_typename
+            else "Not including __typename fields in generated queries."
+        )
         return dedent(
             f"""\
             Selected strategy: {Strategy.CLIENT}
@@ -182,6 +188,7 @@ class ClientSettings(BaseSettings):
             Comments type: {self.include_comments.value}
             {snake_case_msg}
             {async_client_msg}
+            {include_typename_msg}
             {files_to_include_msg}
             {plugins_msg}
             """

--- a/tests/client_generators/result_types_generator/test_include_typename.py
+++ b/tests/client_generators/result_types_generator/test_include_typename.py
@@ -1,0 +1,332 @@
+"""Test include_typename functionality in ResultTypesGenerator."""
+
+from graphql import build_schema, parse, OperationDefinitionNode
+
+from ariadne_codegen.client_generators.result_types import ResultTypesGenerator
+from ariadne_codegen.client_generators.constants import TYPENAME_FIELD_NAME, DISCRIMINATOR_KEYWORD
+
+
+SIMPLE_SCHEMA = """
+    type Query {
+        hello: String
+        user: User
+        animal: Animal
+    }
+    
+    type User {
+        id: ID!
+        name: String!
+    }
+    
+    union Animal = Dog | Cat
+    
+    interface Pet {
+        id: ID!
+        name: String!
+    }
+    
+    type Dog implements Pet {
+        id: ID!
+        name: String!
+        breed: String!
+    }
+    
+    type Cat implements Pet {
+        id: ID!
+        name: String!
+        lives: Int!
+    }
+"""
+
+
+def test_result_types_generator_includes_typename_by_default():
+    """Test that __typename is included by default for abstract types."""
+    schema = build_schema(SIMPLE_SCHEMA)
+    
+    query_str = """
+        query GetAnimals {
+            animal {
+                id
+                name
+                ... on Dog {
+                    breed
+                }
+                ... on Cat {
+                    lives
+                }
+            }
+        }
+    """
+    
+    document = parse(query_str)
+    operation = document.definitions[0]
+    assert isinstance(operation, OperationDefinitionNode)
+    
+    generator = ResultTypesGenerator(
+        schema=schema,
+        operation_definition=operation,
+        enums_module_name="enums",
+        include_typename=True,  # Default behavior
+    )
+    
+    # Check that the generator has include_typename=True
+    assert generator.include_typename is True
+
+
+def test_result_types_generator_respects_include_typename_false():
+    """Test that __typename is not included when include_typename=False."""
+    schema = build_schema(SIMPLE_SCHEMA)
+    
+    query_str = """
+        query GetUser {
+            user {
+                id
+                name
+            }
+        }
+    """
+    
+    document = parse(query_str)
+    operation = document.definitions[0]
+    assert isinstance(operation, OperationDefinitionNode)
+    
+    generator = ResultTypesGenerator(
+        schema=schema,
+        operation_definition=operation,
+        enums_module_name="enums",
+        include_typename=False,  # Disabled
+    )
+    
+    # Check that the generator has include_typename=False
+    assert generator.include_typename is False
+
+
+def test_add_typename_field_to_selections_respects_include_typename_false():
+    """Test that _add_typename_field_to_selections respects include_typename=False."""
+    from graphql import FieldNode, NameNode, SelectionSetNode
+    from ariadne_codegen.client_generators.constants import TYPENAME_FIELD_NAME
+    
+    schema = build_schema(SIMPLE_SCHEMA)
+    
+    query_str = """
+        query GetUser {
+            user {
+                id
+            }
+        }
+    """
+    
+    document = parse(query_str)
+    operation = document.definitions[0]
+    assert isinstance(operation, OperationDefinitionNode)
+    
+    # Test with include_typename=False
+    generator_false = ResultTypesGenerator(
+        schema=schema,
+        operation_definition=operation,
+        enums_module_name="enums",
+        include_typename=False,
+    )
+    
+    # Create a sample field without __typename
+    id_field = FieldNode(name=NameNode(value="id"))
+    resolved_fields = [id_field]
+    selection_set = SelectionSetNode(selections=(id_field,))
+    
+    # Call the method
+    result_fields, result_selections = generator_false._add_typename_field_to_selections(
+        resolved_fields, selection_set
+    )
+    
+    # Should not add __typename field
+    field_names = {f.name.value for f in result_fields}
+    assert TYPENAME_FIELD_NAME not in field_names
+    assert len(result_fields) == 1  # Only the original field
+    assert result_fields[0].name.value == "id"
+    
+    # Test with include_typename=True (default)
+    generator_true = ResultTypesGenerator(
+        schema=schema,
+        operation_definition=operation,
+        enums_module_name="enums",
+        include_typename=True,
+    )
+    
+    # Call the method with the same inputs
+    result_fields, result_selections = generator_true._add_typename_field_to_selections(
+        resolved_fields, selection_set
+    )
+    
+    # Should add __typename field
+    field_names = {f.name.value for f in result_fields}
+    assert TYPENAME_FIELD_NAME in field_names
+    assert len(result_fields) == 2  # Original field + __typename
+    assert result_fields[0].name.value == TYPENAME_FIELD_NAME  # __typename added first
+    assert result_fields[1].name.value == "id"
+
+
+def test_add_typename_field_to_selections_does_not_duplicate():
+    """Test that __typename is not added if it already exists."""
+    from graphql import FieldNode, NameNode, SelectionSetNode
+    
+    schema = build_schema(SIMPLE_SCHEMA)
+    
+    query_str = """
+        query GetUser {
+            user {
+                id
+            }
+        }
+    """
+    
+    document = parse(query_str)
+    operation = document.definitions[0]
+    assert isinstance(operation, OperationDefinitionNode)
+    
+    generator = ResultTypesGenerator(
+        schema=schema,
+        operation_definition=operation,
+        enums_module_name="enums",
+        include_typename=True,
+    )
+    
+    # Create fields that already include __typename
+    typename_field = FieldNode(name=NameNode(value=TYPENAME_FIELD_NAME))
+    id_field = FieldNode(name=NameNode(value="id"))
+    resolved_fields = [typename_field, id_field]
+    selection_set = SelectionSetNode(selections=(typename_field, id_field))
+    
+    # Call the method
+    result_fields, result_selections = generator._add_typename_field_to_selections(
+        resolved_fields, selection_set
+    )
+    
+    # Should not add another __typename field
+    typename_count = sum(
+        1 for f in result_fields if f.name.value == TYPENAME_FIELD_NAME
+    )
+    assert typename_count == 1
+    assert len(result_fields) == 2  # Original fields only
+
+
+def test_union_discriminator_respects_include_typename():
+    """Test that discriminator fields are not generated when include_typename=False."""
+    import ast
+    
+    schema = build_schema(SIMPLE_SCHEMA)
+    
+    # Test with a union type that should normally get a discriminator
+    query_str = """
+        query GetAnimal {
+            animal {
+                ... on Dog {
+                    name
+                    breed
+                }
+                ... on Cat {
+                    name
+                    lives
+                }
+            }
+        }
+    """
+    
+    document = parse(query_str)
+    operation = document.definitions[0]
+    assert isinstance(operation, OperationDefinitionNode)
+    
+    # Test with include_typename=True (should have discriminator)
+    generator_with_typename = ResultTypesGenerator(
+        schema=schema,
+        operation_definition=operation,
+        enums_module_name="enums",
+        include_typename=True,
+    )
+    
+    module_with_typename = generator_with_typename.generate()
+    
+    # Check that discriminator is present in the generated code
+    has_discriminator_with_typename = False
+    for node in ast.walk(module_with_typename):
+        if (isinstance(node, ast.keyword) and 
+            node.arg == DISCRIMINATOR_KEYWORD):
+            has_discriminator_with_typename = True
+            break
+    
+    # Test with include_typename=False (should NOT have discriminator)
+    generator_without_typename = ResultTypesGenerator(
+        schema=schema,
+        operation_definition=operation,
+        enums_module_name="enums",
+        include_typename=False,
+    )
+    
+    module_without_typename = generator_without_typename.generate()
+    
+    # Check that discriminator is NOT present in the generated code
+    has_discriminator_without_typename = False
+    for node in ast.walk(module_without_typename):
+        if (isinstance(node, ast.keyword) and 
+            node.arg == DISCRIMINATOR_KEYWORD):
+            has_discriminator_without_typename = True
+            break
+    
+    # Assertions
+    assert has_discriminator_with_typename, "Expected discriminator when include_typename=True"
+    assert not has_discriminator_without_typename, "Should not have discriminator when include_typename=False"
+
+
+def test_union_types_work_without_discriminator_when_include_typename_false():
+    """Test that union types can still be parsed when include_typename=False (without discriminator)."""
+    import ast
+    
+    schema = build_schema(SIMPLE_SCHEMA)
+    
+    # Test with a union type
+    query_str = """
+        query GetAnimal {
+            animal {
+                ... on Dog {
+                    name
+                    breed
+                }
+                ... on Cat {
+                    name
+                    lives
+                }
+            }
+        }
+    """
+    
+    document = parse(query_str)
+    operation = document.definitions[0]
+    assert isinstance(operation, OperationDefinitionNode)
+    
+    # Test with include_typename=False
+    generator_false = ResultTypesGenerator(
+        schema=schema,
+        operation_definition=operation,
+        enums_module_name="enums",
+        include_typename=False,
+    )
+    
+    module_false = generator_false.generate()
+    
+    # Should generate union types without discriminator and without __typename field
+    found_union = False
+    found_typename_field = False
+    for node in ast.walk(module_false):
+        # Check for union annotation
+        if (isinstance(node, ast.AnnAssign) and 
+            isinstance(node.annotation, ast.Subscript) and
+            isinstance(node.annotation.value, ast.Name) and
+            node.annotation.value.id == "Union"):
+            found_union = True
+        # Check that no typename__ field exists
+        if (isinstance(node, ast.AnnAssign) and 
+            isinstance(node.target, ast.Name) and
+            node.target.id == "typename__"):
+            found_typename_field = True
+    
+    assert found_union, "Should generate union types when include_typename=False"
+    assert not found_typename_field, "Should not generate typename__ field when include_typename=False"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -252,3 +252,67 @@ def test_get_graphql_schema_settings_returns_settings_object_ignoring_extra_fiel
 
     assert isinstance(settings, GraphQLSchemaSettings)
     assert settings.schema_path == schema_path.as_posix()
+
+
+
+def test_get_client_settings_with_include_typename_false(tmp_path):
+    """Test that include_typename=False is properly parsed from config."""
+    schema_path = tmp_path / "schema.graphql"
+    schema_path.touch()
+    queries_path = tmp_path / "queries.graphql"
+    queries_path.touch()
+    config_dict = {
+        "tool": {
+            "ariadne-codegen": {
+                "schema_path": schema_path.as_posix(),
+                "queries_path": queries_path.as_posix(),
+                "include_typename": False,
+            }
+        }
+    }
+    settings = get_client_settings(config_dict)
+
+    assert isinstance(settings, ClientSettings)
+    assert settings.include_typename is False
+
+
+def test_get_client_settings_with_include_typename_true(tmp_path):
+    """Test that include_typename=True is properly parsed from config."""
+    schema_path = tmp_path / "schema.graphql"
+    schema_path.touch()
+    queries_path = tmp_path / "queries.graphql"
+    queries_path.touch()
+    config_dict = {
+        "tool": {
+            "ariadne-codegen": {
+                "schema_path": schema_path.as_posix(),
+                "queries_path": queries_path.as_posix(),
+                "include_typename": True,
+            }
+        }
+    }
+    settings = get_client_settings(config_dict)
+
+    assert isinstance(settings, ClientSettings)
+    assert settings.include_typename is True
+
+
+def test_get_client_settings_without_include_typename_defaults_to_true(tmp_path):
+    """Test that include_typename defaults to True when not specified in config."""
+    schema_path = tmp_path / "schema.graphql"
+    schema_path.touch()
+    queries_path = tmp_path / "queries.graphql"
+    queries_path.touch()
+    config_dict = {
+        "tool": {
+            "ariadne-codegen": {
+                "schema_path": schema_path.as_posix(),
+                "queries_path": queries_path.as_posix(),
+            }
+        }
+    }
+    settings = get_client_settings(config_dict)
+
+    assert isinstance(settings, ClientSettings)
+    assert settings.include_typename is True
+

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -305,3 +305,50 @@ def test_graphql_schema_settings_with_invalid_type_map_variable_name_raises_exce
             remote_schema_url="http://testserver/graphq/",
             type_map_variable_name="1type_map",
         )
+
+
+def test_client_settings_include_typename_default_value(tmp_path):
+    """Test that include_typename defaults to True."""
+    schema_path = tmp_path / "schema.graphql"
+    schema_path.touch()
+    queries_path = tmp_path / "queries.graphql"
+    queries_path.touch()
+
+    settings = ClientSettings(
+        schema_path=schema_path.as_posix(),
+        queries_path=queries_path.as_posix(),
+    )
+
+    assert settings.include_typename is True
+
+
+def test_client_settings_include_typename_can_be_set_to_false(tmp_path):
+    """Test that include_typename can be set to False."""
+    schema_path = tmp_path / "schema.graphql"
+    schema_path.touch()
+    queries_path = tmp_path / "queries.graphql"
+    queries_path.touch()
+
+    settings = ClientSettings(
+        schema_path=schema_path.as_posix(),
+        queries_path=queries_path.as_posix(),
+        include_typename=False,
+    )
+
+    assert settings.include_typename is False
+
+
+def test_client_settings_include_typename_can_be_set_to_true(tmp_path):
+    """Test that include_typename can be explicitly set to True."""
+    schema_path = tmp_path / "schema.graphql"
+    schema_path.touch()
+    queries_path = tmp_path / "queries.graphql"
+    queries_path.touch()
+
+    settings = ClientSettings(
+        schema_path=schema_path.as_posix(),
+        queries_path=queries_path.as_posix(),
+        include_typename=True,
+    )
+
+    assert settings.include_typename is True


### PR DESCRIPTION
This pull request introduces a new `include_typename` option throughout the code generation pipeline, allowing users to control whether `__typename` fields and union discriminators are included in generated client code. The change is propagated through settings, generators, and helper functions, and the logic for handling unions and fragments is updated to respect this new flag.

**Settings and Configuration**

* Added `include_typename` boolean option to the `ClientSettings` dataclass in `settings.py`, including messaging to indicate whether `__typename` fields are included in generated queries. [[1]](diffhunk://#diff-916935c8827ff7f9d7314d37e89a1c2044e09d59a342085e3dcb519d6693b63aR75) [[2]](diffhunk://#diff-916935c8827ff7f9d7314d37e89a1c2044e09d59a342085e3dcb519d6693b63aR170-R174) [[3]](diffhunk://#diff-916935c8827ff7f9d7314d37e89a1c2044e09d59a342085e3dcb519d6693b63aR191)

**Generator Initialization and Propagation**

* Updated constructors for key generators (`FragmentsGenerator`, `PackageGenerator`, `ResultTypesGenerator`) to accept and store the `include_typename` flag, and ensured it is passed through all relevant generator creation and function calls. [[1]](diffhunk://#diff-870d94176c4dc476f8269c040ef01b187b4d05d5d752a196faa93c08a19bac46R23) [[2]](diffhunk://#diff-870d94176c4dc476f8269c040ef01b187b4d05d5d752a196faa93c08a19bac46R32) [[3]](diffhunk://#diff-2e64f3b2e25052aac124421b1e09c0950cdda829c56918817821f7cf9c80a22eR87) [[4]](diffhunk://#diff-2e64f3b2e25052aac124421b1e09c0950cdda829c56918817821f7cf9c80a22eR137) [[5]](diffhunk://#diff-9042b649db08641441c03575181ff29e2d7b821c5de5cf07254fc4845bca9509R88) [[6]](diffhunk://#diff-9042b649db08641441c03575181ff29e2d7b821c5de5cf07254fc4845bca9509R103) [[7]](diffhunk://#diff-2e64f3b2e25052aac124421b1e09c0950cdda829c56918817821f7cf9c80a22eR460) [[8]](diffhunk://#diff-2e64f3b2e25052aac124421b1e09c0950cdda829c56918817821f7cf9c80a22eR540)

**Union Annotation and Typename Logic**

* Modified the union annotation logic in `result_fields.py` so that when `include_typename=False`, union types are generated without the discriminator (i.e., without `__typename` in `Annotated`). [[1]](diffhunk://#diff-d696644260097bd460e3b1875557f80b1f53ad717457973d674990f82d529e5aL366-R371) [[2]](diffhunk://#diff-d696644260097bd460e3b1875557f80b1f53ad717457973d674990f82d529e5aR380) [[3]](diffhunk://#diff-d696644260097bd460e3b1875557f80b1f53ad717457973d674990f82d529e5aR392-R396) [[4]](diffhunk://#diff-d696644260097bd460e3b1875557f80b1f53ad717457973d674990f82d529e5aL110-R111)

**Field and Fragment Handling**

* Updated fragment and field parsing logic to accept and respect the `include_typename` flag, ensuring that `__typename` fields are only added when requested. [[1]](diffhunk://#diff-d696644260097bd460e3b1875557f80b1f53ad717457973d674990f82d529e5aR85) [[2]](diffhunk://#diff-9042b649db08641441c03575181ff29e2d7b821c5de5cf07254fc4845bca9509R267) [[3]](diffhunk://#diff-9042b649db08641441c03575181ff29e2d7b821c5de5cf07254fc4845bca9509R388-R391) [[4]](diffhunk://#diff-9042b649db08641441c03575181ff29e2d7b821c5de5cf07254fc4845bca9509L439-R446)

**Pipeline Integration**

* Ensured the `include_typename` setting is propagated through the package generator pipeline and all relevant function calls, so the behavior is consistent for all generated code.

These changes give users fine-grained control over the inclusion of `__typename` fields and union discriminators in generated clients, improving flexibility and compatibility with various GraphQL server configurations.