### PR TITLE
fix: pass the config dict to custom remote schema HTTP client [AR-2]

### DIFF
--- a/ariadne_codegen/main.py
+++ b/ariadne_codegen/main.py
@@ -42,7 +42,7 @@ def main(strategy=Strategy.CLIENT.value, config=None):
 def client(config_dict):
     settings = get_client_settings(config_dict)
 
-    schema = get_graphql_schema(settings)
+    schema = get_graphql_schema(settings, config_dict)
 
     plugin_manager = PluginManager(
         schema=schema,
@@ -82,7 +82,7 @@ def client(config_dict):
 def graphql_schema(config_dict):
     settings = get_graphql_schema_settings(config_dict)
 
-    schema = get_graphql_schema(settings)
+    schema = get_graphql_schema(settings, config_dict)
 
     plugin_manager = PluginManager(
         schema=schema,

--- a/ariadne_codegen/schema.py
+++ b/ariadne_codegen/schema.py
@@ -55,7 +55,7 @@ class HttpClient(Protocol):
     ) -> Response: ...
 
 
-def get_graphql_schema(settings: BaseSettings) -> GraphQLSchema:
+def get_graphql_schema(settings: BaseSettings, config_dict: dict) -> GraphQLSchema:
     """Return GraphQL schema from the source defined in settings."""
     if settings.schema_path:
         schema = get_graphql_schema_from_path(settings.schema_path)
@@ -64,6 +64,7 @@ def get_graphql_schema(settings: BaseSettings) -> GraphQLSchema:
     else:
         schema = get_graphql_schema_from_url(
             url=settings.remote_schema_url,
+            config_dict=config_dict,
             headers=settings.remote_schema_headers,
             verify_ssl=settings.remote_schema_verify_ssl,
             timeout=settings.remote_schema_timeout,
@@ -109,6 +110,7 @@ def get_graphql_queries(
 
 def get_graphql_schema_from_url(
     url: str,
+    config_dict: dict,
     headers: Optional[dict[str, str]] = None,
     verify_ssl: bool = True,
     timeout: float = 5,
@@ -116,7 +118,7 @@ def get_graphql_schema_from_url(
     http_client_path: str | None = None,
 ) -> GraphQLSchema:
     http_client = (
-        get_remote_schema_http_client(http_client_path)
+        get_remote_schema_http_client(http_client_path, config_dict)
         if http_client_path is not None
         else httpx
     )
@@ -133,10 +135,12 @@ def get_graphql_schema_from_url(
     )
 
 
-def get_remote_schema_http_client(http_client_path: str) -> HttpClient:
+def get_remote_schema_http_client(
+    http_client_path: str, config_dict: dict
+) -> HttpClient:
     imported_module_or_attribute = get_module_or_attribute(http_client_path)
     if callable(imported_module_or_attribute):
-        return imported_module_or_attribute()
+        return imported_module_or_attribute(config_dict)
     return imported_module_or_attribute
 
 

--- a/docs/02-guides/02-schema-sources.md
+++ b/docs/02-guides/02-schema-sources.md
@@ -77,7 +77,7 @@ The following options control how the introspection request is performed:
 - `remote_schema_headers` - extra headers that are passed along with introspection query, eg. `{"Authorization" = "Bearer token"}`. To include an environment variable in a header value, prefix the variable with `$`, eg. `{"Authorization" = "$AUTH_TOKEN"}`
 - `remote_schema_verify_ssl` (defaults to `true`) - a flag that specifies whether to verify ssl while introspecting remote schema
 - `remote_schema_timeout` (defaults to `5`) - timeout in seconds while introspecting remote schema
-- `remote_schema_http_client_path` (defaults to `None`) - dotted import path to a custom HTTP client used only for the introspection request, instead of the default `httpx` client
+- `remote_schema_http_client_path` (defaults to `None`) - dotted import path to a module or a callable that returns custom HTTP client. It is used only for the introspection request, instead of the default `httpx` client. See [Configuration](../03-reference/01-configuration.md) for details.
 
 ### Introspection query options
 

--- a/docs/03-reference/01-configuration.md
+++ b/docs/03-reference/01-configuration.md
@@ -29,7 +29,7 @@ Exactly one of the following parameters is required - they are mutually exclusiv
 - `remote_schema_headers` - extra headers that are passed along with introspection query, eg. `{"Authorization" = "Bearer token"}`. To include an environment variable in a header value, prefix the variable with `$`, eg. `{"Authorization" = "$AUTH_TOKEN"}`
 - `remote_schema_verify_ssl` (defaults to `true`) - a flag that specifies whether to verify ssl while introspecting remote schema
 - `remote_schema_timeout` (defaults to `5`) - timeout in seconds while introspecting remote schema
-- `remote_schema_http_client_path` - absolute import path to the HTTP client class used to introspect remote schema. If not provided, default `httpx` client is used.
+- `remote_schema_http_client_path` - absolute import path to the HTTP client used to introspect remote schema. If not provided, default `httpx` client is used. See [Remove schema client customization](#remote-schema-client-customization) below for details.
 - `target_package_name` (defaults to `"graphql_client"`) - name of generated package
 - `target_package_path` (defaults to cwd) - path where to generate package
 - `client_name` (defaults to `"Client"`) - name of generated client class
@@ -79,6 +79,31 @@ These options control which fields are included in the GraphQL introspection que
 - `introspection_schema_description` (defaults to `false`) – include schema description
 - `introspection_directive_is_repeatable` (defaults to `false`) – include `isRepeatable` information for directives
 - `introspection_input_object_one_of` (defaults to `false`) – include `oneOf` information for input objects
+
+## Remote schema client customization
+
+By default, `httpx` is used to introspect a remote schema. Another client can be used instead by setting `remote_schema_http_client_path`. The provided client must implement the following protocol:
+
+```py
+class Response(Protocol):
+    status_code: int
+
+    def json(self, **kwargs: Any) -> Any: ...
+
+
+class HttpClient(Protocol):
+    def post(
+        self,
+        url: Any | str,
+        json: Any | None = None,
+        headers: Any | None = None,
+        verify: Any | None = None,
+        timeout: Any | None = None,
+        **kwargs: Any,
+    ) -> Response: ...
+```
+
+If the provided import path points to a module, the module itself must implement the protocol. If the provided import path points to a callable, it is called with a single argument: `config_dict: dict` (the parsed `pyproject.toml`), and the returned object is expected to implement `HttpClient` protocol.
 
 ## Base Client customization
 


### PR DESCRIPTION
I want to merge this change because it extends the functionality introduced in https://github.com/mirumee/ariadne-codegen/pull/444:
- the code passes now the `config_dict` as an argument to the provided value. It will allow to define settings in `pyproject.toml` which will be used in the custom HTTP client.
- the better docs was added.