### PR TITLE
Add failing test: duplicate typename__ when type implements multiple interfaces

### DIFF
--- a/tests/client_generators/result_types_generator/test_duplicate_typename.py
+++ b/tests/client_generators/result_types_generator/test_duplicate_typename.py
@@ -1,0 +1,69 @@
+import ast
+
+import pytest
+from graphql import OperationDefinitionNode, build_schema, parse
+
+from ariadne_codegen.client_generators.constants import TYPENAME_ALIAS
+from ariadne_codegen.client_generators.result_types import ResultTypesGenerator
+
+SCHEMA = """
+    type Query {
+        foo: Foo
+    }
+
+    interface Bar {
+        id: ID!
+    }
+
+    interface Baz {
+        name: String!
+    }
+
+    type Foo implements Bar & Baz {
+        id: ID!
+        name: String!
+    }
+"""
+
+
+@pytest.mark.xfail(reason="Codegen emits duplicate typename__ for multi-interface types")
+def test_no_duplicate_typename_when_type_implements_multiple_interfaces():
+    schema = build_schema(SCHEMA)
+
+    query_str = """
+        query GetFoo {
+            foo {
+                ... on Bar {
+                    __typename
+                    id
+                }
+                ... on Baz {
+                    __typename
+                    name
+                }
+            }
+        }
+    """
+
+    document = parse(query_str)
+    operation = document.definitions[0]
+    assert isinstance(operation, OperationDefinitionNode)
+
+    generator = ResultTypesGenerator(
+        schema=schema,
+        operation_definition=operation,
+        enums_module_name="enums",
+    )
+
+    class_defs = generator.get_classes()
+    foo_class = next(c for c in class_defs if c.name == "GetFooFoo")
+
+    typename_fields = [
+        node
+        for node in foo_class.body
+        if isinstance(node, ast.AnnAssign)
+        and isinstance(node.target, ast.Name)
+        and node.target.id == TYPENAME_ALIAS
+    ]
+
+    assert len(typename_fields) == 1


### PR DESCRIPTION
When a concrete type implements multiple interfaces and a query spreads on both with `__typename`, codegen emits the field twice — which makes mypy blow up with `Name "typename__" already defined [no-redef]`.

```graphql
type Foo implements Bar & Baz { id: ID!, name: String! }

query GetFoo {
    foo {
        ... on Bar { __typename id }
        ... on Baz { __typename name }
    }
}
```

Actual:
```python
class GetFooFoo(BaseModel):
    typename__: Literal["Foo"] = Field(alias="__typename")
    id: str
    typename__: Literal["Foo"] = Field(alias="__typename")
    name: str
```

Expected:
```python
class GetFooFoo(BaseModel):
    typename__: Literal["Foo"] = Field(alias="__typename")
    id: str
    name: str
```

Works fine at runtime (pydantic is happy), but mypy won't accept it.

Fix is at https://github.com/magicmark/ariadne-codegen/pull/1 (on my fork for now — can't target a fork branch as base on upstream).