### PR TITLE
fix: sanitize python keywords in enum default values

### DIFF
--- a/ariadne_codegen/client_generators/input_fields.py
+++ b/ariadne_codegen/client_generators/input_fields.py
@@ -35,6 +35,7 @@ from ..codegen import (
     generate_subscript,
 )
 from ..exceptions import ParsingError
+from ..utils import process_name
 from .constants import (
     ANY,
     FIELD_CLASS,
@@ -136,7 +137,8 @@ def parse_input_const_value_node(
         return generate_constant(None)
 
     if isinstance(node, EnumValueNode):
-        return generate_name(f"{field_type}.{node.value}")
+        member_name = process_name(node.value, convert_to_snake_case=False)
+        return generate_name(f"{field_type}.{member_name}")
 
     if isinstance(node, ListValueNode):
         list_ = generate_list(

--- a/tests/client_generators/test_input_fields.py
+++ b/tests/client_generators/test_input_fields.py
@@ -243,6 +243,7 @@ def test_parse_input_field_type_returns_annotation_for_list(
         (BooleanValueNode(value=True), "", ast.Constant(value=True)),
         (NullValueNode(), "", ast.Constant(value=None)),
         (EnumValueNode(value="VAL"), "TestEnum", ast.Name(id="TestEnum.VAL")),
+        (EnumValueNode(value="and"), "TestEnum", ast.Name(id="TestEnum.and_")),
     ],
 )
 def test_parse_input_const_value_node_returns_correct_constant(


### PR DESCRIPTION
Input field defaults referencing an enum value that is a Python keyword (e.g. `and`, `or`) generated `Enum.and`, which is invalid syntax and does not match the sanitized enum member `and_`. The default value now passes through `process_name`, matching the enum member generation.

Fixes #364