### PR TITLE
Respect convert_to_snake_case for operation names

### DIFF
--- a/ariadne_codegen/client_generators/package.py
+++ b/ariadne_codegen/client_generators/package.py
@@ -193,7 +193,7 @@ class PackageGenerator:
         return_type_name = str_to_pascal_case(name.value)
         method_name = process_name(
             name.value,
-            convert_to_snake_case=True,
+            convert_to_snake_case=self.convert_to_snake_case,
             plugin_manager=self.plugin_manager,
             node=definition,
         )

--- a/tests/client_generators/package_generator/test_generated_files.py
+++ b/tests/client_generators/package_generator/test_generated_files.py
@@ -335,6 +335,50 @@ def test_generate_creates_client_with_valid_method_names(
         assert function.name == "from_"
 
 
+def test_generate_respects_convert_to_snake_case_false_for_operation_names(
+    tmp_path, schema, async_base_client_import
+):
+    package_name = "test_graphql_client"
+    generator = PackageGenerator(
+        package_name=package_name,
+        target_path=tmp_path.as_posix(),
+        schema=schema,
+        init_generator=InitFileGenerator(),
+        client_generator=ClientGenerator(
+            base_client_import=async_base_client_import,
+            arguments_generator=ArgumentsGenerator(
+                schema=schema, convert_to_snake_case=False
+            ),
+        ),
+        enums_generator=EnumsGenerator(schema=schema),
+        input_types_generator=InputTypesGenerator(schema=schema),
+        fragments_generator=FragmentsGenerator(schema=schema, fragments_definitions={}),
+        async_client=False,
+        convert_to_snake_case=False,
+    )
+    query_str = """
+    query getTokenDetails($id: ID!) {
+        query1(id: $id) {
+            field1
+        }
+    }
+    """
+
+    generator.add_operation(parse(query_str).definitions[0])
+    generator.generate()
+
+    client_file_path = tmp_path / package_name / "client.py"
+    with client_file_path.open() as client_file:
+        client_content = client_file.read()
+        parsed = ast.parse(client_content)
+        class_def = get_class_def(parsed)
+        function = [x for x in class_def.body if isinstance(x, ast.FunctionDef)][0]
+        assert function.name == "getTokenDetails"
+
+    query_types_file_path = tmp_path / package_name / "getTokenDetails.py"
+    assert query_types_file_path.exists()
+
+
 def test_generate_with_conflicting_query_name_raises_parsing_error(
     tmp_path, schema, async_base_client_import
 ):


### PR DESCRIPTION
## Summary
- replace the hardcoded snake_case conversion in `PackageGenerator.add_operation` with the package setting
- add a regression test proving `convert_to_snake_case=False` preserves a camelCase operation name and generated module name

This addresses the hardcoded conversion path discussed in #343. The custom-operation generator path already receives the setting; this keeps named GraphQL operations consistent with it.

## Validation
- `uv run pytest tests/client_generators/package_generator -q` — 31 passed
- `uv run pytest tests/client_generators/test_custom_operation_generator.py tests/client_generators/package_generator -q` — 35 passed
- `uv run pytest -q` — 912 passed, 2 xfailed
- `uv run ruff check`
- `uv run ruff format --check`
- `git diff --check`