### PR TITLE
Fix duplicate typename__ when type implements multiple interfaces

### DIFF
--- a/ariadne_codegen/client_generators/result_types.py
+++ b/ariadne_codegen/client_generators/result_types.py
@@ -352,7 +352,15 @@ class ResultTypesGenerator:
         self._fragments_used_as_mixins = self._fragments_used_as_mixins.union(
             set(fragments)
         )
-        return fields, fragments
+
+        seen_names: set[str] = set()
+        deduplicated: list[FieldNode] = []
+        for field in fields:
+            name = field.alias.value if field.alias else field.name.value
+            if name not in seen_names:
+                seen_names.add(name)
+                deduplicated.append(field)
+        return deduplicated, fragments
 
     def _get_inline_fragment_root_type(
         self, selection_value: str, root_type: str

--- a/tests/client_generators/result_types_generator/test_duplicate_typename.py
+++ b/tests/client_generators/result_types_generator/test_duplicate_typename.py
@@ -1,0 +1,69 @@
+import ast
+
+import pytest
+from graphql import OperationDefinitionNode, build_schema, parse
+
+from ariadne_codegen.client_generators.constants import TYPENAME_ALIAS
+from ariadne_codegen.client_generators.result_types import ResultTypesGenerator
+
+SCHEMA = """
+    type Query {
+        foo: Foo
+    }
+
+    interface Bar {
+        id: ID!
+    }
+
+    interface Baz {
+        name: String!
+    }
+
+    type Foo implements Bar & Baz {
+        id: ID!
+        name: String!
+    }
+"""
+
+
+@pytest.mark.xfail(reason="Codegen emits duplicate typename__ for multi-interface types")
+def test_no_duplicate_typename_when_type_implements_multiple_interfaces():
+    schema = build_schema(SCHEMA)
+
+    query_str = """
+        query GetFoo {
+            foo {
+                ... on Bar {
+                    __typename
+                    id
+                }
+                ... on Baz {
+                    __typename
+                    name
+                }
+            }
+        }
+    """
+
+    document = parse(query_str)
+    operation = document.definitions[0]
+    assert isinstance(operation, OperationDefinitionNode)
+
+    generator = ResultTypesGenerator(
+        schema=schema,
+        operation_definition=operation,
+        enums_module_name="enums",
+    )
+
+    class_defs = generator.get_classes()
+    foo_class = next(c for c in class_defs if c.name == "GetFooFoo")
+
+    typename_fields = [
+        node
+        for node in foo_class.body
+        if isinstance(node, ast.AnnAssign)
+        and isinstance(node.target, ast.Name)
+        and node.target.id == TYPENAME_ALIAS
+    ]
+
+    assert len(typename_fields) == 1

--- a/tests/client_generators/result_types_generator/test_duplicate_typename.py
+++ b/tests/client_generators/result_types_generator/test_duplicate_typename.py
@@ -1,6 +1,5 @@
 import ast
 
-import pytest
 from graphql import OperationDefinitionNode, build_schema, parse
 
 from ariadne_codegen.client_generators.constants import TYPENAME_ALIAS
@@ -26,7 +25,6 @@ SCHEMA = """
 """
 
 
-@pytest.mark.xfail(reason="Codegen emits duplicate typename__ for multi-interface types")
 def test_no_duplicate_typename_when_type_implements_multiple_interfaces():
     schema = build_schema(SCHEMA)
 


### PR DESCRIPTION
Fixes the bug from the xfail test — `_resolve_selection_set` merges fields from all matching inline fragments, so when a type implements interfaces Bar and Baz and both spreads select `__typename`, you get it twice.

The fix deduplicates fields by name at the end of `_resolve_selection_set`, keeping the first occurrence. All 924 existing tests pass unchanged.

Stacked on #442.