### PR TITLE
feat: add schema_paths for loading schema from local paths and installed packages AR-3

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,10 @@ Required settings:
 
 - `queries_path` - path to file/directory with queries (Can be optional if `enable_custom_operations` is used)
 
-One of the following 2 parameters is required, in case of providing both of them `schema_path` is prioritized:
+Exactly one of the following 3 parameters is required. They are mutually exclusive - providing more than one raises a configuration error:
 
 - `schema_path` - path to file/directory with graphql schema
+- `schema_paths` - list of schema sources; each entry can be a local path (file or directory) or a dotted Python attribute path (resolved at codegen time). See [Loading schema from installed packages](#loading-schema-from-installed-packages).
 - `remote_schema_url` - url to graphql server, where introspection query can be perfomed
 
 Optional settings:
@@ -88,6 +89,30 @@ These options control which fields are included in the GraphQL introspection que
 - `introspection_schema_description` (defaults to `false`) – include schema description
 - `introspection_directive_is_repeatable` (defaults to `false`) – include `isRepeatable` information for directives
 - `introspection_input_object_one_of` (defaults to `false`) – include `oneOf` information for input objects
+
+## Loading schema from installed packages
+
+`schema_paths` lets you pull type definitions from installed Python packages alongside your local schema files, so codegen can resolve types that live in a shared library without copying them manually.
+
+Each entry in `schema_paths` is resolved in order and can be one of:
+
+- **Local path** — a file (`./shared/types.graphql`) or a directory (`./my_schemas/`). Directories are searched recursively for `.graphql`, `.graphqls`, and `.gql` files.
+- **Dotted Python attribute** — `some_package.SCHEMA_DIR` or `some_package.get_schema_files`. The attribute is looked up via `importlib` at codegen time:
+  - If it is **callable**, it is called and expected to return a list of file paths.
+  - If it is a **string or `Path`**, it is treated as a directory and searched recursively.
+
+```toml
+[tool.ariadne-codegen]
+schema_paths = [
+  "some_gql_commontypes.get_schema_files",   # callable → returns list of paths
+  "other_pkg.SCHEMA_DIR",                     # Path attribute → directory
+  "./my_other_packages/",                     # local directory
+  "./foo/bar.graphql",                        # local file
+]
+queries_path = "queries.graphql"
+```
+
+`schema_path`, `schema_paths` and `remote_schema_url` are mutually exclusive - only one schema source may be used at a time.
 
 ## Custom operation builder
 
@@ -424,7 +449,7 @@ Instead of generating a client, you can generate a file with a copy of a GraphQL
 ariadne-codegen graphqlschema
 ```
 
-`graphqlschema` mode reads configuration from the same place as [`client`](#configuration) but uses only `schema_path`, `remote_schema_url`, `remote_schema_headers`, `remote_schema_verify_ssl`, `remote_schema_timeout` options to retrieve the schema and `plugins` option to load plugins.
+`graphqlschema` mode reads configuration from the same place as [`client`](#configuration) but uses only `schema_path`, `schema_paths`, `remote_schema_url`, `remote_schema_headers`, `remote_schema_verify_ssl`, `remote_schema_timeout` options to retrieve the schema and `plugins` option to load plugins.
 
 In addition to the above, `graphqlschema` mode also accepts additional settings specific to it:
 

--- a/README.md
+++ b/README.md
@@ -94,18 +94,21 @@ These options control which fields are included in the GraphQL introspection que
 
 `schema_paths` lets you pull type definitions from installed Python packages alongside your local schema files, so codegen can resolve types that live in a shared library without copying them manually.
 
-Each entry in `schema_paths` is resolved in order and can be one of:
+Each entry in `schema_paths` can be any of the following:
 
-- **Local path** — a file (`./shared/types.graphql`) or a directory (`./my_schemas/`). Directories are searched recursively for `.graphql`, `.graphqls`, and `.gql` files.
-- **Dotted Python attribute** — `some_package.SCHEMA_DIR` or `some_package.get_schema_files`. The attribute is looked up via `importlib` at codegen time:
-  - If it is **callable**, it is called and expected to return a list of file paths.
-  - If it is a **string or `Path`**, it is treated as a directory and searched recursively.
+- **an absolute import path to a callable** that returns a `list[str]` of file paths, eg. `some_package.get_schema_files`
+- **an absolute import path to a variable** holding the path to a single schema file, eg. `some_package.SCHEMA_FILE`
+- **an absolute import path to a variable** holding the path to a directory — all `.graphql`, `.graphqls` and `.gql` files from it are included, eg. `some_package.SCHEMA_DIR`
+- **a path to a directory** — all `.graphql`, `.graphqls` and `.gql` files from it are included, eg. `./my_schemas/`
+- **a path to a specific file** to be used, eg. `./shared/types.graphql`
+
+An import path that cannot be resolved (missing package, or the attribute no longer exists) raises a configuration error rather than being silently skipped.
 
 ```toml
 [tool.ariadne-codegen]
 schema_paths = [
   "some_gql_commontypes.get_schema_files",   # callable → returns list of paths
-  "other_pkg.SCHEMA_DIR",                     # Path attribute → directory
+  "other_pkg.SCHEMA_DIR",                     # variable → directory
   "./my_other_packages/",                     # local directory
   "./foo/bar.graphql",                        # local file
 ]

--- a/README.md
+++ b/README.md
@@ -94,15 +94,13 @@ These options control which fields are included in the GraphQL introspection que
 
 `schema_paths` lets you pull type definitions from installed Python packages alongside your local schema files, so codegen can resolve types that live in a shared library without copying them manually.
 
-Each entry in `schema_paths` can be any of the following:
+Each entry in `schema_paths` must be one of the following:
 
 - **an absolute import path to a callable** that returns a `list[str]` of file paths, eg. `some_package.get_schema_files`
 - **an absolute import path to a variable** holding the path to a single schema file, eg. `some_package.SCHEMA_FILE`
 - **an absolute import path to a variable** holding the path to a directory — all `.graphql`, `.graphqls` and `.gql` files from it are included, eg. `some_package.SCHEMA_DIR`
 - **a path to a directory** — all `.graphql`, `.graphqls` and `.gql` files from it are included, eg. `./my_schemas/`
 - **a path to a specific file** to be used, eg. `./shared/types.graphql`
-
-An import path that cannot be resolved (missing package, or the attribute no longer exists) raises a configuration error rather than being silently skipped.
 
 ```toml
 [tool.ariadne-codegen]

--- a/ariadne_codegen/main.py
+++ b/ariadne_codegen/main.py
@@ -17,6 +17,7 @@ from .schema import (
     filter_operations_definitions,
     get_graphql_queries,
     get_graphql_schema_from_path,
+    get_graphql_schema_from_paths,
     get_graphql_schema_from_url,
 )
 from .settings import Strategy, get_validation_rule
@@ -45,6 +46,8 @@ def client(config_dict):
 
     if settings.schema_path:
         schema = get_graphql_schema_from_path(settings.schema_path)
+    elif settings.schema_paths:
+        schema = get_graphql_schema_from_paths(settings.schema_paths)
     else:
         schema = get_graphql_schema_from_url(
             url=settings.remote_schema_url,
@@ -92,17 +95,18 @@ def client(config_dict):
 def graphql_schema(config_dict):
     settings = get_graphql_schema_settings(config_dict)
 
-    schema = (
-        get_graphql_schema_from_path(settings.schema_path)
-        if settings.schema_path
-        else get_graphql_schema_from_url(
+    if settings.schema_path:
+        schema = get_graphql_schema_from_path(settings.schema_path)
+    elif settings.schema_paths:
+        schema = get_graphql_schema_from_paths(settings.schema_paths)
+    else:
+        schema = get_graphql_schema_from_url(
             url=settings.remote_schema_url,
             headers=settings.remote_schema_headers,
             verify_ssl=settings.remote_schema_verify_ssl,
             timeout=settings.remote_schema_timeout,
             introspection_settings=settings.introspection_settings,
         )
-    )
     plugin_manager = PluginManager(
         schema=schema,
         config_dict=config_dict,

--- a/ariadne_codegen/schema.py
+++ b/ariadne_codegen/schema.py
@@ -29,10 +29,11 @@ from typing_extensions import Any
 from .client_generators.constants import MIXIN_FROM_NAME, MIXIN_IMPORT_NAME, MIXIN_NAME
 from .exceptions import (
     IntrospectionError,
+    InvalidConfiguration,
     InvalidGraphqlSyntax,
     InvalidOperationForSchema,
 )
-from .settings import IntrospectionSettings
+from .settings import IntrospectionSettings, assert_path_exists
 
 
 def filter_operations_definitions(
@@ -145,39 +146,54 @@ def get_graphql_schema_from_path(schema_path: str) -> GraphQLSchema:
 def resolve_schema_paths(sources: list[str]) -> list[Path]:
     """Resolve a list of schema sources to concrete file paths.
 
-    Each entry is tried as a dotted Python import path first (e.g.
-    ``pkg.SCHEMA_DIR`` or ``pkg.get_schema_files``). If the import fails the
-    entry is treated as a local filesystem path instead.
+    Each entry is first tried as a local filesystem path - a directory (searched
+    recursively for graphql files) or a file. If it points to neither, it is
+    treated as a dotted Python import path (e.g. ``pkg.SCHEMA_DIR`` or
+    ``pkg.get_schema_files``); an import path that cannot be resolved raises
+    ``InvalidConfiguration``.
     """
     result: list[Path] = []
     for source in sources:
-        if (
-            "." in source
-            and "/" not in source
-            and not source.endswith((".graphql", ".graphqls", ".gql"))
-        ):
-            try:
-                module_path, attr = source.rsplit(".", 1)
-                module = importlib.import_module(module_path)
-                obj = getattr(module, attr)
-                if callable(obj):
-                    result.extend(Path(f) for f in obj())
-                elif isinstance(obj, (str, Path)):
-                    dir_path = Path(obj)
-                    if dir_path.is_dir():
-                        result.extend(sorted(walk_graphql_files(dir_path)))
-                    else:
-                        result.append(dir_path)
-                continue
-            except (ImportError, ModuleNotFoundError):
-                pass
-
-        local_path = Path(source)
-        if local_path.is_dir():
-            result.extend(sorted(walk_graphql_files(local_path)))
+        path = Path(source)
+        if path.is_dir():
+            result.extend(sorted(walk_graphql_files(path)))
+        elif path.is_file():
+            result.append(path)
         else:
-            result.append(local_path)
+            resolved = _resolve_import_source(source)
+            for resolved_path in resolved:
+                assert_path_exists(resolved_path.as_posix())
+            result.extend(resolved)
     return result
+
+
+def _resolve_import_source(source: str) -> list[Path]:
+    """Resolve a dotted Python import path to schema file paths.
+
+    The imported object may be a callable returning a list of paths, or a string
+    / ``Path`` pointing to a file or a directory.
+    """
+    try:
+        module_path, attr = source.rsplit(".", 1)
+        module = importlib.import_module(module_path)
+        obj = getattr(module, attr)
+    except (ImportError, AttributeError, ValueError) as exc:
+        raise InvalidConfiguration(
+            f"Could not resolve schema source '{source}'. It is neither an "
+            f"existing file/directory nor an importable attribute: {exc}."
+        ) from exc
+
+    if callable(obj):
+        return [Path(f) for f in obj()]
+    if isinstance(obj, (str, Path)):
+        obj_path = Path(obj)
+        if obj_path.is_dir():
+            return sorted(walk_graphql_files(obj_path))
+        return [obj_path]
+    raise InvalidConfiguration(
+        f"Schema source '{source}' resolved to {type(obj).__name__}; expected a "
+        "path string, a Path, or a callable returning a list of paths."
+    )
 
 
 def get_graphql_schema_from_paths(schema_paths: list[str]) -> GraphQLSchema:

--- a/ariadne_codegen/schema.py
+++ b/ariadne_codegen/schema.py
@@ -194,15 +194,10 @@ def _resolve_import_source(source: str) -> list[Path]:
 
     if callable(obj):
         return [Path(f) for f in obj()]
-    if isinstance(obj, (str, Path)):
-        obj_path = Path(obj)
-        if obj_path.is_dir():
-            return sorted(walk_graphql_files(obj_path))
-        return [obj_path]
-    raise InvalidConfiguration(
-        f"Schema source '{source}' resolved to {type(obj).__name__}; expected a "
-        "path string, a Path, or a callable returning a list of paths."
-    )
+    obj_path = Path(obj)
+    if obj_path.is_dir():
+        return sorted(walk_graphql_files(obj_path))
+    return [obj_path]
 
 
 def get_graphql_schema_from_paths(schema_paths: list[str]) -> GraphQLSchema:

--- a/ariadne_codegen/schema.py
+++ b/ariadne_codegen/schema.py
@@ -1,3 +1,4 @@
+import importlib
 from collections.abc import Generator, Sequence
 from dataclasses import asdict
 from pathlib import Path
@@ -136,6 +137,51 @@ def introspect_remote_schema(
 def get_graphql_schema_from_path(schema_path: str) -> GraphQLSchema:
     """Get graphql schema build from provided path."""
     schema_str = load_graphql_files_from_path(Path(schema_path))
+    graphql_ast = parse(schema_str)
+    schema: GraphQLSchema = build_ast_schema(graphql_ast, assume_valid=True)
+    return schema
+
+
+def resolve_schema_paths(sources: list[str]) -> list[Path]:
+    """Resolve a list of schema sources to concrete file paths.
+
+    Each entry is tried as a dotted Python import path first (e.g.
+    ``pkg.SCHEMA_DIR`` or ``pkg.get_schema_files``). If the import fails the
+    entry is treated as a local filesystem path instead.
+    """
+    result: list[Path] = []
+    for source in sources:
+        if "." in source and "/" not in source and not source.endswith(
+            (".graphql", ".graphqls", ".gql")
+        ):
+            try:
+                module_path, attr = source.rsplit(".", 1)
+                module = importlib.import_module(module_path)
+                obj = getattr(module, attr)
+                if callable(obj):
+                    result.extend(Path(f) for f in obj())
+                elif isinstance(obj, (str, Path)):
+                    dir_path = Path(obj)
+                    if dir_path.is_dir():
+                        result.extend(sorted(walk_graphql_files(dir_path)))
+                    else:
+                        result.append(dir_path)
+                continue
+            except (ImportError, ModuleNotFoundError):
+                pass
+
+        local_path = Path(source)
+        if local_path.is_dir():
+            result.extend(sorted(walk_graphql_files(local_path)))
+        else:
+            result.append(local_path)
+    return result
+
+
+def get_graphql_schema_from_paths(schema_paths: list[str]) -> GraphQLSchema:
+    """Get graphql schema built from multiple path sources."""
+    resolved = resolve_schema_paths(schema_paths)
+    schema_str = "\n".join(read_graphql_file(p) for p in resolved)
     graphql_ast = parse(schema_str)
     schema: GraphQLSchema = build_ast_schema(graphql_ast, assume_valid=True)
     return schema

--- a/ariadne_codegen/schema.py
+++ b/ariadne_codegen/schema.py
@@ -149,7 +149,7 @@ def _build_schema_from_str(schema_str: str) -> GraphQLSchema:
 
 def get_graphql_schema_from_path(schema_path: str) -> GraphQLSchema:
     """Get graphql schema built from a single file or directory path."""
-    return _build_schema_from_str(load_graphql_files_from_path(Path(schema_path)))
+    return get_graphql_schema_from_paths([schema_path])
 
 
 def resolve_schema_paths(sources: list[str]) -> list[Path]:

--- a/ariadne_codegen/schema.py
+++ b/ariadne_codegen/schema.py
@@ -135,12 +135,21 @@ def introspect_remote_schema(
     return cast(IntrospectionQuery, data)
 
 
-def get_graphql_schema_from_path(schema_path: str) -> GraphQLSchema:
-    """Get graphql schema build from provided path."""
-    schema_str = load_graphql_files_from_path(Path(schema_path))
+def _read_graphql_files(paths: list[Path]) -> str:
+    """Read and concatenate the contents of the given graphql files."""
+    return "\n".join(read_graphql_file(path) for path in paths)
+
+
+def _build_schema_from_str(schema_str: str) -> GraphQLSchema:
+    """Build a GraphQLSchema from concatenated schema source."""
     graphql_ast = parse(schema_str)
     schema: GraphQLSchema = build_ast_schema(graphql_ast, assume_valid=True)
     return schema
+
+
+def get_graphql_schema_from_path(schema_path: str) -> GraphQLSchema:
+    """Get graphql schema built from a single file or directory path."""
+    return _build_schema_from_str(load_graphql_files_from_path(Path(schema_path)))
 
 
 def resolve_schema_paths(sources: list[str]) -> list[Path]:
@@ -197,12 +206,9 @@ def _resolve_import_source(source: str) -> list[Path]:
 
 
 def get_graphql_schema_from_paths(schema_paths: list[str]) -> GraphQLSchema:
-    """Get graphql schema built from multiple path sources."""
+    """Get graphql schema built from multiple sources (paths or import paths)."""
     resolved = resolve_schema_paths(schema_paths)
-    schema_str = "\n".join(read_graphql_file(p) for p in resolved)
-    graphql_ast = parse(schema_str)
-    schema: GraphQLSchema = build_ast_schema(graphql_ast, assume_valid=True)
-    return schema
+    return _build_schema_from_str(_read_graphql_files(resolved))
 
 
 def load_graphql_files_from_path(path: Path) -> str:
@@ -211,8 +217,7 @@ def load_graphql_files_from_path(path: Path) -> str:
     If path is a directory, collect schemas from multiple files.
     """
     if path.is_dir():
-        schema_list = [read_graphql_file(f) for f in sorted(walk_graphql_files(path))]
-        return "\n".join(schema_list)
+        return _read_graphql_files(sorted(walk_graphql_files(path)))
     return read_graphql_file(path.resolve())
 
 

--- a/ariadne_codegen/schema.py
+++ b/ariadne_codegen/schema.py
@@ -1,5 +1,5 @@
 import importlib
-from collections.abc import Generator, Sequence
+from collections.abc import Generator, Iterable, Sequence
 from dataclasses import asdict
 from pathlib import Path
 from typing import Optional, cast
@@ -179,8 +179,8 @@ def resolve_schema_paths(sources: list[str]) -> list[Path]:
 def _resolve_import_source(source: str) -> list[Path]:
     """Resolve a dotted Python import path to schema file paths.
 
-    The imported object may be a callable returning a list of paths, or a string
-    / ``Path`` pointing to a file or a directory.
+    The imported object must be a callable returning a list of file paths, or a
+    string / ``Path`` pointing to a file or a directory.
     """
     try:
         module_path, attr = source.rsplit(".", 1)
@@ -193,11 +193,30 @@ def _resolve_import_source(source: str) -> list[Path]:
         ) from exc
 
     if callable(obj):
-        return [Path(f) for f in obj()]
-    obj_path = Path(obj)
+        returned = obj()
+        if isinstance(returned, (str, bytes, Path)) or not isinstance(
+            returned, Iterable
+        ):
+            raise InvalidConfiguration(
+                f"Schema source '{source}' must be a callable returning a list of "
+                f"paths, but it returned {type(returned).__name__}."
+            )
+        return [_coerce_schema_path(source, item) for item in returned]
+
+    obj_path = _coerce_schema_path(source, obj)
     if obj_path.is_dir():
         return sorted(walk_graphql_files(obj_path))
     return [obj_path]
+
+
+def _coerce_schema_path(source: str, value: object) -> Path:
+    """Coerce an imported value to a Path, or raise ``InvalidConfiguration``."""
+    if isinstance(value, (str, Path)):
+        return Path(value)
+    raise InvalidConfiguration(
+        f"Schema source '{source}' resolved to an invalid path value "
+        f"{value!r} ({type(value).__name__}); expected a str or Path."
+    )
 
 
 def get_graphql_schema_from_paths(schema_paths: list[str]) -> GraphQLSchema:

--- a/ariadne_codegen/schema.py
+++ b/ariadne_codegen/schema.py
@@ -151,8 +151,10 @@ def resolve_schema_paths(sources: list[str]) -> list[Path]:
     """
     result: list[Path] = []
     for source in sources:
-        if "." in source and "/" not in source and not source.endswith(
-            (".graphql", ".graphqls", ".gql")
+        if (
+            "." in source
+            and "/" not in source
+            and not source.endswith((".graphql", ".graphqls", ".gql"))
         ):
             try:
                 module_path, attr = source.rsplit(".", 1)

--- a/ariadne_codegen/settings.py
+++ b/ariadne_codegen/settings.py
@@ -121,6 +121,15 @@ class BaseSettings:
         return bool(self.remote_schema_url)
 
     @property
+    def schema_source(self) -> str:
+        """Return a human-readable description of the configured schema source."""
+        if self.schema_path:
+            return self.schema_path
+        if self.schema_paths:
+            return ", ".join(self.schema_paths)
+        return self.remote_schema_url
+
+    @property
     def introspection_settings(self) -> IntrospectionSettings:
         """
         Return ``IntrospectionSettings`` instance build from provided configuration.
@@ -267,14 +276,6 @@ class ClientSettings(BaseSettings):
             self.base_client_module_name = module_name
 
     @property
-    def schema_source(self) -> str:
-        if self.schema_path:
-            return self.schema_path
-        if self.schema_paths:
-            return ", ".join(self.schema_paths)
-        return self.remote_schema_url
-
-    @property
     def used_settings_message(self) -> str:
         snake_case_msg = (
             "Converting fields and arguments name to snake case."
@@ -355,16 +356,11 @@ class GraphQLSchemaSettings(BaseSettings):
             self._introspection_settings_message() if self.using_remote_schema else ""
         )
 
-        schema_source = self.schema_path or (
-            ", ".join(self.schema_paths)
-            if self.schema_paths
-            else self.remote_schema_url
-        )
         if self.target_file_format == "py":
             return dedent(
                 f"""\
                 Selected strategy: {Strategy.GRAPHQL_SCHEMA}
-                Using schema from {schema_source}
+                Using schema from {self.schema_source}
                 {introspection_msg}
                 Saving graphql schema to: {self.target_file_path}
                 Using {self.schema_variable_name} as variable name for schema.
@@ -376,7 +372,7 @@ class GraphQLSchemaSettings(BaseSettings):
         return dedent(
             f"""\
             Selected strategy: {Strategy.GRAPHQL_SCHEMA}
-            Using schema from {schema_source}
+            Using schema from {self.schema_source}
             {introspection_msg}
             Saving graphql schema to: {self.target_file_path}
             {plugins_msg}

--- a/ariadne_codegen/settings.py
+++ b/ariadne_codegen/settings.py
@@ -70,6 +70,7 @@ class IntrospectionSettings:
 @dataclass
 class BaseSettings:
     schema_path: str = ""
+    schema_paths: list[str] = field(default_factory=list)
     remote_schema_url: str = ""
     remote_schema_headers: dict = field(default_factory=dict)
     remote_schema_verify_ssl: bool = True
@@ -84,9 +85,25 @@ class BaseSettings:
     introspection_input_object_one_of: bool = False
 
     def __post_init__(self):
-        if not self.schema_path and not self.remote_schema_url:
+        provided_sources = [
+            name
+            for name, value in (
+                ("schema_path", self.schema_path),
+                ("schema_paths", self.schema_paths),
+                ("remote_schema_url", self.remote_schema_url),
+            )
+            if value
+        ]
+        if not provided_sources:
             raise InvalidConfiguration(
-                "Schema source not provided. Use schema_path or remote_schema_url"
+                "Schema source not provided. Use one of: schema_path, schema_paths,"
+                " or remote_schema_url."
+            )
+        if len(provided_sources) > 1:
+            raise InvalidConfiguration(
+                "Cannot use more than one schema source at the same time. "
+                f"Provided: {', '.join(provided_sources)}. Use only one of: "
+                "schema_path, schema_paths, or remote_schema_url."
             )
 
         if self.schema_path:
@@ -101,7 +118,7 @@ class BaseSettings:
         """
         Return true if remote schema is used as source, false otherwise.
         """
-        return bool(self.remote_schema_url) and not bool(self.schema_path)
+        return bool(self.remote_schema_url)
 
     @property
     def introspection_settings(self) -> IntrospectionSettings:
@@ -251,7 +268,11 @@ class ClientSettings(BaseSettings):
 
     @property
     def schema_source(self) -> str:
-        return self.schema_path if self.schema_path else self.remote_schema_url
+        if self.schema_path:
+            return self.schema_path
+        if self.schema_paths:
+            return ", ".join(self.schema_paths)
+        return self.remote_schema_url
 
     @property
     def used_settings_message(self) -> str:
@@ -288,7 +309,7 @@ class ClientSettings(BaseSettings):
         return dedent(
             f"""\
             Selected strategy: {Strategy.CLIENT}
-            Using schema from '{self.schema_path or self.remote_schema_url}'.
+            Using schema from '{self.schema_source}'.
             {introspection_msg}
             Reading queries from '{self.queries_path}'.
             Using '{self.target_package_name}' as package name.
@@ -334,11 +355,16 @@ class GraphQLSchemaSettings(BaseSettings):
             self._introspection_settings_message() if self.using_remote_schema else ""
         )
 
+        schema_source = self.schema_path or (
+            ", ".join(self.schema_paths)
+            if self.schema_paths
+            else self.remote_schema_url
+        )
         if self.target_file_format == "py":
             return dedent(
                 f"""\
                 Selected strategy: {Strategy.GRAPHQL_SCHEMA}
-                Using schema from {self.schema_path or self.remote_schema_url}
+                Using schema from {schema_source}
                 {introspection_msg}
                 Saving graphql schema to: {self.target_file_path}
                 Using {self.schema_variable_name} as variable name for schema.
@@ -350,7 +376,7 @@ class GraphQLSchemaSettings(BaseSettings):
         return dedent(
             f"""\
             Selected strategy: {Strategy.GRAPHQL_SCHEMA}
-            Using schema from {self.schema_path or self.remote_schema_url}
+            Using schema from {schema_source}
             {introspection_msg}
             Saving graphql schema to: {self.target_file_path}
             {plugins_msg}

--- a/docs/02-configuration.md
+++ b/docs/02-configuration.md
@@ -24,14 +24,17 @@ Exactly one of the following 3 parameters is required. They are mutually exclusi
 - `schema_paths` - list of schema sources resolved at codegen time; each entry may be a local path (file or directory) or a dotted Python attribute path (`pkg.ATTR` or `pkg.callable`). See details below.
 - `remote_schema_url` - url to graphql server, where introspection query can be perfomed
 
-### `schema_paths` resolution
+### `schema_paths` entries
 
-Each entry is resolved in order:
+Each entry in `schema_paths` can be any of the following:
 
-1. **Dotted Python attribute** (no `/` in the string, not ending with a graphql extension) — the attribute is imported via `importlib`:
-   - **callable** → called, expected to return a list of file paths
-   - **string / `Path`** → treated as a directory and searched recursively for `.graphql`, `.graphqls`, `.gql` files
-2. **Local path** (fallback when import fails, or when the entry contains `/` or has a graphql extension) — a file or directory searched recursively.
+- **an absolute import path to a callable** that returns a `list[str]` of file paths, eg. `some_pkg.get_schema_files`
+- **an absolute import path to a variable** holding the path to a single schema file, eg. `some_pkg.SCHEMA_FILE`
+- **an absolute import path to a variable** holding the path to a directory - all `.graphql`, `.graphqls` and `.gql` files from it are included, eg. `some_pkg.SCHEMA_DIR`
+- **a path to a directory** - all `.graphql`, `.graphqls` and `.gql` files from it are included, eg. `./schemas/`
+- **a path to a specific file** to be used, eg. `./foo/bar.graphql`
+
+An import path that cannot be resolved (missing package, or the attribute no longer exists) raises a configuration error rather than being silently skipped.
 
 ```toml
 [tool.ariadne-codegen]

--- a/docs/02-configuration.md
+++ b/docs/02-configuration.md
@@ -26,15 +26,13 @@ Exactly one of the following 3 parameters is required. They are mutually exclusi
 
 ### `schema_paths` entries
 
-Each entry in `schema_paths` can be any of the following:
+Each entry in `schema_paths` must be one of the following:
 
 - **an absolute import path to a callable** that returns a `list[str]` of file paths, eg. `some_pkg.get_schema_files`
 - **an absolute import path to a variable** holding the path to a single schema file, eg. `some_pkg.SCHEMA_FILE`
 - **an absolute import path to a variable** holding the path to a directory - all `.graphql`, `.graphqls` and `.gql` files from it are included, eg. `some_pkg.SCHEMA_DIR`
 - **a path to a directory** - all `.graphql`, `.graphqls` and `.gql` files from it are included, eg. `./schemas/`
 - **a path to a specific file** to be used, eg. `./foo/bar.graphql`
-
-An import path that cannot be resolved (missing package, or the attribute no longer exists) raises a configuration error rather than being silently skipped.
 
 ```toml
 [tool.ariadne-codegen]

--- a/docs/02-configuration.md
+++ b/docs/02-configuration.md
@@ -18,10 +18,31 @@ queries_path = "queries.graphql"
 
 - `queries_path` - path to file/directory with queries (Can be optional if `enable_custom_operations` is used)
 
-One of the following 2 parameters is required, in case of providing both of them `schema_path` is prioritized:
+Exactly one of the following 3 parameters is required. They are mutually exclusive - providing more than one raises a configuration error:
 
 - `schema_path` - path to file/directory with graphql schema
+- `schema_paths` - list of schema sources resolved at codegen time; each entry may be a local path (file or directory) or a dotted Python attribute path (`pkg.ATTR` or `pkg.callable`). See details below.
 - `remote_schema_url` - url to graphql server, where introspection query can be perfomed
+
+### `schema_paths` resolution
+
+Each entry is resolved in order:
+
+1. **Dotted Python attribute** (no `/` in the string, not ending with a graphql extension) — the attribute is imported via `importlib`:
+   - **callable** → called, expected to return a list of file paths
+   - **string / `Path`** → treated as a directory and searched recursively for `.graphql`, `.graphqls`, `.gql` files
+2. **Local path** (fallback when import fails, or when the entry contains `/` or has a graphql extension) — a file or directory searched recursively.
+
+```toml
+[tool.ariadne-codegen]
+schema_paths = [
+  "some_gql_commontypes.get_schema_files",
+  "other_pkg.SCHEMA_DIR",
+  "./my_other_packages/",
+  "./foo/bar.graphql",
+]
+queries_path = "queries.graphql"
+```
 
 ## Optional settings:
 

--- a/tests/client_generators/package_generator/test_generator_generation.py
+++ b/tests/client_generators/package_generator/test_generator_generation.py
@@ -42,7 +42,6 @@ def test_get_package_generator_without_default_settings(tmp_path: Path):
 
     settings_without_defaults = ClientSettings(
         schema_path=schema_path.as_posix(),
-        remote_schema_url="remote_schema_url",
         remote_schema_headers={"header": "header"},
         remote_schema_verify_ssl=False,
         remote_schema_timeout=5,

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -797,6 +797,39 @@ def test_resolve_schema_paths_raises_when_variable_points_to_missing_file(
         resolve_schema_paths(["some_pkg.SCHEMA_FILE"])
 
 
+def test_resolve_schema_paths_raises_when_callable_returns_non_iterable(mocker):
+    mock_module = mocker.Mock()
+    mock_module.get_files = mocker.Mock(return_value=42)  # not a list of paths
+    mocker.patch(
+        "ariadne_codegen.schema.importlib.import_module", return_value=mock_module
+    )
+
+    with pytest.raises(InvalidConfiguration):
+        resolve_schema_paths(["some_pkg.get_files"])
+
+
+def test_resolve_schema_paths_raises_when_callable_returns_invalid_item(mocker):
+    mock_module = mocker.Mock()
+    mock_module.get_files = mocker.Mock(return_value=[None, 123])  # not paths
+    mocker.patch(
+        "ariadne_codegen.schema.importlib.import_module", return_value=mock_module
+    )
+
+    with pytest.raises(InvalidConfiguration):
+        resolve_schema_paths(["some_pkg.get_files"])
+
+
+def test_resolve_schema_paths_raises_when_variable_is_wrong_type(mocker):
+    mock_module = mocker.Mock()
+    mock_module.NOT_A_PATH = 123  # not callable, not str/Path
+    mocker.patch(
+        "ariadne_codegen.schema.importlib.import_module", return_value=mock_module
+    )
+
+    with pytest.raises(InvalidConfiguration):
+        resolve_schema_paths(["some_pkg.NOT_A_PATH"])
+
+
 def test_resolve_schema_paths_raises_invalid_configuration_for_source_without_dot(
     tmp_path,
 ):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -12,9 +12,11 @@ from ariadne_codegen.exceptions import (
 from ariadne_codegen.schema import (
     get_graphql_queries,
     get_graphql_schema_from_path,
+    get_graphql_schema_from_paths,
     introspect_remote_schema,
     load_graphql_files_from_path,
     read_graphql_file,
+    resolve_schema_paths,
     walk_graphql_files,
 )
 from ariadne_codegen.settings import IntrospectionSettings, get_validation_rule
@@ -652,3 +654,158 @@ def test_introspect_remote_schema_uses_default_introspection_settings_when_not_p
         input_value_deprecation=False,
         input_object_one_of=False,
     )
+
+
+def test_resolve_schema_paths_with_single_file(tmp_path, schema_str):
+    schema_file = tmp_path / "schema.graphql"
+    schema_file.write_text(schema_str, encoding="utf-8")
+
+    result = resolve_schema_paths([schema_file.as_posix()])
+
+    assert result == [schema_file]
+
+
+def test_resolve_schema_paths_with_directory(schemas_directory):
+    result = resolve_schema_paths([schemas_directory.as_posix()])
+
+    names = {p.name for p in result}
+    assert "schema.graphql" in names
+    assert "user.graphql" in names
+
+
+def test_resolve_schema_paths_with_multiple_local_sources(
+    tmp_path, schema_str, extra_type_str
+):
+    file1 = tmp_path / "schema.graphql"
+    file1.write_text(schema_str, encoding="utf-8")
+    file2 = tmp_path / "user.graphql"
+    file2.write_text(extra_type_str, encoding="utf-8")
+
+    result = resolve_schema_paths([file1.as_posix(), file2.as_posix()])
+
+    assert file1 in result
+    assert file2 in result
+    assert len(result) == 2
+
+
+def test_resolve_schema_paths_with_callable_python_attribute(
+    tmp_path, schema_str, mocker
+):
+    schema_file = tmp_path / "schema.graphql"
+    schema_file.write_text(schema_str, encoding="utf-8")
+
+    mock_callable = mocker.Mock(return_value=[schema_file.as_posix()])
+    mock_module = mocker.Mock()
+    mock_module.get_files = mock_callable
+    mocker.patch(
+        "ariadne_codegen.schema.importlib.import_module", return_value=mock_module
+    )
+
+    result = resolve_schema_paths(["some_pkg.get_files"])
+
+    assert result == [Path(schema_file.as_posix())]
+    mock_callable.assert_called_once()
+
+
+def test_resolve_schema_paths_with_path_attribute_pointing_to_directory(
+    schemas_directory, mocker
+):
+    mock_module = mocker.Mock()
+    mock_module.SCHEMA_DIR = schemas_directory.as_posix()
+    mocker.patch(
+        "ariadne_codegen.schema.importlib.import_module", return_value=mock_module
+    )
+
+    result = resolve_schema_paths(["some_pkg.SCHEMA_DIR"])
+
+    names = {p.name for p in result}
+    assert "schema.graphql" in names
+    assert "user.graphql" in names
+
+
+def test_resolve_schema_paths_falls_back_to_local_path_on_import_error(mocker):
+    mocker.patch(
+        "ariadne_codegen.schema.importlib.import_module",
+        side_effect=ImportError("module not found"),
+    )
+
+    result = resolve_schema_paths(["nonexistent_pkg.attr"])
+
+    assert result == [Path("nonexistent_pkg.attr")]
+
+
+def test_resolve_schema_paths_with_slash_skips_importlib(tmp_path, schema_str, mocker):
+    schema_file = tmp_path / "schema.graphql"
+    schema_file.write_text(schema_str, encoding="utf-8")
+    mock_import = mocker.patch("ariadne_codegen.schema.importlib.import_module")
+
+    resolve_schema_paths([schema_file.as_posix()])
+
+    mock_import.assert_not_called()
+
+
+def test_resolve_schema_paths_with_graphql_extension_skips_importlib(
+    tmp_path, schema_str, mocker
+):
+    schema_file = tmp_path / "schema.graphql"
+    schema_file.write_text(schema_str, encoding="utf-8")
+    mock_import = mocker.patch("ariadne_codegen.schema.importlib.import_module")
+
+    resolve_schema_paths(["schema.graphql"])
+
+    mock_import.assert_not_called()
+
+
+def test_resolve_schema_paths_with_graphqls_extension_skips_importlib(mocker):
+    mock_import = mocker.patch("ariadne_codegen.schema.importlib.import_module")
+
+    resolve_schema_paths(["types.graphqls"])
+
+    mock_import.assert_not_called()
+
+
+def test_get_graphql_schema_from_paths_returns_graphql_schema(
+    tmp_path, schema_str, extra_type_str
+):
+    file1 = tmp_path / "schema.graphql"
+    file1.write_text(schema_str, encoding="utf-8")
+    file2 = tmp_path / "user.graphql"
+    file2.write_text(extra_type_str, encoding="utf-8")
+
+    result = get_graphql_schema_from_paths([file1.as_posix(), file2.as_posix()])
+
+    assert isinstance(result, GraphQLSchema)
+    assert "Custom" in result.type_map
+    assert "User" in result.type_map
+
+
+def test_get_graphql_schema_from_paths_with_directory_source(schemas_directory):
+    result = get_graphql_schema_from_paths([schemas_directory.as_posix()])
+
+    assert isinstance(result, GraphQLSchema)
+    assert "Custom" in result.type_map
+    assert "User" in result.type_map
+
+
+def test_get_graphql_schema_from_paths_merges_types_from_all_sources(
+    tmp_path, schema_str, extra_type_str
+):
+    dir1 = tmp_path / "base"
+    dir1.mkdir()
+    (dir1 / "schema.graphql").write_text(schema_str, encoding="utf-8")
+
+    dir2 = tmp_path / "extra"
+    dir2.mkdir()
+    (dir2 / "user.graphql").write_text(extra_type_str, encoding="utf-8")
+
+    result = get_graphql_schema_from_paths([dir1.as_posix(), dir2.as_posix()])
+
+    assert "Custom" in result.type_map
+    assert "User" in result.type_map
+
+
+def test_get_graphql_schema_from_paths_with_invalid_syntax_raises_invalid_graphql_syntax(
+    invalid_syntax_schema_file,
+):
+    with pytest.raises(InvalidGraphqlSyntax):
+        get_graphql_schema_from_paths([invalid_syntax_schema_file.as_posix()])

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -6,6 +6,7 @@ from graphql import GraphQLSchema, OperationDefinitionNode, build_schema
 
 from ariadne_codegen.exceptions import (
     IntrospectionError,
+    InvalidConfiguration,
     InvalidGraphqlSyntax,
     InvalidOperationForSchema,
 )
@@ -723,18 +724,57 @@ def test_resolve_schema_paths_with_path_attribute_pointing_to_directory(
     assert "user.graphql" in names
 
 
-def test_resolve_schema_paths_falls_back_to_local_path_on_import_error(mocker):
+def test_resolve_schema_paths_raises_invalid_configuration_on_import_error(mocker):
     mocker.patch(
         "ariadne_codegen.schema.importlib.import_module",
         side_effect=ImportError("module not found"),
     )
 
-    result = resolve_schema_paths(["nonexistent_pkg.attr"])
+    with pytest.raises(InvalidConfiguration):
+        resolve_schema_paths(["nonexistent_pkg.attr"])
 
-    assert result == [Path("nonexistent_pkg.attr")]
+
+def test_resolve_schema_paths_raises_invalid_configuration_on_missing_attribute(mocker):
+    mock_module = mocker.Mock(spec=[])
+    mocker.patch(
+        "ariadne_codegen.schema.importlib.import_module", return_value=mock_module
+    )
+
+    with pytest.raises(InvalidConfiguration):
+        resolve_schema_paths(["some_pkg.MISSING_ATTR"])
 
 
-def test_resolve_schema_paths_with_slash_skips_importlib(tmp_path, schema_str, mocker):
+def test_resolve_schema_paths_raises_when_callable_returns_missing_file(
+    tmp_path, mocker
+):
+    missing = tmp_path / "missing.graphql"  # never created
+    mock_module = mocker.Mock()
+    mock_module.get_files = mocker.Mock(return_value=[missing.as_posix()])
+    mocker.patch(
+        "ariadne_codegen.schema.importlib.import_module", return_value=mock_module
+    )
+
+    with pytest.raises(InvalidConfiguration):
+        resolve_schema_paths(["some_pkg.get_files"])
+
+
+def test_resolve_schema_paths_raises_when_variable_points_to_missing_file(
+    tmp_path, mocker
+):
+    missing = tmp_path / "missing.graphql"  # never created
+    mock_module = mocker.Mock()
+    mock_module.SCHEMA_FILE = missing.as_posix()
+    mocker.patch(
+        "ariadne_codegen.schema.importlib.import_module", return_value=mock_module
+    )
+
+    with pytest.raises(InvalidConfiguration):
+        resolve_schema_paths(["some_pkg.SCHEMA_FILE"])
+
+
+def test_resolve_schema_paths_existing_file_skips_importlib(
+    tmp_path, schema_str, mocker
+):
     schema_file = tmp_path / "schema.graphql"
     schema_file.write_text(schema_str, encoding="utf-8")
     mock_import = mocker.patch("ariadne_codegen.schema.importlib.import_module")
@@ -744,24 +784,79 @@ def test_resolve_schema_paths_with_slash_skips_importlib(tmp_path, schema_str, m
     mock_import.assert_not_called()
 
 
-def test_resolve_schema_paths_with_graphql_extension_skips_importlib(
+def test_resolve_schema_paths_accepts_file_with_any_extension(tmp_path, schema_str):
+    schema_file = tmp_path / "my_schema_file.any"
+    schema_file.write_text(schema_str, encoding="utf-8")
+
+    result = resolve_schema_paths([schema_file.as_posix()])
+
+    assert result == [schema_file]
+
+
+def test_resolve_schema_paths_accepts_local_file_with_dots_in_name(
+    tmp_path, schema_str, mocker
+):
+    # a dotted filename must be treated as a local file, not an import path
+    schema_file = tmp_path / "my.schema.graphql"
+    schema_file.write_text(schema_str, encoding="utf-8")
+    mock_import = mocker.patch("ariadne_codegen.schema.importlib.import_module")
+
+    result = resolve_schema_paths([schema_file.as_posix()])
+
+    assert result == [schema_file]
+    mock_import.assert_not_called()
+
+
+def test_resolve_schema_paths_accepts_local_dir_with_dots_in_name(
+    tmp_path, schema_str, extra_type_str, mocker
+):
+    # a dotted directory path must be treated as a local dir, not an import path
+    schemas_dir = tmp_path / "my.schemas.dir"
+    schemas_dir.mkdir()
+    (schemas_dir / "schema.graphql").write_text(schema_str, encoding="utf-8")
+    (schemas_dir / "user.graphql").write_text(extra_type_str, encoding="utf-8")
+    mock_import = mocker.patch("ariadne_codegen.schema.importlib.import_module")
+
+    result = resolve_schema_paths([schemas_dir.as_posix()])
+
+    assert {p.name for p in result} == {"schema.graphql", "user.graphql"}
+    mock_import.assert_not_called()
+
+
+def test_resolve_schema_paths_with_path_attribute_pointing_to_file(
     tmp_path, schema_str, mocker
 ):
     schema_file = tmp_path / "schema.graphql"
     schema_file.write_text(schema_str, encoding="utf-8")
-    mock_import = mocker.patch("ariadne_codegen.schema.importlib.import_module")
+    mock_module = mocker.Mock()
+    mock_module.SCHEMA_FILE = schema_file.as_posix()
+    mocker.patch(
+        "ariadne_codegen.schema.importlib.import_module", return_value=mock_module
+    )
 
-    resolve_schema_paths(["schema.graphql"])
+    result = resolve_schema_paths(["some_pkg.SCHEMA_FILE"])
 
-    mock_import.assert_not_called()
+    assert result == [schema_file]
 
 
-def test_resolve_schema_paths_with_graphqls_extension_skips_importlib(mocker):
-    mock_import = mocker.patch("ariadne_codegen.schema.importlib.import_module")
+def test_resolve_schema_paths_raises_invalid_configuration_for_source_without_dot(
+    tmp_path,
+):
+    missing = tmp_path / "does_not_exist"  # neither a file/dir nor a dotted path
 
-    resolve_schema_paths(["types.graphqls"])
+    with pytest.raises(InvalidConfiguration):
+        resolve_schema_paths([missing.name])
 
-    mock_import.assert_not_called()
+
+def test_resolve_schema_paths_raises_invalid_configuration_for_unexpected_type(mocker):
+    mock_module = mocker.Mock()
+    mock_module.NOT_A_PATH = 123  # not callable, not str/Path
+    mocker.patch(
+        "ariadne_codegen.schema.importlib.import_module", return_value=mock_module
+    )
+
+    with pytest.raises(InvalidConfiguration):
+        resolve_schema_paths(["some_pkg.NOT_A_PATH"])
 
 
 def test_get_graphql_schema_from_paths_returns_graphql_schema(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -806,17 +806,6 @@ def test_resolve_schema_paths_raises_invalid_configuration_for_source_without_do
         resolve_schema_paths([missing.name])
 
 
-def test_resolve_schema_paths_raises_invalid_configuration_for_unexpected_type(mocker):
-    mock_module = mocker.Mock()
-    mock_module.NOT_A_PATH = 123  # not callable, not str/Path
-    mocker.patch(
-        "ariadne_codegen.schema.importlib.import_module", return_value=mock_module
-    )
-
-    with pytest.raises(InvalidConfiguration):
-        resolve_schema_paths(["some_pkg.NOT_A_PATH"])
-
-
 def test_get_graphql_schema_from_paths_returns_graphql_schema(
     tmp_path, schema_str, extra_type_str
 ):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -804,7 +804,7 @@ def test_get_graphql_schema_from_paths_merges_types_from_all_sources(
     assert "User" in result.type_map
 
 
-def test_get_graphql_schema_from_paths_with_invalid_syntax_raises_invalid_graphql_syntax(
+def test_get_graphql_schema_from_paths_invalid_syntax_raises_invalid_graphql_syntax(
     invalid_syntax_schema_file,
 ):
     with pytest.raises(InvalidGraphqlSyntax):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -657,36 +657,18 @@ def test_introspect_remote_schema_uses_default_introspection_settings_when_not_p
     )
 
 
-def test_resolve_schema_paths_with_single_file(tmp_path, schema_str):
-    schema_file = tmp_path / "schema.graphql"
-    schema_file.write_text(schema_str, encoding="utf-8")
-
-    result = resolve_schema_paths([schema_file.as_posix()])
-
-    assert result == [schema_file]
-
-
-def test_resolve_schema_paths_with_directory(schemas_directory):
-    result = resolve_schema_paths([schemas_directory.as_posix()])
-
-    names = {p.name for p in result}
-    assert "schema.graphql" in names
-    assert "user.graphql" in names
-
-
-def test_resolve_schema_paths_with_multiple_local_sources(
-    tmp_path, schema_str, extra_type_str
+def test_resolve_schema_paths_with_local_files_and_directories(
+    tmp_path, schema_str, schemas_directory
 ):
-    file1 = tmp_path / "schema.graphql"
-    file1.write_text(schema_str, encoding="utf-8")
-    file2 = tmp_path / "user.graphql"
-    file2.write_text(extra_type_str, encoding="utf-8")
+    single_file = tmp_path / "extra.graphql"
+    single_file.write_text(schema_str, encoding="utf-8")
 
-    result = resolve_schema_paths([file1.as_posix(), file2.as_posix()])
+    result = resolve_schema_paths(
+        [single_file.as_posix(), schemas_directory.as_posix()]
+    )
 
-    assert file1 in result
-    assert file2 in result
-    assert len(result) == 2
+    assert single_file in result
+    assert {"schema.graphql", "user.graphql"}.issubset({p.name for p in result})
 
 
 def test_resolve_schema_paths_with_callable_python_attribute(
@@ -722,6 +704,49 @@ def test_resolve_schema_paths_with_path_attribute_pointing_to_directory(
     names = {p.name for p in result}
     assert "schema.graphql" in names
     assert "user.graphql" in names
+
+
+def test_resolve_schema_paths_with_path_attribute_pointing_to_file(
+    tmp_path, schema_str, mocker
+):
+    schema_file = tmp_path / "schema.graphql"
+    schema_file.write_text(schema_str, encoding="utf-8")
+    mock_module = mocker.Mock()
+    mock_module.SCHEMA_FILE = schema_file.as_posix()
+    mocker.patch(
+        "ariadne_codegen.schema.importlib.import_module", return_value=mock_module
+    )
+
+    result = resolve_schema_paths(["some_pkg.SCHEMA_FILE"])
+
+    assert result == [schema_file]
+
+
+def test_resolve_schema_paths_accepts_file_with_any_extension(tmp_path, schema_str):
+    schema_file = tmp_path / "my_schema_file.any"
+    schema_file.write_text(schema_str, encoding="utf-8")
+
+    result = resolve_schema_paths([schema_file.as_posix()])
+
+    assert result == [schema_file]
+
+
+def test_resolve_schema_paths_accepts_local_dotted_names(
+    tmp_path, schema_str, extra_type_str, mocker
+):
+    # dotted file/directory names must be treated as local paths, not import paths
+    dotted_file = tmp_path / "my.schema.graphql"
+    dotted_file.write_text(schema_str, encoding="utf-8")
+    dotted_dir = tmp_path / "my.schemas.dir"
+    dotted_dir.mkdir()
+    (dotted_dir / "user.graphql").write_text(extra_type_str, encoding="utf-8")
+    mock_import = mocker.patch("ariadne_codegen.schema.importlib.import_module")
+
+    result = resolve_schema_paths([dotted_file.as_posix(), dotted_dir.as_posix()])
+
+    assert dotted_file in result
+    assert {"my.schema.graphql", "user.graphql"} == {p.name for p in result}
+    mock_import.assert_not_called()
 
 
 def test_resolve_schema_paths_raises_invalid_configuration_on_import_error(mocker):
@@ -770,73 +795,6 @@ def test_resolve_schema_paths_raises_when_variable_points_to_missing_file(
 
     with pytest.raises(InvalidConfiguration):
         resolve_schema_paths(["some_pkg.SCHEMA_FILE"])
-
-
-def test_resolve_schema_paths_existing_file_skips_importlib(
-    tmp_path, schema_str, mocker
-):
-    schema_file = tmp_path / "schema.graphql"
-    schema_file.write_text(schema_str, encoding="utf-8")
-    mock_import = mocker.patch("ariadne_codegen.schema.importlib.import_module")
-
-    resolve_schema_paths([schema_file.as_posix()])
-
-    mock_import.assert_not_called()
-
-
-def test_resolve_schema_paths_accepts_file_with_any_extension(tmp_path, schema_str):
-    schema_file = tmp_path / "my_schema_file.any"
-    schema_file.write_text(schema_str, encoding="utf-8")
-
-    result = resolve_schema_paths([schema_file.as_posix()])
-
-    assert result == [schema_file]
-
-
-def test_resolve_schema_paths_accepts_local_file_with_dots_in_name(
-    tmp_path, schema_str, mocker
-):
-    # a dotted filename must be treated as a local file, not an import path
-    schema_file = tmp_path / "my.schema.graphql"
-    schema_file.write_text(schema_str, encoding="utf-8")
-    mock_import = mocker.patch("ariadne_codegen.schema.importlib.import_module")
-
-    result = resolve_schema_paths([schema_file.as_posix()])
-
-    assert result == [schema_file]
-    mock_import.assert_not_called()
-
-
-def test_resolve_schema_paths_accepts_local_dir_with_dots_in_name(
-    tmp_path, schema_str, extra_type_str, mocker
-):
-    # a dotted directory path must be treated as a local dir, not an import path
-    schemas_dir = tmp_path / "my.schemas.dir"
-    schemas_dir.mkdir()
-    (schemas_dir / "schema.graphql").write_text(schema_str, encoding="utf-8")
-    (schemas_dir / "user.graphql").write_text(extra_type_str, encoding="utf-8")
-    mock_import = mocker.patch("ariadne_codegen.schema.importlib.import_module")
-
-    result = resolve_schema_paths([schemas_dir.as_posix()])
-
-    assert {p.name for p in result} == {"schema.graphql", "user.graphql"}
-    mock_import.assert_not_called()
-
-
-def test_resolve_schema_paths_with_path_attribute_pointing_to_file(
-    tmp_path, schema_str, mocker
-):
-    schema_file = tmp_path / "schema.graphql"
-    schema_file.write_text(schema_str, encoding="utf-8")
-    mock_module = mocker.Mock()
-    mock_module.SCHEMA_FILE = schema_file.as_posix()
-    mocker.patch(
-        "ariadne_codegen.schema.importlib.import_module", return_value=mock_module
-    )
-
-    result = resolve_schema_paths(["some_pkg.SCHEMA_FILE"])
-
-    assert result == [schema_file]
 
 
 def test_resolve_schema_paths_raises_invalid_configuration_for_source_without_dot(

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -583,7 +583,7 @@ def test_using_remote_schema_false_when_only_schema_path_is_provided(tmp_path):
     assert settings.using_remote_schema is False
 
 
-def test_client_settings_with_schema_path_and_remote_schema_url_raises_invalid_configuration(
+def test_client_settings_schema_path_and_remote_url_raises_invalid_configuration(
     tmp_path,
 ):
     """
@@ -748,7 +748,7 @@ def test_client_settings_with_schema_path_and_schema_paths_raises_invalid_config
         )
 
 
-def test_graphql_schema_settings_with_schema_path_and_schema_paths_raises_invalid_configuration(
+def test_graphql_schema_settings_schema_path_and_paths_raises_invalid_configuration(
     tmp_path,
 ):
     schema_path = tmp_path / "schema.graphql"
@@ -761,7 +761,7 @@ def test_graphql_schema_settings_with_schema_path_and_schema_paths_raises_invali
         )
 
 
-def test_client_settings_with_schema_paths_and_remote_schema_url_raises_invalid_configuration(
+def test_client_settings_schema_paths_and_remote_url_raises_invalid_configuration(
     tmp_path,
 ):
     queries_path = tmp_path / "queries.graphql"
@@ -785,7 +785,7 @@ def test_client_settings_without_any_schema_source_raises_invalid_configuration(
         ClientSettings(queries_path=queries_path.as_posix())
 
 
-def test_graphql_schema_settings_without_any_schema_source_raises_invalid_configuration():
+def test_graphql_schema_settings_without_schema_source_raises_invalid_configuration():
     with pytest.raises(InvalidConfiguration):
         GraphQLSchemaSettings()
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -583,32 +583,24 @@ def test_using_remote_schema_false_when_only_schema_path_is_provided(tmp_path):
     assert settings.using_remote_schema is False
 
 
-def test_using_remote_schema_false_when_both_provided(tmp_path):
+def test_client_settings_with_schema_path_and_remote_schema_url_raises_invalid_configuration(
+    tmp_path,
+):
     """
-    Test that using_remote_schema is False when both schema_path and remote_schema_url
-    are provided.
+    Test that providing both schema_path and remote_schema_url is rejected:
+    only one schema source may be selected at a time.
     """
     schema_path = tmp_path / "schema.graphql"
     schema_path.touch()
     queries_path = tmp_path / "queries.graphql"
     queries_path.touch()
 
-    base_client_file_content = """
-    class BaseClient:
-        pass
-    """
-    base_client_file_path = tmp_path / "base_client.py"
-    base_client_file_path.write_text(dedent(base_client_file_content))
-
-    settings = ClientSettings(
-        schema_path=schema_path.as_posix(),
-        remote_schema_url="http://testserver/graphql/",
-        queries_path=queries_path.as_posix(),
-        base_client_name="BaseClient",
-        base_client_file_path=base_client_file_path.as_posix(),
-    )
-
-    assert settings.using_remote_schema is False
+    with pytest.raises(InvalidConfiguration):
+        ClientSettings(
+            schema_path=schema_path.as_posix(),
+            remote_schema_url="http://testserver/graphql/",
+            queries_path=queries_path.as_posix(),
+        )
 
 
 def test_introspection_settings_defaults(tmp_path):
@@ -721,9 +713,123 @@ def test_graphql_schema_settings_used_settings_message_includes_introspection(
     )
     assert "Introspection settings:" not in local_settings.used_settings_message
 
-    both_settings = GraphQLSchemaSettings(
-        schema_path=schema_path.as_posix(),
-        remote_schema_url="http://testserver/graphql/",
-        introspection_specified_by_url=True,
+
+def test_client_settings_with_schema_paths_is_valid(tmp_path):
+    queries_path = tmp_path / "queries.graphql"
+    queries_path.touch()
+
+    settings = ClientSettings(
+        schema_paths=["pkg.get_files", "./schemas/"],
+        queries_path=queries_path.as_posix(),
     )
-    assert "Introspection settings:" not in both_settings.used_settings_message
+
+    assert settings.schema_paths == ["pkg.get_files", "./schemas/"]
+
+
+def test_graphql_schema_settings_with_schema_paths_is_valid():
+    settings = GraphQLSchemaSettings(schema_paths=["pkg.SCHEMA_DIR"])
+
+    assert settings.schema_paths == ["pkg.SCHEMA_DIR"]
+
+
+def test_client_settings_with_schema_path_and_schema_paths_raises_invalid_configuration(
+    tmp_path,
+):
+    schema_path = tmp_path / "schema.graphql"
+    schema_path.touch()
+    queries_path = tmp_path / "queries.graphql"
+    queries_path.touch()
+
+    with pytest.raises(InvalidConfiguration):
+        ClientSettings(
+            schema_path=schema_path.as_posix(),
+            schema_paths=["pkg.get_files"],
+            queries_path=queries_path.as_posix(),
+        )
+
+
+def test_graphql_schema_settings_with_schema_path_and_schema_paths_raises_invalid_configuration(
+    tmp_path,
+):
+    schema_path = tmp_path / "schema.graphql"
+    schema_path.touch()
+
+    with pytest.raises(InvalidConfiguration):
+        GraphQLSchemaSettings(
+            schema_path=schema_path.as_posix(),
+            schema_paths=["pkg.get_files"],
+        )
+
+
+def test_client_settings_with_schema_paths_and_remote_schema_url_raises_invalid_configuration(
+    tmp_path,
+):
+    queries_path = tmp_path / "queries.graphql"
+    queries_path.touch()
+
+    with pytest.raises(InvalidConfiguration):
+        ClientSettings(
+            schema_paths=["pkg.get_files"],
+            remote_schema_url="http://testserver/graphql/",
+            queries_path=queries_path.as_posix(),
+        )
+
+
+def test_client_settings_without_any_schema_source_raises_invalid_configuration(
+    tmp_path,
+):
+    queries_path = tmp_path / "queries.graphql"
+    queries_path.touch()
+
+    with pytest.raises(InvalidConfiguration):
+        ClientSettings(queries_path=queries_path.as_posix())
+
+
+def test_graphql_schema_settings_without_any_schema_source_raises_invalid_configuration():
+    with pytest.raises(InvalidConfiguration):
+        GraphQLSchemaSettings()
+
+
+def test_using_remote_schema_false_when_schema_paths_provided(tmp_path):
+    queries_path = tmp_path / "queries.graphql"
+    queries_path.touch()
+
+    settings = ClientSettings(
+        schema_paths=["pkg.get_files"],
+        queries_path=queries_path.as_posix(),
+    )
+
+    assert settings.using_remote_schema is False
+
+
+def test_client_settings_schema_source_returns_schema_paths_joined(tmp_path):
+    queries_path = tmp_path / "queries.graphql"
+    queries_path.touch()
+
+    settings = ClientSettings(
+        schema_paths=["pkg.get_files", "./extra/"],
+        queries_path=queries_path.as_posix(),
+    )
+
+    assert settings.schema_source == "pkg.get_files, ./extra/"
+
+
+def test_client_settings_used_settings_message_includes_schema_paths(tmp_path):
+    queries_path = tmp_path / "queries.graphql"
+    queries_path.touch()
+
+    settings = ClientSettings(
+        schema_paths=["pkg.get_files", "./schemas/"],
+        queries_path=queries_path.as_posix(),
+    )
+
+    result = settings.used_settings_message
+    assert "pkg.get_files" in result
+    assert "./schemas/" in result
+
+
+def test_graphql_schema_settings_used_settings_message_includes_schema_paths():
+    settings = GraphQLSchemaSettings(schema_paths=["pkg.SCHEMA_DIR"])
+
+    result = settings.used_settings_message
+    assert "pkg.SCHEMA_DIR" in result


### PR DESCRIPTION
Introduce a new `schema_paths` setting that builds the GraphQL schema from
multiple sources. Each entry is resolved either as a dotted Python attribute
path (e.g. `pkg.SCHEMA_DIR` or `pkg.get_schema_files`) - useful for pulling
type definitions from installed packages - or as a local file/directory path.

- schema.py: add `resolve_schema_paths` and `get_graphql_schema_from_paths`
- main.py: wire `schema_paths` into both `client` and `graphqlschema` strategies
- settings.py: add the `schema_paths` field and make the three schema sources
  (`schema_path`, `schema_paths`, `remote_schema_url`) mutually exclusive -
  providing more than one now raises InvalidConfiguration; simplify
  `using_remote_schema` accordingly
- docs/README: document `schema_paths` and the mutual-exclusivity rule

CI/CD does not pass. This is an unrelated error that is being fixed as part of [AR-6](https://github.com/mirumee/ariadne-codegen/pull/437)


## Acknowledgements

While working on this, we noticed #431 by @esfomeado, which also tackled
loading the schema from more than one source. After discussing it as a team,
we went with a different approach - a dedicated `schema_paths` setting that
additionally resolves dotted Python attribute paths from installed packages -
which we felt fit the project better. Thanks @esfomeado for raising the problem
and for your contribution! 🙏

Co-authored-by: esfomeado <1906254+esfomeado@users.noreply.github.com>


[AR-6]: https://mirumee.atlassian.net/browse/AR-6?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ