### PR TITLE
feat: Allow to use custom client for fetching remote schema [AR-2]

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Optional settings:
 - `remote_schema_headers` - extra headers that are passed along with introspection query, eg. `{"Authorization" = "Bearer token"}`. To include an environment variable in a header value, prefix the variable with `$`, eg. `{"Authorization" = "$AUTH_TOKEN"}`
 - `remote_schema_verify_ssl` (defaults to `true`) - a flag that specifies wheter to verify ssl while introspecting remote schema
 - `remote_schema_timeout` (defaults to `5`) - timeout in seconds while introspecting remote schema
+- `remote_schema_http_client_path` - absolute import path to the HTTP client class used to introspect remote schema. If not provided, default `httpx` client is used.
 - `target_package_name` (defaults to `"graphql_client"`) - name of generated package
 - `target_package_path` (defaults to cwd) - path where to generate package
 - `client_name` (defaults to `"Client"`) - name of generated client class
@@ -498,7 +499,7 @@ Instead of generating a client, you can generate a file with a copy of a GraphQL
 ariadne-codegen graphqlschema
 ```
 
-`graphqlschema` mode reads configuration from the same place as [`client`](#configuration) but uses only `schema_path`, `schema_paths`, `remote_schema_url`, `remote_schema_headers`, `remote_schema_verify_ssl`, `remote_schema_timeout` options to retrieve the schema and `plugins` option to load plugins.
+`graphqlschema` mode reads configuration from the same place as [`client`](#configuration) but uses only `schema_path`, `schema_paths`, `remote_schema_url`, `remote_schema_headers`, `remote_schema_verify_ssl`, `remote_schema_timeout`, `remote_schema_http_client_path` options to retrieve the schema and `plugins` option to load plugins.
 
 In addition to the above, `graphqlschema` mode also accepts additional settings specific to it:
 

--- a/ariadne_codegen/exceptions.py
+++ b/ariadne_codegen/exceptions.py
@@ -36,3 +36,7 @@ class IntrospectionError(CodeGenException):
 
 class PluginImportError(CodeGenException):
     """Error occurred during the plugin lookup."""
+
+
+class ModuleImportError(CodeGenException):
+    """Error occurred during the module lookup from declarative settings."""

--- a/ariadne_codegen/main.py
+++ b/ariadne_codegen/main.py
@@ -55,6 +55,7 @@ def client(config_dict):
             verify_ssl=settings.remote_schema_verify_ssl,
             timeout=settings.remote_schema_timeout,
             introspection_settings=settings.introspection_settings,
+            http_client_path=settings.remote_schema_http_client_path,
         )
 
     plugin_manager = PluginManager(
@@ -106,6 +107,7 @@ def graphql_schema(config_dict):
             verify_ssl=settings.remote_schema_verify_ssl,
             timeout=settings.remote_schema_timeout,
             introspection_settings=settings.introspection_settings,
+            http_client_path=settings.remote_schema_http_client_path,
         )
     plugin_manager = PluginManager(
         schema=schema,

--- a/ariadne_codegen/main.py
+++ b/ariadne_codegen/main.py
@@ -16,9 +16,7 @@ from .schema import (
     filter_fragments_definitions,
     filter_operations_definitions,
     get_graphql_queries,
-    get_graphql_schema_from_path,
-    get_graphql_schema_from_paths,
-    get_graphql_schema_from_url,
+    get_graphql_schema,
 )
 from .settings import Strategy, get_validation_rule
 
@@ -44,19 +42,7 @@ def main(strategy=Strategy.CLIENT.value, config=None):
 def client(config_dict):
     settings = get_client_settings(config_dict)
 
-    if settings.schema_path:
-        schema = get_graphql_schema_from_path(settings.schema_path)
-    elif settings.schema_paths:
-        schema = get_graphql_schema_from_paths(settings.schema_paths)
-    else:
-        schema = get_graphql_schema_from_url(
-            url=settings.remote_schema_url,
-            headers=settings.remote_schema_headers,
-            verify_ssl=settings.remote_schema_verify_ssl,
-            timeout=settings.remote_schema_timeout,
-            introspection_settings=settings.introspection_settings,
-            http_client_path=settings.remote_schema_http_client_path,
-        )
+    schema = get_graphql_schema(settings)
 
     plugin_manager = PluginManager(
         schema=schema,
@@ -96,19 +82,8 @@ def client(config_dict):
 def graphql_schema(config_dict):
     settings = get_graphql_schema_settings(config_dict)
 
-    if settings.schema_path:
-        schema = get_graphql_schema_from_path(settings.schema_path)
-    elif settings.schema_paths:
-        schema = get_graphql_schema_from_paths(settings.schema_paths)
-    else:
-        schema = get_graphql_schema_from_url(
-            url=settings.remote_schema_url,
-            headers=settings.remote_schema_headers,
-            verify_ssl=settings.remote_schema_verify_ssl,
-            timeout=settings.remote_schema_timeout,
-            introspection_settings=settings.introspection_settings,
-            http_client_path=settings.remote_schema_http_client_path,
-        )
+    schema = get_graphql_schema(settings)
+
     plugin_manager = PluginManager(
         schema=schema,
         config_dict=config_dict,

--- a/ariadne_codegen/module_importer.py
+++ b/ariadne_codegen/module_importer.py
@@ -1,0 +1,48 @@
+import importlib
+import importlib.util
+from typing import Any
+
+from .exceptions import ModuleImportError
+
+
+def get_module_or_attribute(import_str: str) -> Any:
+    """Returns module or module's attribute for arbitrary import path."""
+    if is_module_str(import_str):
+        try:
+            module = importlib.import_module(import_str)
+        except ModuleNotFoundError as exc:
+            raise ModuleImportError(
+                f"Incorrect module. Cannot import from {import_str}"
+            ) from exc
+        return module
+    return get_attribute_from_module(import_str)
+
+
+def is_module_str(import_str: str) -> bool:
+    """Returns True if given import path points to module."""
+    try:
+        spec = importlib.util.find_spec(import_str)
+        return spec is not None
+    except ModuleNotFoundError:
+        return False
+
+
+def get_attribute_from_module(module_attribute_str: str) -> Any:
+    """Returns imported attribute from the module."""
+    if "." not in module_attribute_str:
+        raise ModuleImportError("Incorrect path. Use an absolute import path.")
+    module_str, attribute_name = module_attribute_str.rsplit(".", 1)
+
+    try:
+        module = importlib.import_module(module_str)
+        attribute = getattr(module, attribute_name)
+    except ModuleNotFoundError as exc:
+        raise ModuleImportError(
+            f"Incorrect module. Cannot import from {module_str}"
+        ) from exc
+    except AttributeError as exc:
+        raise ModuleImportError(
+            f"Attribute {attribute_name} not found in module {module_str}"
+        ) from exc
+
+    return attribute

--- a/ariadne_codegen/plugins/explorer.py
+++ b/ariadne_codegen/plugins/explorer.py
@@ -1,9 +1,9 @@
 import importlib
-import importlib.util
 import inspect
 from typing import Any
 
-from ..exceptions import PluginImportError
+from ..exceptions import ModuleImportError, PluginImportError
+from ..module_importer import get_attribute_from_module, is_module_str
 from .base import Plugin
 
 
@@ -17,14 +17,6 @@ def get_plugins_types(plugins_strs: list[str]) -> list[type[Plugin]]:
     return classes
 
 
-def is_module_str(plugin_str: str) -> bool:
-    try:
-        spec = importlib.util.find_spec(plugin_str)
-        return spec is not None
-    except ModuleNotFoundError:
-        return False
-
-
 def get_plugins_types_from_module(module_str: str) -> list[type[Plugin]]:
     module = importlib.import_module(module_str)
     return [obj for _, obj in inspect.getmembers(module) if is_plugin_type(obj)]
@@ -35,25 +27,10 @@ def is_plugin_type(obj: Any) -> bool:
 
 
 def get_plugin_type(class_str: str) -> type[Plugin]:
-    last_dot_index = class_str.rfind(".")
-    if last_dot_index < 0:
-        raise PluginImportError("Incorrect plugin path. Use an absolute import path.")
-    module_str, class_name = (
-        class_str[:last_dot_index],
-        class_str[last_dot_index + 1 :],
-    )
-
     try:
-        module = importlib.import_module(module_str)
-        class_obj = getattr(module, class_name)
-    except ModuleNotFoundError as exc:
-        raise PluginImportError(
-            f"Incorrect plugin module. Cannot import from {module_str}"
-        ) from exc
-    except AttributeError as exc:
-        raise PluginImportError(
-            f"Class {class_name} not found in module {module_str}"
-        ) from exc
+        class_obj = get_attribute_from_module(class_str)
+    except ModuleImportError as e:
+        raise PluginImportError(str(e)) from e
 
     if not is_plugin_type(class_obj):
         raise PluginImportError(f"Selected object {class_str} is not a plugin class.")

--- a/ariadne_codegen/schema.py
+++ b/ariadne_codegen/schema.py
@@ -34,7 +34,7 @@ from .exceptions import (
     ModuleImportError,
 )
 from .module_importer import get_attribute_from_module, get_module_or_attribute
-from .settings import IntrospectionSettings, assert_path_exists
+from .settings import BaseSettings, IntrospectionSettings, assert_path_exists
 
 
 class Response(Protocol):
@@ -53,6 +53,24 @@ class HttpClient(Protocol):
         timeout: Any | None = None,
         **kwargs: Any,
     ) -> Response: ...
+
+
+def get_graphql_schema(settings: BaseSettings) -> GraphQLSchema:
+    """Return GraphQL schema from the source defined in settings."""
+    if settings.schema_path:
+        schema = get_graphql_schema_from_path(settings.schema_path)
+    elif settings.schema_paths:
+        schema = get_graphql_schema_from_paths(settings.schema_paths)
+    else:
+        schema = get_graphql_schema_from_url(
+            url=settings.remote_schema_url,
+            headers=settings.remote_schema_headers,
+            verify_ssl=settings.remote_schema_verify_ssl,
+            timeout=settings.remote_schema_timeout,
+            introspection_settings=settings.introspection_settings,
+            http_client_path=settings.remote_schema_http_client_path,
+        )
+    return schema
 
 
 def filter_operations_definitions(

--- a/ariadne_codegen/schema.py
+++ b/ariadne_codegen/schema.py
@@ -1,4 +1,3 @@
-import importlib
 from collections.abc import Generator, Iterable, Sequence
 from dataclasses import asdict
 from pathlib import Path
@@ -32,8 +31,9 @@ from .exceptions import (
     InvalidConfiguration,
     InvalidGraphqlSyntax,
     InvalidOperationForSchema,
+    ModuleImportError,
 )
-from .module_importer import get_module_or_attribute
+from .module_importer import get_attribute_from_module, get_module_or_attribute
 from .settings import IntrospectionSettings, assert_path_exists
 
 
@@ -223,10 +223,8 @@ def _resolve_import_source(source: str) -> list[Path]:
     string / ``Path`` pointing to a file or a directory.
     """
     try:
-        module_path, attr = source.rsplit(".", 1)
-        module = importlib.import_module(module_path)
-        obj = getattr(module, attr)
-    except (ImportError, AttributeError, ValueError) as exc:
+        obj = get_attribute_from_module(source)
+    except ModuleImportError as exc:
         raise InvalidConfiguration(
             f"Could not resolve schema source '{source}'. It is neither an "
             f"existing file/directory nor an importable attribute: {exc}."

--- a/ariadne_codegen/schema.py
+++ b/ariadne_codegen/schema.py
@@ -2,7 +2,7 @@ import importlib
 from collections.abc import Generator, Iterable, Sequence
 from dataclasses import asdict
 from pathlib import Path
-from typing import Optional, cast
+from typing import Optional, Protocol, cast
 
 import httpx
 from graphql import (
@@ -33,7 +33,26 @@ from .exceptions import (
     InvalidGraphqlSyntax,
     InvalidOperationForSchema,
 )
+from .module_importer import get_module_or_attribute
 from .settings import IntrospectionSettings, assert_path_exists
+
+
+class Response(Protocol):
+    status_code: int
+
+    def json(self, **kwargs: Any) -> Any: ...
+
+
+class HttpClient(Protocol):
+    def post(
+        self,
+        url: Any | str,
+        json: Any | None = None,
+        headers: Any | None = None,
+        verify: Any | None = None,
+        timeout: Any | None = None,
+        **kwargs: Any,
+    ) -> Response: ...
 
 
 def filter_operations_definitions(
@@ -76,10 +95,17 @@ def get_graphql_schema_from_url(
     verify_ssl: bool = True,
     timeout: float = 5,
     introspection_settings: Optional[IntrospectionSettings] = None,
+    http_client_path: str | None = None,
 ) -> GraphQLSchema:
+    http_client = (
+        get_remote_schema_http_client(http_client_path)
+        if http_client_path is not None
+        else httpx
+    )
     return build_client_schema(
         introspect_remote_schema(
             url=url,
+            http_client=http_client,
             headers=headers,
             verify_ssl=verify_ssl,
             timeout=timeout,
@@ -89,8 +115,19 @@ def get_graphql_schema_from_url(
     )
 
 
+def get_remote_schema_http_client(http_client_path: str) -> HttpClient:
+    imported_module_or_attribute = get_module_or_attribute(http_client_path)
+    if callable(imported_module_or_attribute):
+        return imported_module_or_attribute()
+    return imported_module_or_attribute
+
+
 def introspect_remote_schema(
     url: str,
+    # Default `httpx` module confirms the `HttpClient` protocol,
+    # but `ty` does not implement recognizing module as protocol.
+    # Remove `Any` when https://github.com/astral-sh/ty/issues/931 will be ready.
+    http_client: HttpClient | Any,
     headers: Optional[dict[str, str]] = None,
     verify_ssl: bool = True,
     timeout: float = 5,
@@ -99,18 +136,21 @@ def introspect_remote_schema(
     # If introspection settings are not provided, use default values.
     settings = introspection_settings or IntrospectionSettings()
     query = get_introspection_query(**asdict(settings))
+
     try:
-        response = httpx.post(
-            url,
-            json={"query": query},
-            headers=headers,
-            verify=verify_ssl,
-            timeout=timeout,
-        )
+        httpx.URL(url)
     except httpx.InvalidURL as exc:
         raise IntrospectionError(f"Invalid remote schema url: {url}") from exc
 
-    if not response.is_success:
+    response = http_client.post(
+        url,
+        json={"query": query},
+        headers=headers,
+        verify=verify_ssl,
+        timeout=timeout,
+    )
+
+    if not (200 <= response.status_code <= 299):
         raise IntrospectionError(
             "Failure of remote schema introspection. "
             f"HTTP status code: {response.status_code}"

--- a/ariadne_codegen/settings.py
+++ b/ariadne_codegen/settings.py
@@ -75,6 +75,7 @@ class BaseSettings:
     remote_schema_headers: dict = field(default_factory=dict)
     remote_schema_verify_ssl: bool = True
     remote_schema_timeout: float = 5
+    remote_schema_http_client_path: str | None = None
     enable_custom_operations: bool = False
     plugins: list[str] = field(default_factory=list)
     introspection_descriptions: bool = False

--- a/docs/02-configuration.md
+++ b/docs/02-configuration.md
@@ -50,6 +50,7 @@ queries_path = "queries.graphql"
 - `remote_schema_headers` - extra headers that are passed along with introspection query, eg. `{"Authorization" = "Bearer: token"}`. To include an environment variable in a header value, prefix the variable with `$`, eg. `{"Authorization" = "$AUTH_TOKEN"}`
 - `remote_schema_verify_ssl` (defaults to `true`) - a flag that specifies wheter to verify ssl while introspecting remote schema
 - `remote_schema_timeout` (defaults to `5`) - timeout in seconds while introspecting remote schema
+- `remote_schema_http_client_path` - absolute import path to the HTTP client class used to introspect remote schema. If not provided, default `httpx` client is used.
 - `target_package_name` (defaults to `"graphql_client"`) - name of generated package
 - `target_package_path` (defaults to cwd) - path where to generate package
 - `client_name` (defaults to `"Client"`) - name of generated client class

--- a/tests/plugins/test_explorer.py
+++ b/tests/plugins/test_explorer.py
@@ -11,7 +11,6 @@ from ariadne_codegen.plugins.explorer import (
     get_plugin_type,
     get_plugins_types,
     get_plugins_types_from_module,
-    is_module_str,
     is_plugin_type,
 )
 
@@ -92,21 +91,6 @@ def test_get_plugins_types_returns_plugin_classes_from_all_modules(tmp_path_cwd)
         "module_xyz.x.PluginX",
         "module_xyz.y.PluginY",
     } == {f"{c.__module__}.{c.__name__}" for c in types}
-
-
-def test_is_module_str_returns_true_if_string_points_to_existing_module(tmp_path_cwd):
-    module_str = "test_a.sub_b.sub_c"
-    create_module_dir(tmp_path_cwd, module_str)
-
-    assert is_module_str(module_str)
-
-
-def test_is_module_str_returns_false_if_string_points_to_specific_file(tmp_path_cwd):
-    module_str = "test_a.sub_b.sub_c"
-    module_path = create_module_dir(tmp_path_cwd, module_str)
-    module_path.joinpath("abcd.py").touch()
-
-    assert not is_module_str(module_str + ".abcd.py")
 
 
 def test_get_plugins_types_from_module_returns_all_public_plugins(tmp_path_cwd):

--- a/tests/test_module_importer.py
+++ b/tests/test_module_importer.py
@@ -54,7 +54,7 @@ def test_get_module_or_attribute_returns_module_for_module_string(
 
 
 def test_get_module_or_attribute_returns_attribute_from_module(tmp_path_cwd):
-    module_path = create_module_dir(tmp_path_cwd, "test_module")
+    module_path = create_module_dir(tmp_path_cwd, "test_module_a")
     file_content = """
     from ariadne_codegen import Plugin
 
@@ -63,10 +63,10 @@ def test_get_module_or_attribute_returns_attribute_from_module(tmp_path_cwd):
     """
     module_path.joinpath("xyz.py").write_text(dedent(file_content))
 
-    test_class = get_module_or_attribute("test_module.xyz.TestClass")
+    test_class = get_module_or_attribute("test_module_a.xyz.TestClass")
 
     assert test_class.__name__ == "TestClass"
-    assert test_class.__module__ == "test_module.xyz"
+    assert test_class.__module__ == "test_module_a.xyz"
 
 
 def test_is_module_str_returns_true_if_string_points_to_existing_module(tmp_path_cwd):
@@ -85,7 +85,7 @@ def test_is_module_str_returns_false_if_string_points_to_specific_file(tmp_path_
 
 
 def test_get_attribute_from_module_returns_attribute(tmp_path_cwd):
-    module_path = create_module_dir(tmp_path_cwd, "test_module")
+    module_path = create_module_dir(tmp_path_cwd, "test_module_b")
     file_content = """
     from ariadne_codegen import Plugin
 
@@ -94,10 +94,10 @@ def test_get_attribute_from_module_returns_attribute(tmp_path_cwd):
     """
     module_path.joinpath("xyz.py").write_text(dedent(file_content))
 
-    test_class = get_attribute_from_module("test_module.xyz.TestClass")
+    test_class = get_attribute_from_module("test_module_b.xyz.TestClass")
 
     assert test_class.__name__ == "TestClass"
-    assert test_class.__module__ == "test_module.xyz"
+    assert test_class.__module__ == "test_module_b.xyz"
 
 
 def test_get_attribute_from_module_raises_module_import_error_for_class():

--- a/tests/test_module_importer.py
+++ b/tests/test_module_importer.py
@@ -1,0 +1,120 @@
+import os
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from ariadne_codegen.exceptions import ModuleImportError
+from ariadne_codegen.module_importer import (
+    get_attribute_from_module,
+    get_module_or_attribute,
+    is_module_str,
+)
+
+
+@pytest.fixture
+def tmp_path_cwd(tmp_path):
+    old_cwd = Path.cwd()
+    os.chdir(tmp_path)
+    sys.path.append(tmp_path.as_posix())
+
+    yield tmp_path
+
+    os.chdir(old_cwd)
+    sys.path.remove(tmp_path.as_posix())
+
+
+def create_module_dir(base: Path, module_str: str) -> Path:
+    path = base
+    for dir_name in module_str.split("."):
+        path = path / dir_name
+        path.mkdir()
+        path.joinpath("__init__.py").touch()
+    return path
+
+
+@pytest.mark.parametrize(
+    "module_str",
+    [
+        ("test_a",),
+        ("test_a.sub_b.sub_c",),
+    ],
+)
+def test_get_module_or_attribute_returns_module_for_module_string(
+    module_str, tmp_path_cwd
+):
+    module_str = "test_a.sub_b.sub_c"
+    create_module_dir(tmp_path_cwd, module_str)
+
+    imported_module = get_module_or_attribute(module_str)
+
+    assert imported_module.__name__ == "test_a.sub_b.sub_c"
+    assert imported_module.__package__ == "test_a.sub_b.sub_c"
+
+
+def test_get_module_or_attribute_returns_attribute_from_module(tmp_path_cwd):
+    module_path = create_module_dir(tmp_path_cwd, "test_module")
+    file_content = """
+    from ariadne_codegen import Plugin
+
+    class TestClass:
+        pass
+    """
+    module_path.joinpath("xyz.py").write_text(dedent(file_content))
+
+    test_class = get_module_or_attribute("test_module.xyz.TestClass")
+
+    assert test_class.__name__ == "TestClass"
+    assert test_class.__module__ == "test_module.xyz"
+
+
+def test_is_module_str_returns_true_if_string_points_to_existing_module(tmp_path_cwd):
+    module_str = "test_a.sub_b.sub_c"
+    create_module_dir(tmp_path_cwd, module_str)
+
+    assert is_module_str(module_str)
+
+
+def test_is_module_str_returns_false_if_string_points_to_specific_file(tmp_path_cwd):
+    module_str = "test_a.sub_b.sub_c"
+    module_path = create_module_dir(tmp_path_cwd, module_str)
+    module_path.joinpath("abcd.py").touch()
+
+    assert not is_module_str(module_str + ".abcd.py")
+
+
+def test_get_attribute_from_module_returns_attribute(tmp_path_cwd):
+    module_path = create_module_dir(tmp_path_cwd, "test_module")
+    file_content = """
+    from ariadne_codegen import Plugin
+
+    class TestClass:
+        pass
+    """
+    module_path.joinpath("xyz.py").write_text(dedent(file_content))
+
+    test_class = get_attribute_from_module("test_module.xyz.TestClass")
+
+    assert test_class.__name__ == "TestClass"
+    assert test_class.__module__ == "test_module.xyz"
+
+
+def test_get_attribute_from_module_raises_module_import_error_for_class():
+    with pytest.raises(ModuleImportError):
+        get_attribute_from_module("TestClass")
+
+
+def test_get_attribute_from_module_raises_module_import_error_for_not_existing_module():
+    with pytest.raises(ModuleImportError):
+        get_attribute_from_module("test_module.TestClass")
+
+
+def test_get_attribute_from_module_raises_module_import_error_for_not_existing_class(
+    tmp_path_cwd,
+):
+    module_str = "test_module"
+    create_module_dir(tmp_path_cwd, module_str)
+
+    with pytest.raises(ModuleImportError):
+        get_attribute_from_module(f"{module_str}.TestClass")

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -700,7 +700,8 @@ def test_resolve_schema_paths_with_callable_python_attribute(
     mock_module = mocker.Mock()
     mock_module.get_files = mock_callable
     mocker.patch(
-        "ariadne_codegen.schema.importlib.import_module", return_value=mock_module
+        "ariadne_codegen.module_importer.importlib.import_module",
+        return_value=mock_module,
     )
 
     result = resolve_schema_paths(["some_pkg.get_files"])
@@ -715,7 +716,8 @@ def test_resolve_schema_paths_with_path_attribute_pointing_to_directory(
     mock_module = mocker.Mock()
     mock_module.SCHEMA_DIR = schemas_directory.as_posix()
     mocker.patch(
-        "ariadne_codegen.schema.importlib.import_module", return_value=mock_module
+        "ariadne_codegen.module_importer.importlib.import_module",
+        return_value=mock_module,
     )
 
     result = resolve_schema_paths(["some_pkg.SCHEMA_DIR"])
@@ -733,7 +735,8 @@ def test_resolve_schema_paths_with_path_attribute_pointing_to_file(
     mock_module = mocker.Mock()
     mock_module.SCHEMA_FILE = schema_file.as_posix()
     mocker.patch(
-        "ariadne_codegen.schema.importlib.import_module", return_value=mock_module
+        "ariadne_codegen.module_importer.importlib.import_module",
+        return_value=mock_module,
     )
 
     result = resolve_schema_paths(["some_pkg.SCHEMA_FILE"])
@@ -759,7 +762,9 @@ def test_resolve_schema_paths_accepts_local_dotted_names(
     dotted_dir = tmp_path / "my.schemas.dir"
     dotted_dir.mkdir()
     (dotted_dir / "user.graphql").write_text(extra_type_str, encoding="utf-8")
-    mock_import = mocker.patch("ariadne_codegen.schema.importlib.import_module")
+    mock_import = mocker.patch(
+        "ariadne_codegen.module_importer.importlib.import_module"
+    )
 
     result = resolve_schema_paths([dotted_file.as_posix(), dotted_dir.as_posix()])
 
@@ -770,8 +775,8 @@ def test_resolve_schema_paths_accepts_local_dotted_names(
 
 def test_resolve_schema_paths_raises_invalid_configuration_on_import_error(mocker):
     mocker.patch(
-        "ariadne_codegen.schema.importlib.import_module",
-        side_effect=ImportError("module not found"),
+        "ariadne_codegen.module_importer.importlib.import_module",
+        side_effect=ModuleNotFoundError("module not found"),
     )
 
     with pytest.raises(InvalidConfiguration):
@@ -781,7 +786,8 @@ def test_resolve_schema_paths_raises_invalid_configuration_on_import_error(mocke
 def test_resolve_schema_paths_raises_invalid_configuration_on_missing_attribute(mocker):
     mock_module = mocker.Mock(spec=[])
     mocker.patch(
-        "ariadne_codegen.schema.importlib.import_module", return_value=mock_module
+        "ariadne_codegen.module_importer.importlib.import_module",
+        return_value=mock_module,
     )
 
     with pytest.raises(InvalidConfiguration):
@@ -795,7 +801,8 @@ def test_resolve_schema_paths_raises_when_callable_returns_missing_file(
     mock_module = mocker.Mock()
     mock_module.get_files = mocker.Mock(return_value=[missing.as_posix()])
     mocker.patch(
-        "ariadne_codegen.schema.importlib.import_module", return_value=mock_module
+        "ariadne_codegen.module_importer.importlib.import_module",
+        return_value=mock_module,
     )
 
     with pytest.raises(InvalidConfiguration):
@@ -809,7 +816,8 @@ def test_resolve_schema_paths_raises_when_variable_points_to_missing_file(
     mock_module = mocker.Mock()
     mock_module.SCHEMA_FILE = missing.as_posix()
     mocker.patch(
-        "ariadne_codegen.schema.importlib.import_module", return_value=mock_module
+        "ariadne_codegen.module_importer.importlib.import_module",
+        return_value=mock_module,
     )
 
     with pytest.raises(InvalidConfiguration):
@@ -820,7 +828,8 @@ def test_resolve_schema_paths_raises_when_callable_returns_non_iterable(mocker):
     mock_module = mocker.Mock()
     mock_module.get_files = mocker.Mock(return_value=42)  # not a list of paths
     mocker.patch(
-        "ariadne_codegen.schema.importlib.import_module", return_value=mock_module
+        "ariadne_codegen.module_importer.importlib.import_module",
+        return_value=mock_module,
     )
 
     with pytest.raises(InvalidConfiguration):
@@ -831,7 +840,8 @@ def test_resolve_schema_paths_raises_when_callable_returns_invalid_item(mocker):
     mock_module = mocker.Mock()
     mock_module.get_files = mocker.Mock(return_value=[None, 123])  # not paths
     mocker.patch(
-        "ariadne_codegen.schema.importlib.import_module", return_value=mock_module
+        "ariadne_codegen.module_importer.importlib.import_module",
+        return_value=mock_module,
     )
 
     with pytest.raises(InvalidConfiguration):
@@ -842,7 +852,8 @@ def test_resolve_schema_paths_raises_when_variable_is_wrong_type(mocker):
     mock_module = mocker.Mock()
     mock_module.NOT_A_PATH = 123  # not callable, not str/Path
     mocker.patch(
-        "ariadne_codegen.schema.importlib.import_module", return_value=mock_module
+        "ariadne_codegen.module_importer.importlib.import_module",
+        return_value=mock_module,
     )
 
     with pytest.raises(InvalidConfiguration):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -339,11 +339,11 @@ def test_introspect_remote_schema_called_with_invalid_url_raises_introspection_e
     mocker,
 ):
     mocker.patch(
-        "ariadne_codegen.schema.httpx.post", side_effect=httpx.InvalidURL("msg")
+        "ariadne_codegen.schema.httpx.URL", side_effect=httpx.InvalidURL("msg")
     )
 
     with pytest.raises(IntrospectionError):
-        introspect_remote_schema("invalid_url")
+        introspect_remote_schema("invalid_url", httpx)
 
 
 def test_introspect_remote_schema_raises_introspection_error_for_not_success_response(
@@ -355,7 +355,7 @@ def test_introspect_remote_schema_raises_introspection_error_for_not_success_res
     )
 
     with pytest.raises(IntrospectionError) as exc:
-        introspect_remote_schema("http://testserver/graphql/")
+        introspect_remote_schema("http://testserver/graphql/", httpx)
 
     assert "400" in exc.value.args[0]
 
@@ -369,7 +369,7 @@ def test_introspect_remote_schema_raises_introspection_error_for_not_json_respon
     )
 
     with pytest.raises(IntrospectionError):
-        introspect_remote_schema("http://testserver/graphql/")
+        introspect_remote_schema("http://testserver/graphql/", httpx)
 
 
 def test_introspect_remote_schema_raises_introspection_error_for_not_dict_response(
@@ -381,7 +381,7 @@ def test_introspect_remote_schema_raises_introspection_error_for_not_dict_respon
     )
 
     with pytest.raises(IntrospectionError) as exc:
-        introspect_remote_schema("http://testserver/graphql/")
+        introspect_remote_schema("http://testserver/graphql/", httpx)
 
     assert "Invalid introspection result format." in str(exc.value)
 
@@ -395,7 +395,7 @@ def test_introspect_remote_schema_raises_introspection_error_for_json_without_da
     )
 
     with pytest.raises(IntrospectionError) as exc:
-        introspect_remote_schema("http://testserver/graphql/")
+        introspect_remote_schema("http://testserver/graphql/", httpx)
 
     assert "Invalid data key in introspection result." in str(exc.value)
 
@@ -419,7 +419,7 @@ def test_introspect_remote_schema_raises_introspection_error_for_graphql_errors(
     )
 
     with pytest.raises(IntrospectionError) as exc:
-        introspect_remote_schema("http://testserver/graphql/")
+        introspect_remote_schema("http://testserver/graphql/", httpx)
 
     assert "Error message" in exc.value.args[0]
 
@@ -436,7 +436,7 @@ def test_introspect_remote_schema_raises_introspection_error_for_invalid_data_va
     )
 
     with pytest.raises(IntrospectionError) as exc:
-        introspect_remote_schema("http://testserver/graphql/")
+        introspect_remote_schema("http://testserver/graphql/", httpx)
 
     assert "Invalid data key in introspection result." in str(exc.value)
 
@@ -450,7 +450,7 @@ def test_introspect_remote_schema_returns_introspection_result(mocker):
         ),
     )
 
-    result = introspect_remote_schema("http://testserver/graphql/")
+    result = introspect_remote_schema("http://testserver/graphql/", httpx)
 
     assert result == {"__schema": {}}
 
@@ -464,7 +464,9 @@ def test_introspect_remote_schema_uses_provided_headers(mocker):
         ),
     )
 
-    introspect_remote_schema("http://testserver/graphql/", headers={"test": "value"})
+    introspect_remote_schema(
+        "http://testserver/graphql/", httpx, headers={"test": "value"}
+    )
 
     assert mocked_post.called
     assert mocked_post.call_args.kwargs["headers"] == {"test": "value"}
@@ -479,10 +481,27 @@ def test_introspect_remote_schema_uses_provided_verify_ssl_flag(verify_ssl, mock
         ),
     )
 
-    introspect_remote_schema("http://testserver/graphql/", verify_ssl=verify_ssl)
+    introspect_remote_schema("http://testserver/graphql/", httpx, verify_ssl=verify_ssl)
 
     assert mocked_post.called
     assert mocked_post.call_args.kwargs["verify"] == verify_ssl
+
+
+def test_introspect_remote_schema_works_with_custom_classes():
+
+    class TestResponse:
+        status_code = 200
+
+        def json(self, **kwargs):
+            return {"data": {"__schema": {}}}
+
+    class TestClient:
+        def post(self, url, **kwargs):
+            return TestResponse()
+
+    result = introspect_remote_schema("http://testserver/graphql/", TestClient())
+
+    assert result == {"__schema": {}}
 
 
 def test_get_graphql_queries_returns_schema_definitions_from_single_file(
@@ -614,7 +633,7 @@ def test_introspect_remote_schema_passes_introspection_settings_to_introspection
     )
 
     introspect_remote_schema(
-        "http://testserver/graphql/", introspection_settings=settings
+        "http://testserver/graphql/", httpx, introspection_settings=settings
     )
 
     mocked_get_query.assert_called_once_with(
@@ -645,7 +664,7 @@ def test_introspect_remote_schema_uses_default_introspection_settings_when_not_p
         ),
     )
 
-    introspect_remote_schema("http://testserver/graphql/")
+    introspect_remote_schema("http://testserver/graphql/", httpx)
 
     mocked_get_query.assert_called_once_with(
         descriptions=False,


### PR DESCRIPTION
This PR allows to define `remote_schema_http_client_path` to point the module, class or object which will be used as HTTP client to fetch the schema introspection from remote server.