### PR TITLE
Fix __typename field handling to use GraphQLString

### DIFF
--- a/ariadne_codegen/client_generators/result_types.py
+++ b/ariadne_codegen/client_generators/result_types.py
@@ -13,8 +13,8 @@ from graphql import (
     GraphQLNamedType,
     GraphQLNonNull,
     GraphQLObjectType,
-    GraphQLScalarType,
     GraphQLSchema,
+    GraphQLString,
     GraphQLUnionType,
     InlineFragmentNode,
     NameNode,
@@ -423,7 +423,7 @@ class ResultTypesGenerator:
         except KeyError as exc:
             if field_name == TYPENAME_FIELD_NAME:
                 return GraphQLField(
-                    type_=GraphQLNonNull(type_=GraphQLScalarType(name="String"))
+                    type_=GraphQLNonNull(type_=GraphQLString)
                 )
             raise ParsingError(
                 f"Field {field_name} not found in type {type_name}."

--- a/tests/client_generators/result_types_generator/test_include_typename.py
+++ b/tests/client_generators/result_types_generator/test_include_typename.py
@@ -282,3 +282,50 @@ def test_union_discriminator_respects_include_typename():
     assert (
         not has_discriminator_without_typename
     ), "Should not have discriminator when include_typename=False"
+
+
+def test_get_field_from_schema_handles_typename_correctly():
+    """Test that _get_field_from_schema correctly handles __typename field."""
+    from graphql import GraphQLNonNull, GraphQLString
+
+    from ariadne_codegen.exceptions import ParsingError
+
+    schema = build_schema(SIMPLE_SCHEMA)
+
+    query_str = """
+        query GetUser {
+            user {
+                id
+            }
+        }
+    """
+
+    document = parse(query_str)
+    operation = document.definitions[0]
+    assert isinstance(operation, OperationDefinitionNode)
+
+    generator = ResultTypesGenerator(
+        schema=schema,
+        operation_definition=operation,
+        enums_module_name="enums",
+        include_typename=True,
+    )
+
+    # __typename is not in the schema's type_map fields, so it should be handled
+    # as a special case. This validates the fix where using GraphQLString instead
+    # of GraphQLScalarType(name="String") prevents "Redefinition of reserved type" error.
+    typename_field = generator._get_field_from_schema("User", TYPENAME_FIELD_NAME)
+
+    # Verify the field was created correctly using the built-in GraphQLString type
+    assert typename_field is not None
+    assert isinstance(typename_field.type, GraphQLNonNull)
+    assert typename_field.type.of_type is GraphQLString
+    assert typename_field.type.of_type.name == "String"
+
+    # Test that requesting a non-existent field (other than __typename) raises an error
+    try:
+        generator._get_field_from_schema("User", "nonExistentField")
+        assert False, "Expected ParsingError for non-existent field"
+    except ParsingError as e:
+        assert "nonExistentField" in str(e)
+        assert "User" in str(e)


### PR DESCRIPTION
# Fix __typename field handling to use GraphQLString instead of creating new scalar

## Description

Fixes a bug where code generation fails with `TypeError: Redefinition of reserved type 'String'` when processing queries that include `__typename` fields. The issue occurs because `__typename` is a GraphQL meta-field that isn't explicitly defined in schema type maps, so the code falls back to creating a field definition. The original implementation incorrectly attempted to create a new `GraphQLScalarType(name="String")`, which fails because "String" is a reserved built-in type.

## Minimal Example

**Schema:**
```graphql
type Query {
  user: User
}

type User {
  id: ID!
  name: String!
}
```

**Query:**
```graphql
query GetUser {
  user {
    __typename
    id
    name
  }
}
```

**Before (fails):**
```python
return GraphQLField(
    type_=GraphQLNonNull(type_=GraphQLScalarType(name="String"))  # ❌ TypeError
)
```

**After (works):**
```python
return GraphQLField(
    type_=GraphQLNonNull(type_=GraphQLString)  # ✅ Uses built-in type
)
```

## Changes

- Added `GraphQLString` import to `ariadne_codegen/client_generators/result_types.py`
- Updated `_get_field_from_schema()` to use `GraphQLString` instead of creating a new scalar for `__typename` handling
- Added test case `test_get_field_from_schema_handles_typename_correctly()` to validate the fix

## Testing

- All existing tests pass (6/6 in `test_include_typename.py`)
- New test validates `__typename` field handling and would fail without the fix

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] Code follows the project's style guidelines
- [x] Tests pass locally
- [x] Added tests for the fix
- [x] No breaking changes introduced
