### PR TITLE
feat!: build custom-operation leaf fields per query

### DIFF
--- a/ariadne_codegen/client_generators/constants.py
+++ b/ariadne_codegen/client_generators/constants.py
@@ -43,6 +43,7 @@ COMMENT_DATETIME_FORMAT = "%Y-%m-%d %H:%M"
 BASE_OPERATION_FILE_PATH = Path(__file__).parent / "dependencies" / "base_operation.py"
 BASE_GRAPHQL_OPERATION_CLASS_NAME = "BaseGraphQLOperation"
 BASE_GRAPHQL_FIELD_CLASS_NAME = "GraphQLField"
+GRAPHQL_LEAF_FIELD_CLASS_NAME = "GraphQLLeafField"
 CUSTOM_FIELDS_FILE_PATH = Path(__file__).parent / "custom_fields.py"
 CUSTOM_FIELDS_TYPING_FILE_PATH = Path(__file__).parent / "custom_typing_fields.py"
 

--- a/ariadne_codegen/client_generators/custom_fields.py
+++ b/ariadne_codegen/client_generators/custom_fields.py
@@ -91,6 +91,11 @@ class CustomFieldsGenerator:
     def generate(self) -> ast.Module:
         """Generates an AST module containing the custom fields and required imports."""
         self.argument_generator.add_custom_scalar_imports()
+        # Copy the argument generator's imports (input types, enums and, crucially,
+        # custom scalar imports registered by ``add_custom_scalar_imports`` above)
+        # into the module import list. This must run after the call above, otherwise
+        # scalar types used in field-argument annotations would never be imported.
+        self._imports.extend(self.argument_generator.imports)
         module = generate_module(
             body=cast(list[ast.stmt], self._imports + self._class_defs),
         )
@@ -346,7 +351,6 @@ class CustomFieldsGenerator:
             return_arguments_keys,
             return_arguments_values,
         ) = self.argument_generator.generate_arguments(arguments)
-        self._imports.extend(self.argument_generator.imports)
 
         if arguments:
             for arg in arguments.values():

--- a/ariadne_codegen/client_generators/custom_fields.py
+++ b/ariadne_codegen/client_generators/custom_fields.py
@@ -91,10 +91,9 @@ class CustomFieldsGenerator:
     def generate(self) -> ast.Module:
         """Generates an AST module containing the custom fields and required imports."""
         self.argument_generator.add_custom_scalar_imports()
-        # Copy the argument generator's imports (input types, enums and, crucially,
-        # custom scalar imports registered by ``add_custom_scalar_imports`` above)
-        # into the module import list. This must run after the call above, otherwise
-        # scalar types used in field-argument annotations would never be imported.
+        # Pull in the argument generator's imports (scalars, input types, enums).
+        # Must run after `add_custom_scalar_imports` above, or scalars used in
+        # field-argument annotations are never imported.
         self._imports.extend(self.argument_generator.imports)
         module = generate_module(
             body=cast(list[ast.stmt], self._imports + self._class_defs),
@@ -241,8 +240,8 @@ class CustomFieldsGenerator:
                 field.args,
                 description=field.description,
             )
-        # A descriptor rather than a field instance: a class attribute is shared by
-        # every query that selects it, and `alias()`/`to_ast()` mutate the field.
+        # A descriptor, not a shared instance: the class attribute is reused by
+        # every query, and `alias()`/`to_ast()` mutate the field.
         return generate_assign(
             targets=[name],
             value=generate_call(

--- a/ariadne_codegen/client_generators/custom_fields.py
+++ b/ariadne_codegen/client_generators/custom_fields.py
@@ -14,9 +14,9 @@ from graphql import (
 from ariadne_codegen.client_generators.custom_arguments import ArgumentGenerator
 
 from ..codegen import (
-    generate_ann_assign,
     generate_arg,
     generate_arguments,
+    generate_assign,
     generate_attribute,
     generate_call,
     generate_class_def,
@@ -38,6 +38,7 @@ from .constants import (
     BASE_OPERATION_FILE_PATH,
     GRAPHQL_BASE_FIELD_CLASS,
     GRAPHQL_INTERFACE_SUFFIX,
+    GRAPHQL_LEAF_FIELD_CLASS_NAME,
     GRAPHQL_OBJECT_SUFFIX,
     GRAPHQL_UNION_SUFFIX,
     OPTIONAL,
@@ -65,7 +66,10 @@ class CustomFieldsGenerator:
         self._imports: list[ast.ImportFrom] = [
             ast.ImportFrom(
                 module=BASE_OPERATION_FILE_PATH.stem,
-                names=[ast.alias(BASE_GRAPHQL_FIELD_CLASS_NAME)],
+                names=[
+                    ast.alias(BASE_GRAPHQL_FIELD_CLASS_NAME),
+                    ast.alias(GRAPHQL_LEAF_FIELD_CLASS_NAME),
+                ],
                 level=1,
             )
         ]
@@ -232,11 +236,13 @@ class CustomFieldsGenerator:
                 field.args,
                 description=field.description,
             )
-        return generate_ann_assign(
-            target=generate_name(name),
-            annotation=generate_name(f'"{field_name}"'),
+        # A descriptor rather than a field instance: a class attribute is shared by
+        # every query that selects it, and `alias()`/`to_ast()` mutate the field.
+        return generate_assign(
+            targets=[name],
             value=generate_call(
-                func=generate_name(field_name), args=[generate_constant(org_name)]
+                func=generate_name(GRAPHQL_LEAF_FIELD_CLASS_NAME),
+                args=[generate_constant(org_name), generate_name(field_name)],
             ),
             lineno=lineno,
         )

--- a/ariadne_codegen/client_generators/custom_operation.py
+++ b/ariadne_codegen/client_generators/custom_operation.py
@@ -95,10 +95,9 @@ class CustomOperationGenerator:
             self._class_def.body.append(ast.Pass())
 
         self.argument_generator.add_custom_scalar_imports()
-        # Copy the argument generator's imports (input types, enums and, crucially,
-        # custom scalar imports registered by ``add_custom_scalar_imports`` above)
-        # into the module import list. This must run after the call above, otherwise
-        # scalar types used in operation-argument annotations would never be imported.
+        # Pull in the argument generator's imports (scalars, input types, enums).
+        # Must run after `add_custom_scalar_imports` above, or scalars used in
+        # operation-argument annotations are never imported.
         for import_ in self.argument_generator.imports:
             self._add_import(import_)
 

--- a/ariadne_codegen/client_generators/custom_operation.py
+++ b/ariadne_codegen/client_generators/custom_operation.py
@@ -95,6 +95,12 @@ class CustomOperationGenerator:
             self._class_def.body.append(ast.Pass())
 
         self.argument_generator.add_custom_scalar_imports()
+        # Copy the argument generator's imports (input types, enums and, crucially,
+        # custom scalar imports registered by ``add_custom_scalar_imports`` above)
+        # into the module import list. This must run after the call above, otherwise
+        # scalar types used in operation-argument annotations would never be imported.
+        for import_ in self.argument_generator.imports:
+            self._add_import(import_)
 
         self._class_def.lineno = len(self._imports) + 3
 
@@ -134,9 +140,6 @@ class CustomOperationGenerator:
             return_arguments_keys,
             return_arguments_values,
         ) = self.argument_generator.generate_arguments(operation_args)
-
-        for import_ in self.argument_generator.imports:
-            self._add_import(import_)
 
         if operation_args:
             for arg in operation_args.values():

--- a/ariadne_codegen/client_generators/dependencies/base_operation.py
+++ b/ariadne_codegen/client_generators/dependencies/base_operation.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Union
+from typing import Any, Generic, Optional, TypeVar, Union
 
 from graphql import (
     ArgumentNode,
@@ -9,6 +9,8 @@ from graphql import (
     SelectionSetNode,
     VariableNode,
 )
+
+GraphQLFieldT = TypeVar("GraphQLFieldT", bound="GraphQLField")
 
 
 class GraphQLArgument:
@@ -152,3 +154,22 @@ class GraphQLField:
             for subfield in subfields:
                 formatted_variables.update(subfield.get_formatted_variables())
         return formatted_variables
+
+
+class GraphQLLeafField(Generic[GraphQLFieldT]):
+    """
+    Descriptor that builds a fresh field on every access.
+
+    Leaf selections are reached through the class (``ProductFields.name``). A
+    single shared instance would carry ``alias()`` and ``to_ast()`` state from one
+    query into every later one, so each access gets its own field.
+    """
+
+    __slots__ = ("_field_name", "_field_class")
+
+    def __init__(self, field_name: str, field_class: type[GraphQLFieldT]) -> None:
+        self._field_name = field_name
+        self._field_class = field_class
+
+    def __get__(self, instance: object, owner: Optional[type] = None) -> GraphQLFieldT:
+        return self._field_class(self._field_name)

--- a/ariadne_codegen/client_generators/dependencies/base_operation.py
+++ b/ariadne_codegen/client_generators/dependencies/base_operation.py
@@ -157,12 +157,10 @@ class GraphQLField:
 
 
 class GraphQLLeafField(Generic[GraphQLFieldT]):
-    """
-    Descriptor that builds a fresh field on every access.
+    """Descriptor that builds a fresh field on every access.
 
-    Leaf selections are reached through the class (``ProductFields.name``). A
-    single shared instance would carry ``alias()`` and ``to_ast()`` state from one
-    query into every later one, so each access gets its own field.
+    Leaf selections are reached through the class (``ProductFields.name``); a
+    shared instance would leak ``alias()``/``to_ast()`` state between queries.
     """
 
     __slots__ = ("_field_name", "_field_class")

--- a/tests/client_generators/dependencies/test_base_operation.py
+++ b/tests/client_generators/dependencies/test_base_operation.py
@@ -1,0 +1,48 @@
+from graphql import print_ast
+
+from ariadne_codegen.client_generators.dependencies.base_operation import (
+    GraphQLField,
+    GraphQLLeafField,
+)
+
+
+class ProductGraphQLField(GraphQLField):
+    pass
+
+
+class ProductFields(GraphQLField):
+    id = GraphQLLeafField("id", ProductGraphQLField)
+    name = GraphQLLeafField("name", ProductGraphQLField)
+
+
+def test_leaf_field_builds_the_declared_field():
+    field = ProductFields.name
+
+    assert isinstance(field, ProductGraphQLField)
+    assert print_ast(field.to_ast(0)) == "name"
+
+
+def test_leaf_field_returns_a_new_instance_on_every_access():
+    assert ProductFields.name is not ProductFields.name
+
+
+def test_leaf_field_alias_does_not_leak_into_later_queries():
+    """A shared class attribute would carry one query's alias into the next."""
+    aliased = ProductFields.name.alias("nick")
+    assert print_ast(aliased.to_ast(0)) == "nick: name"
+
+    later_query = ProductFields.name
+    assert later_query._alias is None
+    assert print_ast(later_query.to_ast(0)) == "name"
+
+
+def test_leaf_field_subfields_do_not_leak_into_later_queries():
+    ProductFields.id._subfields.append(ProductFields.name)
+
+    assert ProductFields.id._subfields == []
+
+
+def test_leaf_field_is_accessible_from_an_instance():
+    instance = ProductFields("product")
+
+    assert isinstance(instance.name, ProductGraphQLField)

--- a/tests/main/clients/custom_query_builder/expected_client/base_operation.py
+++ b/tests/main/clients/custom_query_builder/expected_client/base_operation.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Union
+from typing import Any, Generic, Optional, TypeVar, Union
 
 from graphql import (
     ArgumentNode,
@@ -9,6 +9,8 @@ from graphql import (
     SelectionSetNode,
     VariableNode,
 )
+
+GraphQLFieldT = TypeVar("GraphQLFieldT", bound="GraphQLField")
 
 
 class GraphQLArgument:
@@ -152,3 +154,22 @@ class GraphQLField:
             for subfield in subfields:
                 formatted_variables.update(subfield.get_formatted_variables())
         return formatted_variables
+
+
+class GraphQLLeafField(Generic[GraphQLFieldT]):
+    """
+    Descriptor that builds a fresh field on every access.
+
+    Leaf selections are reached through the class (``ProductFields.name``). A
+    single shared instance would carry ``alias()`` and ``to_ast()`` state from one
+    query into every later one, so each access gets its own field.
+    """
+
+    __slots__ = ("_field_name", "_field_class")
+
+    def __init__(self, field_name: str, field_class: type[GraphQLFieldT]) -> None:
+        self._field_name = field_name
+        self._field_class = field_class
+
+    def __get__(self, instance: object, owner: Optional[type] = None) -> GraphQLFieldT:
+        return self._field_class(self._field_name)

--- a/tests/main/clients/custom_query_builder/expected_client/base_operation.py
+++ b/tests/main/clients/custom_query_builder/expected_client/base_operation.py
@@ -157,12 +157,10 @@ class GraphQLField:
 
 
 class GraphQLLeafField(Generic[GraphQLFieldT]):
-    """
-    Descriptor that builds a fresh field on every access.
+    """Descriptor that builds a fresh field on every access.
 
-    Leaf selections are reached through the class (``ProductFields.name``). A
-    single shared instance would carry ``alias()`` and ``to_ast()`` state from one
-    query into every later one, so each access gets its own field.
+    Leaf selections are reached through the class (``ProductFields.name``); a
+    shared instance would leak ``alias()``/``to_ast()`` state between queries.
     """
 
     __slots__ = ("_field_name", "_field_class")

--- a/tests/main/clients/custom_query_builder/expected_client/custom_fields.py
+++ b/tests/main/clients/custom_query_builder/expected_client/custom_fields.py
@@ -1,6 +1,6 @@
 from typing import Any, Optional, Union
 
-from .base_operation import GraphQLField
+from .base_operation import GraphQLField, GraphQLLeafField
 from .custom_typing_fields import (
     AppGraphQLField,
     BookShelfGraphQLField,
@@ -23,7 +23,7 @@ from .custom_typing_fields import (
 
 
 class AppFields(GraphQLField):
-    id: "AppGraphQLField" = AppGraphQLField("id")
+    id = GraphQLLeafField("id", AppGraphQLField)
 
     def fields(self, *subfields: AppGraphQLField) -> "AppFields":
         """Subfields should come from the AppFields class"""
@@ -36,7 +36,7 @@ class AppFields(GraphQLField):
 
 
 class BookShelfFields(GraphQLField):
-    has_books: "BookShelfGraphQLField" = BookShelfGraphQLField("hasBooks")
+    has_books = GraphQLLeafField("hasBooks", BookShelfGraphQLField)
 
     def fields(self, *subfields: BookShelfGraphQLField) -> "BookShelfFields":
         """Subfields should come from the BookShelfFields class"""
@@ -49,28 +49,22 @@ class BookShelfFields(GraphQLField):
 
 
 class CollectionTranslatableContentFields(GraphQLField):
-    id: "CollectionTranslatableContentGraphQLField" = (
-        CollectionTranslatableContentGraphQLField("id")
-    )
+    id = GraphQLLeafField("id", CollectionTranslatableContentGraphQLField)
     "The ID of the collection translatable content."
-    collection_id: "CollectionTranslatableContentGraphQLField" = (
-        CollectionTranslatableContentGraphQLField("collectionId")
+    collection_id = GraphQLLeafField(
+        "collectionId", CollectionTranslatableContentGraphQLField
     )
     "The ID of the collection to translate.\n\nAdded in Saleor 3.14."
-    seo_title: "CollectionTranslatableContentGraphQLField" = (
-        CollectionTranslatableContentGraphQLField("seoTitle")
-    )
+    seo_title = GraphQLLeafField("seoTitle", CollectionTranslatableContentGraphQLField)
     "SEO title to translate."
-    seo_description: "CollectionTranslatableContentGraphQLField" = (
-        CollectionTranslatableContentGraphQLField("seoDescription")
+    seo_description = GraphQLLeafField(
+        "seoDescription", CollectionTranslatableContentGraphQLField
     )
     "SEO description to translate."
-    name: "CollectionTranslatableContentGraphQLField" = (
-        CollectionTranslatableContentGraphQLField("name")
-    )
+    name = GraphQLLeafField("name", CollectionTranslatableContentGraphQLField)
     "Collection's name to translate."
-    description: "CollectionTranslatableContentGraphQLField" = (
-        CollectionTranslatableContentGraphQLField("description")
+    description = GraphQLLeafField(
+        "description", CollectionTranslatableContentGraphQLField
     )
     "Collection's description to translate.\n\nRich text format. For reference see https://editorjs.io/"
 
@@ -87,11 +81,11 @@ class CollectionTranslatableContentFields(GraphQLField):
 
 
 class MetadataErrorFields(GraphQLField):
-    field: "MetadataErrorGraphQLField" = MetadataErrorGraphQLField("field")
+    field = GraphQLLeafField("field", MetadataErrorGraphQLField)
     "Name of a field that caused the error. A value of `null` indicates that the error isn't associated with a particular field."
-    message: "MetadataErrorGraphQLField" = MetadataErrorGraphQLField("message")
+    message = GraphQLLeafField("message", MetadataErrorGraphQLField)
     "The error message."
-    code: "MetadataErrorGraphQLField" = MetadataErrorGraphQLField("code")
+    code = GraphQLLeafField("code", MetadataErrorGraphQLField)
     "The error code."
 
     def fields(self, *subfields: MetadataErrorGraphQLField) -> "MetadataErrorFields":
@@ -105,9 +99,9 @@ class MetadataErrorFields(GraphQLField):
 
 
 class MetadataItemFields(GraphQLField):
-    key: "MetadataItemGraphQLField" = MetadataItemGraphQLField("key")
+    key = GraphQLLeafField("key", MetadataItemGraphQLField)
     "Key of a metadata item."
-    value: "MetadataItemGraphQLField" = MetadataItemGraphQLField("value")
+    value = GraphQLLeafField("value", MetadataItemGraphQLField)
     "Value of a metadata item."
 
     def fields(self, *subfields: MetadataItemGraphQLField) -> "MetadataItemFields":
@@ -178,10 +172,10 @@ class ObjectWithMetadataInterface(GraphQLField):
 
 
 class PageInfoFields(GraphQLField):
-    has_next_page: "PageInfoGraphQLField" = PageInfoGraphQLField("hasNextPage")
-    has_previous_page: "PageInfoGraphQLField" = PageInfoGraphQLField("hasPreviousPage")
-    start_cursor: "PageInfoGraphQLField" = PageInfoGraphQLField("startCursor")
-    end_cursor: "PageInfoGraphQLField" = PageInfoGraphQLField("endCursor")
+    has_next_page = GraphQLLeafField("hasNextPage", PageInfoGraphQLField)
+    has_previous_page = GraphQLLeafField("hasPreviousPage", PageInfoGraphQLField)
+    start_cursor = GraphQLLeafField("startCursor", PageInfoGraphQLField)
+    end_cursor = GraphQLLeafField("endCursor", PageInfoGraphQLField)
 
     def fields(self, *subfields: PageInfoGraphQLField) -> "PageInfoFields":
         """Subfields should come from the PageInfoFields class"""
@@ -194,9 +188,9 @@ class PageInfoFields(GraphQLField):
 
 
 class ProductFields(GraphQLField):
-    id: "ProductGraphQLField" = ProductGraphQLField("id")
-    slug: "ProductGraphQLField" = ProductGraphQLField("slug")
-    name: "ProductGraphQLField" = ProductGraphQLField("name")
+    id = GraphQLLeafField("id", ProductGraphQLField)
+    slug = GraphQLLeafField("slug", ProductGraphQLField)
+    name = GraphQLLeafField("name", ProductGraphQLField)
 
     @classmethod
     def private_metadata(cls) -> "MetadataItemFields":
@@ -255,9 +249,7 @@ class ProductCountableConnectionFields(GraphQLField):
     def page_info(cls) -> "PageInfoFields":
         return PageInfoFields("pageInfo")
 
-    total_count: "ProductCountableConnectionGraphQLField" = (
-        ProductCountableConnectionGraphQLField("totalCount")
-    )
+    total_count = GraphQLLeafField("totalCount", ProductCountableConnectionGraphQLField)
 
     def fields(
         self,
@@ -281,9 +273,7 @@ class ProductCountableEdgeFields(GraphQLField):
     def node(cls) -> "ProductFields":
         return ProductFields("node")
 
-    cursor: "ProductCountableEdgeGraphQLField" = ProductCountableEdgeGraphQLField(
-        "cursor"
-    )
+    cursor = GraphQLLeafField("cursor", ProductCountableEdgeGraphQLField)
 
     def fields(
         self, *subfields: Union[ProductCountableEdgeGraphQLField, "ProductFields"]
@@ -298,28 +288,20 @@ class ProductCountableEdgeFields(GraphQLField):
 
 
 class ProductTranslatableContentFields(GraphQLField):
-    id: "ProductTranslatableContentGraphQLField" = (
-        ProductTranslatableContentGraphQLField("id")
-    )
+    id = GraphQLLeafField("id", ProductTranslatableContentGraphQLField)
     "The ID of the product translatable content."
-    product_id: "ProductTranslatableContentGraphQLField" = (
-        ProductTranslatableContentGraphQLField("productId")
-    )
+    product_id = GraphQLLeafField("productId", ProductTranslatableContentGraphQLField)
     "The ID of the product to translate.\n\nAdded in Saleor 3.14."
-    seo_title: "ProductTranslatableContentGraphQLField" = (
-        ProductTranslatableContentGraphQLField("seoTitle")
-    )
+    seo_title = GraphQLLeafField("seoTitle", ProductTranslatableContentGraphQLField)
     "SEO title to translate."
-    seo_description: "ProductTranslatableContentGraphQLField" = (
-        ProductTranslatableContentGraphQLField("seoDescription")
+    seo_description = GraphQLLeafField(
+        "seoDescription", ProductTranslatableContentGraphQLField
     )
     "SEO description to translate."
-    name: "ProductTranslatableContentGraphQLField" = (
-        ProductTranslatableContentGraphQLField("name")
-    )
+    name = GraphQLLeafField("name", ProductTranslatableContentGraphQLField)
     "Product's name to translate."
-    description: "ProductTranslatableContentGraphQLField" = (
-        ProductTranslatableContentGraphQLField("description")
+    description = GraphQLLeafField(
+        "description", ProductTranslatableContentGraphQLField
     )
     "Product's description to translate.\n\nRich text format. For reference see https://editorjs.io/"
 
@@ -389,9 +371,7 @@ class TranslatableItemConnectionFields(GraphQLField):
     def edges(cls) -> "TranslatableItemEdgeFields":
         return TranslatableItemEdgeFields("edges")
 
-    total_count: "TranslatableItemConnectionGraphQLField" = (
-        TranslatableItemConnectionGraphQLField("totalCount")
-    )
+    total_count = GraphQLLeafField("totalCount", TranslatableItemConnectionGraphQLField)
     "A total count of items in the collection."
 
     def fields(
@@ -412,11 +392,9 @@ class TranslatableItemConnectionFields(GraphQLField):
 
 
 class TranslatableItemEdgeFields(GraphQLField):
-    node: "TranslatableItemUnion" = TranslatableItemUnion("node")
+    node = GraphQLLeafField("node", TranslatableItemUnion)
     "The item at the end of the edge."
-    cursor: "TranslatableItemEdgeGraphQLField" = TranslatableItemEdgeGraphQLField(
-        "cursor"
-    )
+    cursor = GraphQLLeafField("cursor", TranslatableItemEdgeGraphQLField)
     "A cursor for use in pagination."
 
     def fields(

--- a/tests/main/clients/custom_query_builder_scalars/expected_client/__init__.py
+++ b/tests/main/clients/custom_query_builder_scalars/expected_client/__init__.py
@@ -1,0 +1,22 @@
+from .async_base_client import AsyncBaseClient
+from .base_model import BaseModel, Upload
+from .client import Client
+from .exceptions import (
+    GraphQLClientError,
+    GraphQLClientGraphQLError,
+    GraphQLClientGraphQLMultiError,
+    GraphQLClientHttpError,
+    GraphQLClientInvalidResponseError,
+)
+
+__all__ = [
+    "AsyncBaseClient",
+    "BaseModel",
+    "Client",
+    "GraphQLClientError",
+    "GraphQLClientGraphQLError",
+    "GraphQLClientGraphQLMultiError",
+    "GraphQLClientHttpError",
+    "GraphQLClientInvalidResponseError",
+    "Upload",
+]

--- a/tests/main/clients/custom_query_builder_scalars/expected_client/async_base_client.py
+++ b/tests/main/clients/custom_query_builder_scalars/expected_client/async_base_client.py
@@ -1,0 +1,406 @@
+import asyncio
+import enum
+import json
+from collections.abc import AsyncIterator
+from typing import IO, Any, Optional, Protocol, TypeVar, cast
+from uuid import uuid4
+
+import httpx
+from pydantic import BaseModel
+from pydantic_core import to_jsonable_python
+
+from .base_model import UNSET, Upload
+from .exceptions import (
+    GraphQLClientError,
+    GraphQLClientGraphQLMultiError,
+    GraphQLClientHttpError,
+    GraphQLClientInvalidMessageFormat,
+    GraphQLClientInvalidResponseError,
+)
+
+try:
+    from websockets import (  # type: ignore[import-not-found,unused-ignore]
+        ClientConnection,
+    )
+    from websockets import (  # type: ignore[import-not-found,unused-ignore]
+        connect as ws_connect,
+    )
+    from websockets.typing import (  # type: ignore[import-not-found,unused-ignore]
+        Data,
+        Origin,
+        Subprotocol,
+    )
+except ImportError:
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager  # type: ignore
+    async def ws_connect(*args, **kwargs):
+        raise NotImplementedError("Subscriptions require 'websockets' package.")
+        yield
+
+    ClientConnection = Any  # ty: ignore[invalid-assignment]
+    Data = Any  # ty: ignore[invalid-assignment]
+    Origin = Any  # ty: ignore[invalid-assignment]
+
+    def Subprotocol(*args, **kwargs):  # type: ignore # noqa: N802, N803
+        raise NotImplementedError("Subscriptions require 'websockets' package.")
+
+
+class Response(Protocol):
+    status_code: int
+
+    def json(self, **kwargs: Any) -> Any: ...
+
+
+class HttpClient(Protocol):
+    async def post(
+        self,
+        url: Any | str,
+        json: Any | None = None,
+        data: Any | None = None,
+        files: Any | None = None,
+        headers: Any | None = None,
+        **kwargs: Any,
+    ) -> Response: ...
+
+    async def aclose(self) -> None: ...
+
+
+Self = TypeVar("Self", bound="AsyncBaseClient")
+
+GRAPHQL_TRANSPORT_WS = "graphql-transport-ws"
+
+
+class GraphQLTransportWSMessageType(str, enum.Enum):
+    CONNECTION_INIT = "connection_init"
+    CONNECTION_ACK = "connection_ack"
+    PING = "ping"
+    PONG = "pong"
+    SUBSCRIBE = "subscribe"
+    NEXT = "next"
+    ERROR = "error"
+    COMPLETE = "complete"
+
+
+class AsyncBaseClient:
+    def __init__(
+        self,
+        url: str = "",
+        headers: Optional[dict[str, str]] = None,
+        http_client: Optional[HttpClient] = None,
+        ws_url: str = "",
+        ws_headers: Optional[dict[str, Any]] = None,
+        ws_origin: Optional[str] = None,
+        ws_connection_init_payload: Optional[dict[str, Any]] = None,
+    ) -> None:
+        self.url = url
+        self.headers = headers
+        self.http_client = (
+            http_client if http_client else httpx.AsyncClient(headers=headers)
+        )
+
+        self.ws_url = ws_url
+        self.ws_headers = ws_headers or {}
+        self.ws_origin = Origin(ws_origin) if ws_origin else None
+        self.ws_connection_init_payload = ws_connection_init_payload
+
+    async def __aenter__(self: Self) -> Self:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: object,
+        exc_val: object,
+        exc_tb: object,
+    ) -> None:
+        await self.http_client.aclose()
+
+    async def execute(
+        self,
+        query: str,
+        operation_name: Optional[str] = None,
+        variables: Optional[dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> Response:
+        processed_variables, files, files_map = self._process_variables(variables)
+
+        if files and files_map:
+            return await self._execute_multipart(
+                query=query,
+                operation_name=operation_name,
+                variables=processed_variables,
+                files=files,
+                files_map=files_map,
+                **kwargs,
+            )
+
+        return await self._execute_json(
+            query=query,
+            operation_name=operation_name,
+            variables=processed_variables,
+            **kwargs,
+        )
+
+    def get_data(self, response: Response) -> dict[str, Any]:
+        if not (200 <= response.status_code <= 299):
+            raise GraphQLClientHttpError(
+                status_code=response.status_code, response=response
+            )
+
+        try:
+            response_json = response.json()
+        except ValueError as exc:
+            raise GraphQLClientInvalidResponseError(response=response) from exc
+
+        if (not isinstance(response_json, dict)) or (
+            "data" not in response_json and "errors" not in response_json
+        ):
+            raise GraphQLClientInvalidResponseError(response=response)
+
+        data = response_json.get("data")
+        errors = response_json.get("errors")
+
+        if errors:
+            raise GraphQLClientGraphQLMultiError.from_errors_dicts(
+                errors_dicts=errors, data=data
+            )
+
+        return cast(dict[str, Any], data)
+
+    async def execute_ws(
+        self,
+        query: str,
+        operation_name: Optional[str] = None,
+        variables: Optional[dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[dict[str, Any]]:
+        headers = self.ws_headers.copy()
+        headers.update(kwargs.pop("additional_headers", {}))
+
+        merged_kwargs: dict[str, Any] = {"origin": self.ws_origin}
+        merged_kwargs.update(kwargs)
+        merged_kwargs["additional_headers"] = headers
+
+        operation_id = str(uuid4())
+        async with ws_connect(
+            self.ws_url,
+            subprotocols=[Subprotocol(GRAPHQL_TRANSPORT_WS)],
+            **merged_kwargs,
+        ) as websocket:
+            await self._send_connection_init(websocket)
+            # Wait for connection_ack; some servers (e.g. Hasura) send ping before
+            # connection_ack, so we loop and handle pings until we get ack.
+            try:
+                await asyncio.wait_for(
+                    self._wait_for_connection_ack(websocket),
+                    timeout=5.0,
+                )
+            except asyncio.TimeoutError as exc:
+                raise GraphQLClientError(
+                    "Connection ack not received within 5 seconds"
+                ) from exc
+            await self._send_subscribe(
+                websocket,
+                operation_id=operation_id,
+                query=query,
+                operation_name=operation_name,
+                variables=variables,
+            )
+
+            async for message in websocket:
+                data = await self._handle_ws_message(message, websocket)
+                if data and "connection_ack" not in data:
+                    yield data
+
+    def _process_variables(
+        self, variables: Optional[dict[str, Any]]
+    ) -> tuple[
+        dict[str, Any], dict[str, tuple[str, IO[bytes], str]], dict[str, list[str]]
+    ]:
+        if not variables:
+            return {}, {}, {}
+
+        serializable_variables = self._convert_dict_to_json_serializable(variables)
+        return self._get_files_from_variables(serializable_variables)
+
+    def _convert_dict_to_json_serializable(
+        self, dict_: dict[str, Any]
+    ) -> dict[str, Any]:
+        return {
+            key: self._convert_value(value)
+            for key, value in dict_.items()
+            if value is not UNSET
+        }
+
+    def _convert_value(self, value: Any) -> Any:
+        if isinstance(value, BaseModel):
+            return value.model_dump(by_alias=True, exclude_unset=True)
+        if isinstance(value, list):
+            return [self._convert_value(item) for item in value]
+        return value
+
+    def _get_files_from_variables(
+        self, variables: dict[str, Any]
+    ) -> tuple[
+        dict[str, Any], dict[str, tuple[str, IO[bytes], str]], dict[str, list[str]]
+    ]:
+        files_map: dict[str, list[str]] = {}
+        files_list: list[Upload] = []
+
+        def separate_files(path: str, obj: Any) -> Any:
+            if isinstance(obj, list):
+                nulled_list = []
+                for index, value in enumerate(obj):
+                    value = separate_files(f"{path}.{index}", value)
+                    nulled_list.append(value)
+                return nulled_list
+
+            if isinstance(obj, dict):
+                nulled_dict = {}
+                for key, value in obj.items():
+                    value = separate_files(f"{path}.{key}", value)
+                    nulled_dict[key] = value
+                return nulled_dict
+
+            if isinstance(obj, Upload):
+                if obj in files_list:
+                    file_index = files_list.index(obj)
+                    files_map[str(file_index)].append(path)
+                else:
+                    file_index = len(files_list)
+                    files_list.append(obj)
+                    files_map[str(file_index)] = [path]
+                return None
+
+            return obj
+
+        nulled_variables = separate_files("variables", variables)
+        files: dict[str, tuple[str, IO[bytes], str]] = {
+            str(i): (file_.filename, cast(IO[bytes], file_.content), file_.content_type)
+            for i, file_ in enumerate(files_list)
+        }
+        return nulled_variables, files, files_map
+
+    async def _execute_multipart(
+        self,
+        query: str,
+        operation_name: Optional[str],
+        variables: dict[str, Any],
+        files: dict[str, tuple[str, IO[bytes], str]],
+        files_map: dict[str, list[str]],
+        **kwargs: Any,
+    ) -> Response:
+        data = {
+            "operations": json.dumps(
+                {
+                    "query": query,
+                    "operationName": operation_name,
+                    "variables": variables,
+                },
+                default=to_jsonable_python,
+            ),
+            "map": json.dumps(files_map, default=to_jsonable_python),
+        }
+
+        return await self.http_client.post(
+            url=self.url, data=data, files=files, **kwargs
+        )
+
+    async def _execute_json(
+        self,
+        query: str,
+        operation_name: Optional[str],
+        variables: dict[str, Any],
+        **kwargs: Any,
+    ) -> Response:
+        return await self.http_client.post(
+            url=self.url,
+            json=to_jsonable_python(
+                {
+                    "query": query,
+                    "operationName": operation_name,
+                    "variables": variables,
+                }
+            ),
+            **kwargs,
+        )
+
+    async def _send_connection_init(self, websocket: ClientConnection) -> None:
+        payload: dict[str, Any] = {
+            "type": GraphQLTransportWSMessageType.CONNECTION_INIT.value
+        }
+        if self.ws_connection_init_payload:
+            payload["payload"] = self.ws_connection_init_payload
+        await websocket.send(json.dumps(payload))
+
+    async def _wait_for_connection_ack(self, websocket: ClientConnection) -> None:
+        """Read messages until connection_ack; handle ping/pong in between."""
+        async for message in websocket:
+            data = await self._handle_ws_message(message, websocket)
+            if data is not None and "connection_ack" in data:
+                return
+
+    async def _send_subscribe(
+        self,
+        websocket: ClientConnection,
+        operation_id: str,
+        query: str,
+        operation_name: Optional[str] = None,
+        variables: Optional[dict[str, Any]] = None,
+    ) -> None:
+        payload_inner: dict[str, Any] = {
+            "query": query,
+            "operationName": operation_name,
+        }
+        if variables:
+            payload_inner["variables"] = self._convert_dict_to_json_serializable(
+                variables
+            )
+        payload: dict[str, Any] = {
+            "id": operation_id,
+            "type": GraphQLTransportWSMessageType.SUBSCRIBE.value,
+            "payload": payload_inner,
+        }
+        await websocket.send(json.dumps(payload))
+
+    async def _handle_ws_message(
+        self,
+        message: Data,
+        websocket: ClientConnection,
+        expected_type: Optional[GraphQLTransportWSMessageType] = None,
+    ) -> Optional[dict[str, Any]]:
+        try:
+            message_dict = json.loads(message)
+        except json.JSONDecodeError as exc:
+            raise GraphQLClientInvalidMessageFormat(message=message) from exc
+
+        type_ = message_dict.get("type")
+        payload = message_dict.get("payload", {})
+
+        if not type_ or type_ not in {t.value for t in GraphQLTransportWSMessageType}:
+            raise GraphQLClientInvalidMessageFormat(message=message)
+
+        if expected_type and expected_type != type_:
+            raise GraphQLClientInvalidMessageFormat(
+                f"Invalid message received. Expected: {expected_type.value}"
+            )
+
+        if type_ == GraphQLTransportWSMessageType.NEXT:
+            if "data" not in payload:
+                raise GraphQLClientInvalidMessageFormat(message=message)
+            return cast(dict[str, Any], payload["data"])
+
+        if type_ == GraphQLTransportWSMessageType.COMPLETE:
+            await websocket.close()
+        elif type_ == GraphQLTransportWSMessageType.PING:
+            await websocket.send(
+                json.dumps({"type": GraphQLTransportWSMessageType.PONG.value})
+            )
+        elif type_ == GraphQLTransportWSMessageType.ERROR:
+            raise GraphQLClientGraphQLMultiError.from_errors_dicts(
+                errors_dicts=payload, data=message_dict
+            )
+        elif type_ == GraphQLTransportWSMessageType.CONNECTION_ACK:
+            return {"connection_ack": True}
+
+        return None

--- a/tests/main/clients/custom_query_builder_scalars/expected_client/base_model.py
+++ b/tests/main/clients/custom_query_builder_scalars/expected_client/base_model.py
@@ -1,0 +1,28 @@
+from io import IOBase
+
+from pydantic import BaseModel as PydanticBaseModel
+from pydantic import ConfigDict
+
+
+class UnsetType:
+    def __bool__(self) -> bool:
+        return False
+
+
+UNSET = UnsetType()
+
+
+class BaseModel(PydanticBaseModel):
+    model_config = ConfigDict(
+        populate_by_name=True,
+        validate_assignment=True,
+        arbitrary_types_allowed=True,
+        protected_namespaces=(),
+    )
+
+
+class Upload:
+    def __init__(self, filename: str, content: IOBase, content_type: str):
+        self.filename = filename
+        self.content = content
+        self.content_type = content_type

--- a/tests/main/clients/custom_query_builder_scalars/expected_client/base_operation.py
+++ b/tests/main/clients/custom_query_builder_scalars/expected_client/base_operation.py
@@ -157,12 +157,10 @@ class GraphQLField:
 
 
 class GraphQLLeafField(Generic[GraphQLFieldT]):
-    """
-    Descriptor that builds a fresh field on every access.
+    """Descriptor that builds a fresh field on every access.
 
-    Leaf selections are reached through the class (``ProductFields.name``). A
-    single shared instance would carry ``alias()`` and ``to_ast()`` state from one
-    query into every later one, so each access gets its own field.
+    Leaf selections are reached through the class (``ProductFields.name``); a
+    shared instance would leak ``alias()``/``to_ast()`` state between queries.
     """
 
     __slots__ = ("_field_name", "_field_class")

--- a/tests/main/clients/custom_query_builder_scalars/expected_client/base_operation.py
+++ b/tests/main/clients/custom_query_builder_scalars/expected_client/base_operation.py
@@ -1,0 +1,175 @@
+from typing import Any, Generic, Optional, TypeVar, Union
+
+from graphql import (
+    ArgumentNode,
+    FieldNode,
+    InlineFragmentNode,
+    NamedTypeNode,
+    NameNode,
+    SelectionSetNode,
+    VariableNode,
+)
+
+GraphQLFieldT = TypeVar("GraphQLFieldT", bound="GraphQLField")
+
+
+class GraphQLArgument:
+    """
+    Represents a GraphQL argument and allows conversion to an AST structure.
+    """
+
+    def __init__(self, argument_name: str, argument_value: Any) -> None:
+        self._name = argument_name
+        self._value = argument_value
+
+    def to_ast(self) -> ArgumentNode:
+        """Converts the argument to an ArgumentNode AST object."""
+        return ArgumentNode(
+            name=NameNode(value=self._name),
+            value=VariableNode(name=NameNode(value=self._value)),
+        )
+
+
+class GraphQLField:
+    """
+    Represents a GraphQL field with its name, arguments, subfields, alias,
+    and inline fragments.
+
+    Attributes:
+        formatted_variables (dict[str, dict[str, Any]]): The formatted arguments
+        of the GraphQL field.
+    """
+
+    def __init__(
+        self, field_name: str, arguments: Optional[dict[str, dict[str, Any]]] = None
+    ) -> None:
+        self._field_name = field_name
+        self._variables = arguments or {}
+        self.formatted_variables: dict[str, dict[str, Any]] = {}
+        self._subfields: list[GraphQLField] = []
+        self._alias: Optional[str] = None
+        self._inline_fragments: dict[str, tuple[GraphQLField, ...]] = {}
+
+    def alias(self, alias: str) -> "GraphQLField":
+        """Sets an alias for the GraphQL field and returns the instance."""
+        self._alias = alias
+        return self
+
+    def _build_field_name(self) -> str:
+        """Builds the field name, including the alias if present."""
+        return f"{self._alias}: {self._field_name}" if self._alias else self._field_name
+
+    def _build_selections(
+        self, idx: int, used_names: set[str]
+    ) -> list[Union[FieldNode, InlineFragmentNode]]:
+        """Builds the selection set for the current GraphQL field,
+        including subfields and inline fragments."""
+        # Create selections from subfields
+        selections: list[Union[FieldNode, InlineFragmentNode]] = [
+            subfield.to_ast(idx, used_names) for subfield in self._subfields
+        ]
+
+        # Add inline fragments
+        for name, subfields in self._inline_fragments.items():
+            selections.append(
+                InlineFragmentNode(
+                    type_condition=NamedTypeNode(name=NameNode(value=name)),
+                    selection_set=SelectionSetNode(
+                        selections=[
+                            subfield.to_ast(idx, used_names) for subfield in subfields
+                        ]
+                    ),
+                )
+            )
+
+        return selections
+
+    def _format_variable_name(
+        self, idx: int, var_name: str, used_names: set[str]
+    ) -> str:
+        """Generates a unique variable name by appending an index and,
+        if necessary, an additional counter to avoid duplicates."""
+        base_name = f"{var_name}_{idx}"
+        unique_name = base_name
+        counter = 1
+
+        # Ensure the generated name is unique
+        while unique_name in used_names:
+            unique_name = f"{base_name}_{counter}"
+            counter += 1
+
+        # Add the unique name to the set of used names
+        used_names.add(unique_name)
+
+        return unique_name
+
+    def _collect_all_variables(self, idx: int, used_names: set[str]) -> None:
+        """
+        Collects and formats all variables for the current GraphQL field,
+        ensuring unique names.
+        """
+        self.formatted_variables = {}
+
+        for k, v in self._variables.items():
+            unique_name = self._format_variable_name(idx, k, used_names)
+            self.formatted_variables[unique_name] = {
+                "name": k,
+                "type": v["type"],
+                "value": v["value"],
+            }
+
+    def to_ast(self, idx: int, used_names: Optional[set[str]] = None) -> FieldNode:
+        """Converts the current GraphQL field to an AST (Abstract Syntax Tree) node."""
+        if used_names is None:
+            used_names = set()
+
+        self._collect_all_variables(idx, used_names)
+
+        return FieldNode(
+            name=NameNode(value=self._build_field_name()),
+            arguments=[
+                GraphQLArgument(v["name"], k).to_ast()
+                for k, v in self.formatted_variables.items()
+            ],
+            selection_set=(
+                SelectionSetNode(selections=self._build_selections(idx, used_names))
+                if self._subfields or self._inline_fragments
+                else None
+            ),
+        )
+
+    def get_formatted_variables(self) -> dict[str, dict[str, Any]]:
+        """
+        Retrieves all formatted variables for the current GraphQL field,
+        including those from subfields and inline fragments.
+        """
+        formatted_variables = self.formatted_variables.copy()
+
+        # Collect variables from subfields
+        for subfield in self._subfields:
+            formatted_variables.update(subfield.get_formatted_variables())
+
+        # Collect variables from inline fragments
+        for subfields in self._inline_fragments.values():
+            for subfield in subfields:
+                formatted_variables.update(subfield.get_formatted_variables())
+        return formatted_variables
+
+
+class GraphQLLeafField(Generic[GraphQLFieldT]):
+    """
+    Descriptor that builds a fresh field on every access.
+
+    Leaf selections are reached through the class (``ProductFields.name``). A
+    single shared instance would carry ``alias()`` and ``to_ast()`` state from one
+    query into every later one, so each access gets its own field.
+    """
+
+    __slots__ = ("_field_name", "_field_class")
+
+    def __init__(self, field_name: str, field_class: type[GraphQLFieldT]) -> None:
+        self._field_name = field_name
+        self._field_class = field_class
+
+    def __get__(self, instance: object, owner: Optional[type] = None) -> GraphQLFieldT:
+        return self._field_class(self._field_name)

--- a/tests/main/clients/custom_query_builder_scalars/expected_client/client.py
+++ b/tests/main/clients/custom_query_builder_scalars/expected_client/client.py
@@ -1,0 +1,107 @@
+from typing import Any
+
+from graphql import (
+    DocumentNode,
+    NamedTypeNode,
+    NameNode,
+    OperationDefinitionNode,
+    OperationType,
+    SelectionNode,
+    SelectionSetNode,
+    VariableDefinitionNode,
+    VariableNode,
+    print_ast,
+)
+
+from .async_base_client import AsyncBaseClient
+from .base_operation import GraphQLField
+
+
+def gql(q: str) -> str:
+    return q
+
+
+class Client(AsyncBaseClient):
+    async def execute_custom_operation(
+        self, *fields: GraphQLField, operation_type: OperationType, operation_name: str
+    ) -> dict[str, Any]:
+        selections = self._build_selection_set(fields)
+        combined_variables = self._combine_variables(fields)
+        variable_definitions = self._build_variable_definitions(
+            combined_variables["types"]
+        )
+        operation_ast = self._build_operation_ast(
+            selections, operation_type, operation_name, variable_definitions
+        )
+        response = await self.execute(
+            print_ast(operation_ast),
+            variables=combined_variables["values"],
+            operation_name=operation_name,
+        )
+        return self.get_data(response)
+
+    def _combine_variables(
+        self, fields: tuple[GraphQLField, ...]
+    ) -> dict[str, dict[str, Any]]:
+        variables_types_combined = {}
+        processed_variables_combined = {}
+        for field in fields:
+            formatted_variables = field.get_formatted_variables()
+            variables_types_combined.update(
+                {k: v["type"] for k, v in formatted_variables.items()}
+            )
+            processed_variables_combined.update(
+                {k: v["value"] for k, v in formatted_variables.items()}
+            )
+        return {
+            "types": variables_types_combined,
+            "values": processed_variables_combined,
+        }
+
+    def _build_variable_definitions(
+        self, variables_types_combined: dict[str, str]
+    ) -> list[VariableDefinitionNode]:
+        return [
+            VariableDefinitionNode(
+                variable=VariableNode(name=NameNode(value=var_name)),
+                type=NamedTypeNode(name=NameNode(value=var_value)),
+            )
+            for var_name, var_value in variables_types_combined.items()
+        ]
+
+    def _build_operation_ast(
+        self,
+        selections: list[SelectionNode],
+        operation_type: OperationType,
+        operation_name: str,
+        variable_definitions: list[VariableDefinitionNode],
+    ) -> DocumentNode:
+        return DocumentNode(
+            definitions=[
+                OperationDefinitionNode(
+                    operation=operation_type,
+                    name=NameNode(value=operation_name),
+                    variable_definitions=variable_definitions,
+                    selection_set=SelectionSetNode(selections=selections),
+                )
+            ]
+        )
+
+    def _build_selection_set(
+        self, fields: tuple[GraphQLField, ...]
+    ) -> list[SelectionNode]:
+        return [field.to_ast(idx) for idx, field in enumerate(fields)]
+
+    async def query(self, *fields: GraphQLField, operation_name: str) -> dict[str, Any]:
+        return await self.execute_custom_operation(
+            *fields, operation_type=OperationType.QUERY, operation_name=operation_name
+        )
+
+    async def mutation(
+        self, *fields: GraphQLField, operation_name: str
+    ) -> dict[str, Any]:
+        return await self.execute_custom_operation(
+            *fields,
+            operation_type=OperationType.MUTATION,
+            operation_name=operation_name,
+        )

--- a/tests/main/clients/custom_query_builder_scalars/expected_client/custom_fields.py
+++ b/tests/main/clients/custom_query_builder_scalars/expected_client/custom_fields.py
@@ -1,0 +1,78 @@
+from decimal import Decimal
+from typing import Any, Optional, Union
+
+from .base_operation import GraphQLField, GraphQLLeafField
+from .custom_typing_fields import (
+    CheckoutGraphQLField,
+    OrderGraphQLField,
+    PaymentGraphQLField,
+    PaymentMethodGraphQLField,
+)
+
+
+class CheckoutFields(GraphQLField):
+    id = GraphQLLeafField("id", CheckoutGraphQLField)
+
+    @classmethod
+    def stored_payment_methods(
+        cls, *, amount: Optional[Decimal] = None
+    ) -> "PaymentMethodFields":
+        arguments: dict[str, dict[str, Any]] = {
+            "amount": {"type": "Decimal", "value": amount}
+        }
+        cleared_arguments = {
+            key: value for key, value in arguments.items() if value["value"] is not None
+        }
+        return PaymentMethodFields("storedPaymentMethods", arguments=cleared_arguments)
+
+    def fields(
+        self, *subfields: Union[CheckoutGraphQLField, "PaymentMethodFields"]
+    ) -> "CheckoutFields":
+        """Subfields should come from the CheckoutFields class"""
+        self._subfields.extend(subfields)
+        return self
+
+    def alias(self, alias: str) -> "CheckoutFields":
+        self._alias = alias
+        return self
+
+
+class OrderFields(GraphQLField):
+    id = GraphQLLeafField("id", OrderGraphQLField)
+    token = GraphQLLeafField("token", OrderGraphQLField)
+
+    def fields(self, *subfields: OrderGraphQLField) -> "OrderFields":
+        """Subfields should come from the OrderFields class"""
+        self._subfields.extend(subfields)
+        return self
+
+    def alias(self, alias: str) -> "OrderFields":
+        self._alias = alias
+        return self
+
+
+class PaymentFields(GraphQLField):
+    id = GraphQLLeafField("id", PaymentGraphQLField)
+    total = GraphQLLeafField("total", PaymentGraphQLField)
+
+    def fields(self, *subfields: PaymentGraphQLField) -> "PaymentFields":
+        """Subfields should come from the PaymentFields class"""
+        self._subfields.extend(subfields)
+        return self
+
+    def alias(self, alias: str) -> "PaymentFields":
+        self._alias = alias
+        return self
+
+
+class PaymentMethodFields(GraphQLField):
+    id = GraphQLLeafField("id", PaymentMethodGraphQLField)
+
+    def fields(self, *subfields: PaymentMethodGraphQLField) -> "PaymentMethodFields":
+        """Subfields should come from the PaymentMethodFields class"""
+        self._subfields.extend(subfields)
+        return self
+
+    def alias(self, alias: str) -> "PaymentMethodFields":
+        self._alias = alias
+        return self

--- a/tests/main/clients/custom_query_builder_scalars/expected_client/custom_mutations.py
+++ b/tests/main/clients/custom_query_builder_scalars/expected_client/custom_mutations.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+from decimal import Decimal
+from typing import Any, Optional
+
+from .custom_fields import PaymentFields
+
+
+class Mutation:
+    @classmethod
+    def create_payment(
+        cls, amount: Decimal, *, requested_at: Optional[datetime] = None
+    ) -> PaymentFields:
+        arguments: dict[str, dict[str, Any]] = {
+            "amount": {"type": "Decimal!", "value": amount},
+            "requestedAt": {"type": "DateTime", "value": requested_at},
+        }
+        cleared_arguments = {
+            key: value for key, value in arguments.items() if value["value"] is not None
+        }
+        return PaymentFields(field_name="createPayment", arguments=cleared_arguments)

--- a/tests/main/clients/custom_query_builder_scalars/expected_client/custom_queries.py
+++ b/tests/main/clients/custom_query_builder_scalars/expected_client/custom_queries.py
@@ -1,0 +1,28 @@
+from datetime import datetime
+from typing import Any, Optional
+from uuid import UUID
+
+from .custom_fields import CheckoutFields, OrderFields
+
+
+class Query:
+    @classmethod
+    def checkout(cls, *, token: Optional[UUID] = None) -> CheckoutFields:
+        arguments: dict[str, dict[str, Any]] = {
+            "token": {"type": "UUID", "value": token}
+        }
+        cleared_arguments = {
+            key: value for key, value in arguments.items() if value["value"] is not None
+        }
+        return CheckoutFields(field_name="checkout", arguments=cleared_arguments)
+
+    @classmethod
+    def order(cls, id: str, *, created_at: Optional[datetime] = None) -> OrderFields:
+        arguments: dict[str, dict[str, Any]] = {
+            "id": {"type": "ID!", "value": id},
+            "createdAt": {"type": "DateTime", "value": created_at},
+        }
+        cleared_arguments = {
+            key: value for key, value in arguments.items() if value["value"] is not None
+        }
+        return OrderFields(field_name="order", arguments=cleared_arguments)

--- a/tests/main/clients/custom_query_builder_scalars/expected_client/custom_typing_fields.py
+++ b/tests/main/clients/custom_query_builder_scalars/expected_client/custom_typing_fields.py
@@ -1,0 +1,25 @@
+from .base_operation import GraphQLField
+
+
+class CheckoutGraphQLField(GraphQLField):
+    def alias(self, alias: str) -> "CheckoutGraphQLField":
+        self._alias = alias
+        return self
+
+
+class PaymentMethodGraphQLField(GraphQLField):
+    def alias(self, alias: str) -> "PaymentMethodGraphQLField":
+        self._alias = alias
+        return self
+
+
+class OrderGraphQLField(GraphQLField):
+    def alias(self, alias: str) -> "OrderGraphQLField":
+        self._alias = alias
+        return self
+
+
+class PaymentGraphQLField(GraphQLField):
+    def alias(self, alias: str) -> "PaymentGraphQLField":
+        self._alias = alias
+        return self

--- a/tests/main/clients/custom_query_builder_scalars/expected_client/exceptions.py
+++ b/tests/main/clients/custom_query_builder_scalars/expected_client/exceptions.py
@@ -1,0 +1,85 @@
+from typing import Any, Optional, Protocol, Union
+
+
+class Response(Protocol):
+    status_code: int
+
+
+class GraphQLClientError(Exception):
+    """Base exception."""
+
+
+class GraphQLClientHttpError(GraphQLClientError):
+    def __init__(self, status_code: int, response: Response) -> None:
+        self.status_code = status_code
+        self.response = response
+
+    def __str__(self) -> str:
+        return f"HTTP status code: {self.status_code}"
+
+
+class GraphQLClientInvalidResponseError(GraphQLClientError):
+    def __init__(self, response: Response) -> None:
+        self.response = response
+
+    def __str__(self) -> str:
+        return "Invalid response format."
+
+
+class GraphQLClientGraphQLError(GraphQLClientError):
+    def __init__(
+        self,
+        message: str,
+        locations: Optional[list[dict[str, int]]] = None,
+        path: Optional[list[str]] = None,
+        extensions: Optional[dict[str, object]] = None,
+        original: Optional[dict[str, object]] = None,
+    ):
+        self.message = message
+        self.locations = locations
+        self.path = path
+        self.extensions = extensions
+        self.original = original
+
+    def __str__(self) -> str:
+        return self.message
+
+    @classmethod
+    def from_dict(cls, error: dict[str, Any]) -> "GraphQLClientGraphQLError":
+        return cls(
+            message=error["message"],
+            locations=error.get("locations"),
+            path=error.get("path"),
+            extensions=error.get("extensions"),
+            original=error,
+        )
+
+
+class GraphQLClientGraphQLMultiError(GraphQLClientError):
+    def __init__(
+        self,
+        errors: list[GraphQLClientGraphQLError],
+        data: Optional[dict[str, Any]] = None,
+    ):
+        self.errors = errors
+        self.data = data
+
+    def __str__(self) -> str:
+        return "; ".join(str(e) for e in self.errors)
+
+    @classmethod
+    def from_errors_dicts(
+        cls, errors_dicts: list[dict[str, Any]], data: Optional[dict[str, Any]] = None
+    ) -> "GraphQLClientGraphQLMultiError":
+        return cls(
+            errors=[GraphQLClientGraphQLError.from_dict(e) for e in errors_dicts],
+            data=data,
+        )
+
+
+class GraphQLClientInvalidMessageFormat(GraphQLClientError):  # noqa: N818
+    def __init__(self, message: Union[str, bytes]) -> None:
+        self.message = message
+
+    def __str__(self) -> str:
+        return "Invalid message format."

--- a/tests/main/clients/custom_query_builder_scalars/pyproject.toml
+++ b/tests/main/clients/custom_query_builder_scalars/pyproject.toml
@@ -1,0 +1,14 @@
+[tool.ariadne-codegen]
+schema_path = "schema.graphql"
+include_comments = "none"
+target_package_name = "example_client"
+enable_custom_operations = true
+
+[tool.ariadne-codegen.scalars.UUID]
+type = "uuid.UUID"
+
+[tool.ariadne-codegen.scalars.Decimal]
+type = "decimal.Decimal"
+
+[tool.ariadne-codegen.scalars.DateTime]
+type = "datetime.datetime"

--- a/tests/main/clients/custom_query_builder_scalars/schema.graphql
+++ b/tests/main/clients/custom_query_builder_scalars/schema.graphql
@@ -1,0 +1,36 @@
+schema {
+  query: Query
+  mutation: Mutation
+}
+
+type Query {
+  checkout(token: UUID): Checkout
+  order(id: ID!, createdAt: DateTime): Order
+}
+
+type Mutation {
+  createPayment(amount: Decimal!, requestedAt: DateTime): Payment
+}
+
+type Checkout {
+  id: ID!
+  storedPaymentMethods(amount: Decimal): PaymentMethod
+}
+
+type PaymentMethod {
+  id: ID!
+}
+
+type Order {
+  id: ID!
+  token: UUID!
+}
+
+type Payment {
+  id: ID!
+  total: Decimal!
+}
+
+scalar UUID
+scalar Decimal
+scalar DateTime

--- a/tests/main/clients/custom_sync_query_builder/expected_client/base_operation.py
+++ b/tests/main/clients/custom_sync_query_builder/expected_client/base_operation.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Union
+from typing import Any, Generic, Optional, TypeVar, Union
 
 from graphql import (
     ArgumentNode,
@@ -9,6 +9,8 @@ from graphql import (
     SelectionSetNode,
     VariableNode,
 )
+
+GraphQLFieldT = TypeVar("GraphQLFieldT", bound="GraphQLField")
 
 
 class GraphQLArgument:
@@ -152,3 +154,22 @@ class GraphQLField:
             for subfield in subfields:
                 formatted_variables.update(subfield.get_formatted_variables())
         return formatted_variables
+
+
+class GraphQLLeafField(Generic[GraphQLFieldT]):
+    """
+    Descriptor that builds a fresh field on every access.
+
+    Leaf selections are reached through the class (``ProductFields.name``). A
+    single shared instance would carry ``alias()`` and ``to_ast()`` state from one
+    query into every later one, so each access gets its own field.
+    """
+
+    __slots__ = ("_field_name", "_field_class")
+
+    def __init__(self, field_name: str, field_class: type[GraphQLFieldT]) -> None:
+        self._field_name = field_name
+        self._field_class = field_class
+
+    def __get__(self, instance: object, owner: Optional[type] = None) -> GraphQLFieldT:
+        return self._field_class(self._field_name)

--- a/tests/main/clients/custom_sync_query_builder/expected_client/base_operation.py
+++ b/tests/main/clients/custom_sync_query_builder/expected_client/base_operation.py
@@ -157,12 +157,10 @@ class GraphQLField:
 
 
 class GraphQLLeafField(Generic[GraphQLFieldT]):
-    """
-    Descriptor that builds a fresh field on every access.
+    """Descriptor that builds a fresh field on every access.
 
-    Leaf selections are reached through the class (``ProductFields.name``). A
-    single shared instance would carry ``alias()`` and ``to_ast()`` state from one
-    query into every later one, so each access gets its own field.
+    Leaf selections are reached through the class (``ProductFields.name``); a
+    shared instance would leak ``alias()``/``to_ast()`` state between queries.
     """
 
     __slots__ = ("_field_name", "_field_class")

--- a/tests/main/clients/custom_sync_query_builder/expected_client/custom_fields.py
+++ b/tests/main/clients/custom_sync_query_builder/expected_client/custom_fields.py
@@ -1,6 +1,6 @@
 from typing import Any, Union
 
-from .base_operation import GraphQLField
+from .base_operation import GraphQLField, GraphQLLeafField
 from .custom_typing_fields import (
     AppGraphQLField,
     CollectionTranslatableContentGraphQLField,
@@ -21,7 +21,7 @@ from .custom_typing_fields import (
 
 
 class AppFields(GraphQLField):
-    id: "AppGraphQLField" = AppGraphQLField("id")
+    id = GraphQLLeafField("id", AppGraphQLField)
 
     def fields(self, *subfields: AppGraphQLField) -> "AppFields":
         """Subfields should come from the AppFields class"""
@@ -34,28 +34,22 @@ class AppFields(GraphQLField):
 
 
 class CollectionTranslatableContentFields(GraphQLField):
-    id: "CollectionTranslatableContentGraphQLField" = (
-        CollectionTranslatableContentGraphQLField("id")
-    )
+    id = GraphQLLeafField("id", CollectionTranslatableContentGraphQLField)
     "The ID of the collection translatable content."
-    collection_id: "CollectionTranslatableContentGraphQLField" = (
-        CollectionTranslatableContentGraphQLField("collectionId")
+    collection_id = GraphQLLeafField(
+        "collectionId", CollectionTranslatableContentGraphQLField
     )
     "The ID of the collection to translate.\n\nAdded in Saleor 3.14."
-    seo_title: "CollectionTranslatableContentGraphQLField" = (
-        CollectionTranslatableContentGraphQLField("seoTitle")
-    )
+    seo_title = GraphQLLeafField("seoTitle", CollectionTranslatableContentGraphQLField)
     "SEO title to translate."
-    seo_description: "CollectionTranslatableContentGraphQLField" = (
-        CollectionTranslatableContentGraphQLField("seoDescription")
+    seo_description = GraphQLLeafField(
+        "seoDescription", CollectionTranslatableContentGraphQLField
     )
     "SEO description to translate."
-    name: "CollectionTranslatableContentGraphQLField" = (
-        CollectionTranslatableContentGraphQLField("name")
-    )
+    name = GraphQLLeafField("name", CollectionTranslatableContentGraphQLField)
     "Collection's name to translate."
-    description: "CollectionTranslatableContentGraphQLField" = (
-        CollectionTranslatableContentGraphQLField("description")
+    description = GraphQLLeafField(
+        "description", CollectionTranslatableContentGraphQLField
     )
     "Collection's description to translate.\n\nRich text format. For reference see https://editorjs.io/"
 
@@ -72,11 +66,11 @@ class CollectionTranslatableContentFields(GraphQLField):
 
 
 class MetadataErrorFields(GraphQLField):
-    field: "MetadataErrorGraphQLField" = MetadataErrorGraphQLField("field")
+    field = GraphQLLeafField("field", MetadataErrorGraphQLField)
     "Name of a field that caused the error. A value of `null` indicates that the error isn't associated with a particular field."
-    message: "MetadataErrorGraphQLField" = MetadataErrorGraphQLField("message")
+    message = GraphQLLeafField("message", MetadataErrorGraphQLField)
     "The error message."
-    code: "MetadataErrorGraphQLField" = MetadataErrorGraphQLField("code")
+    code = GraphQLLeafField("code", MetadataErrorGraphQLField)
     "The error code."
 
     def fields(self, *subfields: MetadataErrorGraphQLField) -> "MetadataErrorFields":
@@ -90,9 +84,9 @@ class MetadataErrorFields(GraphQLField):
 
 
 class MetadataItemFields(GraphQLField):
-    key: "MetadataItemGraphQLField" = MetadataItemGraphQLField("key")
+    key = GraphQLLeafField("key", MetadataItemGraphQLField)
     "Key of a metadata item."
-    value: "MetadataItemGraphQLField" = MetadataItemGraphQLField("value")
+    value = GraphQLLeafField("value", MetadataItemGraphQLField)
     "Value of a metadata item."
 
     def fields(self, *subfields: MetadataItemGraphQLField) -> "MetadataItemFields":
@@ -163,10 +157,10 @@ class ObjectWithMetadataInterface(GraphQLField):
 
 
 class PageInfoFields(GraphQLField):
-    has_next_page: "PageInfoGraphQLField" = PageInfoGraphQLField("hasNextPage")
-    has_previous_page: "PageInfoGraphQLField" = PageInfoGraphQLField("hasPreviousPage")
-    start_cursor: "PageInfoGraphQLField" = PageInfoGraphQLField("startCursor")
-    end_cursor: "PageInfoGraphQLField" = PageInfoGraphQLField("endCursor")
+    has_next_page = GraphQLLeafField("hasNextPage", PageInfoGraphQLField)
+    has_previous_page = GraphQLLeafField("hasPreviousPage", PageInfoGraphQLField)
+    start_cursor = GraphQLLeafField("startCursor", PageInfoGraphQLField)
+    end_cursor = GraphQLLeafField("endCursor", PageInfoGraphQLField)
 
     def fields(self, *subfields: PageInfoGraphQLField) -> "PageInfoFields":
         """Subfields should come from the PageInfoFields class"""
@@ -179,9 +173,9 @@ class PageInfoFields(GraphQLField):
 
 
 class ProductFields(GraphQLField):
-    id: "ProductGraphQLField" = ProductGraphQLField("id")
-    slug: "ProductGraphQLField" = ProductGraphQLField("slug")
-    name: "ProductGraphQLField" = ProductGraphQLField("name")
+    id = GraphQLLeafField("id", ProductGraphQLField)
+    slug = GraphQLLeafField("slug", ProductGraphQLField)
+    name = GraphQLLeafField("name", ProductGraphQLField)
 
     @classmethod
     def private_metadata(cls) -> "MetadataItemFields":
@@ -240,9 +234,7 @@ class ProductCountableConnectionFields(GraphQLField):
     def page_info(cls) -> "PageInfoFields":
         return PageInfoFields("pageInfo")
 
-    total_count: "ProductCountableConnectionGraphQLField" = (
-        ProductCountableConnectionGraphQLField("totalCount")
-    )
+    total_count = GraphQLLeafField("totalCount", ProductCountableConnectionGraphQLField)
 
     def fields(
         self,
@@ -266,9 +258,7 @@ class ProductCountableEdgeFields(GraphQLField):
     def node(cls) -> "ProductFields":
         return ProductFields("node")
 
-    cursor: "ProductCountableEdgeGraphQLField" = ProductCountableEdgeGraphQLField(
-        "cursor"
-    )
+    cursor = GraphQLLeafField("cursor", ProductCountableEdgeGraphQLField)
 
     def fields(
         self, *subfields: Union[ProductCountableEdgeGraphQLField, "ProductFields"]
@@ -283,28 +273,20 @@ class ProductCountableEdgeFields(GraphQLField):
 
 
 class ProductTranslatableContentFields(GraphQLField):
-    id: "ProductTranslatableContentGraphQLField" = (
-        ProductTranslatableContentGraphQLField("id")
-    )
+    id = GraphQLLeafField("id", ProductTranslatableContentGraphQLField)
     "The ID of the product translatable content."
-    product_id: "ProductTranslatableContentGraphQLField" = (
-        ProductTranslatableContentGraphQLField("productId")
-    )
+    product_id = GraphQLLeafField("productId", ProductTranslatableContentGraphQLField)
     "The ID of the product to translate.\n\nAdded in Saleor 3.14."
-    seo_title: "ProductTranslatableContentGraphQLField" = (
-        ProductTranslatableContentGraphQLField("seoTitle")
-    )
+    seo_title = GraphQLLeafField("seoTitle", ProductTranslatableContentGraphQLField)
     "SEO title to translate."
-    seo_description: "ProductTranslatableContentGraphQLField" = (
-        ProductTranslatableContentGraphQLField("seoDescription")
+    seo_description = GraphQLLeafField(
+        "seoDescription", ProductTranslatableContentGraphQLField
     )
     "SEO description to translate."
-    name: "ProductTranslatableContentGraphQLField" = (
-        ProductTranslatableContentGraphQLField("name")
-    )
+    name = GraphQLLeafField("name", ProductTranslatableContentGraphQLField)
     "Product's name to translate."
-    description: "ProductTranslatableContentGraphQLField" = (
-        ProductTranslatableContentGraphQLField("description")
+    description = GraphQLLeafField(
+        "description", ProductTranslatableContentGraphQLField
     )
     "Product's description to translate.\n\nRich text format. For reference see https://editorjs.io/"
 
@@ -348,9 +330,7 @@ class TranslatableItemConnectionFields(GraphQLField):
     def edges(cls) -> "TranslatableItemEdgeFields":
         return TranslatableItemEdgeFields("edges")
 
-    total_count: "TranslatableItemConnectionGraphQLField" = (
-        TranslatableItemConnectionGraphQLField("totalCount")
-    )
+    total_count = GraphQLLeafField("totalCount", TranslatableItemConnectionGraphQLField)
     "A total count of items in the collection."
 
     def fields(
@@ -371,11 +351,9 @@ class TranslatableItemConnectionFields(GraphQLField):
 
 
 class TranslatableItemEdgeFields(GraphQLField):
-    node: "TranslatableItemUnion" = TranslatableItemUnion("node")
+    node = GraphQLLeafField("node", TranslatableItemUnion)
     "The item at the end of the edge."
-    cursor: "TranslatableItemEdgeGraphQLField" = TranslatableItemEdgeGraphQLField(
-        "cursor"
-    )
+    cursor = GraphQLLeafField("cursor", TranslatableItemEdgeGraphQLField)
     "A cursor for use in pagination."
 
     def fields(

--- a/tests/main/test_main.py
+++ b/tests/main/test_main.py
@@ -1,5 +1,7 @@
 import ast
+import importlib
 import os
+import sys
 from importlib.metadata import version
 from pathlib import Path
 
@@ -215,6 +217,14 @@ def test_main_shows_version():
         ),
         (
             (
+                CLIENTS_PATH / "custom_query_builder_scalars" / "pyproject.toml",
+                (CLIENTS_PATH / "custom_query_builder_scalars" / "schema.graphql",),
+            ),
+            "example_client",
+            CLIENTS_PATH / "custom_query_builder_scalars" / "expected_client",
+        ),
+        (
+            (
                 CLIENTS_PATH / "client_forward_refs" / "pyproject.toml",
                 (
                     CLIENTS_PATH / "client_forward_refs" / "queries.graphql",
@@ -301,6 +311,53 @@ def test_main_client_forward_refs_with_custom_operations(project_dir, package_na
     client_py = package_path / "client.py"
     assert client_py.exists(), f"Expected {client_py}"
     ast.parse(client_py.read_text())
+
+
+@pytest.mark.parametrize(
+    "project_dir, package_name",
+    [
+        (
+            (
+                CLIENTS_PATH / "custom_query_builder_scalars" / "pyproject.toml",
+                (CLIENTS_PATH / "custom_query_builder_scalars" / "schema.graphql",),
+            ),
+            "example_client",
+        ),
+    ],
+    indirect=["project_dir"],
+)
+def test_main_custom_operations_with_custom_scalar_arguments_are_importable(
+    project_dir, package_name
+):
+    """Custom scalars used in field/operation *argument* positions must have their
+    types imported into ``custom_fields.py``/``custom_queries.py``/
+    ``custom_mutations.py``.
+
+    Regression test: previously the scalar imports were registered after the
+    module import list had already been assembled, so the generated modules
+    referenced e.g. ``Decimal``/``UUID`` in annotations without importing them
+    and raised ``NameError`` on import. Diffing the source would not have caught
+    this, so the modules are actually imported here.
+    """
+    result = CliRunner().invoke(main)
+
+    assert result.exit_code == 0, result.output
+    package_path = project_dir / package_name
+    assert package_path.is_dir()
+
+    sys.path.insert(0, str(project_dir))
+    imported_modules = [
+        name for name in list(sys.modules) if name.split(".")[0] == package_name
+    ]
+    for name in imported_modules:
+        del sys.modules[name]
+    try:
+        for module_suffix in ("custom_fields", "custom_queries", "custom_mutations"):
+            importlib.import_module(f"{package_name}.{module_suffix}")
+    finally:
+        for name in [n for n in list(sys.modules) if n.split(".")[0] == package_name]:
+            del sys.modules[name]
+        sys.path.remove(str(project_dir))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Custom-operation leaf selections (`ProductFields.name`) were class attributes
shared by every query. `alias()` and `to_ast()` mutate the field in place, so
selecting the same leaf in two queries leaked state from one into the other.

Leaf fields are now built per access through a `GraphQLLeafField` descriptor; each query gets its own instance. Also fixes custom scalars used in field- and
operation-*argument* positions, which were registered after the module import
list was assembled and so raised `NameError` (`Decimal`, `UUID`) on import.

The generated `custom_fields.py` changes shape. Anyone committing generated
code will see a diff; behavior of correctly-generated clients is unchanged.